### PR TITLE
Fix deprecation warning for `load_module`

### DIFF
--- a/open_alaqs/core/modules/ModuleManager.py
+++ b/open_alaqs/core/modules/ModuleManager.py
@@ -1,3 +1,5 @@
+import importlib.machinery
+import importlib.util
 import inspect
 import os
 import pkgutil
@@ -24,10 +26,16 @@ class ModuleManager(metaclass=Singleton):
 
     # load all modules in current directory
     def loadModules(self):
-        for loader, name, _ in pkgutil.walk_packages(
+        for file_finder, name, _is_package in pkgutil.walk_packages(
             [os.path.abspath(os.path.dirname(__file__))]
         ):
-            module = loader.find_module(name).load_module(name)
+            loader = importlib.machinery.SourceFileLoader(
+                name, file_finder.find_module(name).path
+            )
+            spec = importlib.util.spec_from_loader(loader.name, loader)
+            module = importlib.util.module_from_spec(spec)
+            loader.exec_module(module)
+
             for _name, obj in inspect.getmembers(module):
 
                 # include only classes


### PR DESCRIPTION
This code should work in Python 3.3+. The `load_module` will be removed in Python 3.12.

The dynamic module loading should die anyways!