### PR TITLE
fix issue if Engine values are integer that are 0ed getting default values

### DIFF
--- a/open_alaqs/core/interfaces/Engine.py
+++ b/open_alaqs/core/interfaces/Engine.py
@@ -510,7 +510,7 @@ class EngineEmissionIndex(Store):
         for ei_val_key, val_key in key_mapping.items():
 
             # Set the values with not update values with empty strings
-            if val_key in val and isinstance(val.get(val_key), float):
+            if val_key in val and isinstance(val.get(val_key), (int, float)):
                 ei_val[ei_val_key] = val[val_key]
 
         # Create the emission index


### PR DESCRIPTION
Fixes (again) #169 and #172

rational is: ei_val is polulated of all values that have been set not none or empty string. These values are used to create later the new EmissionIndex that is initialized with ei_val dictionary with values get from DB.
If the value is not recognised as float it is not passed to init the EmissionIndex so a default value will be used.

The fix allow to pass all values that are float or int read from DB

NOTE: reviewed the code in case similar compare are present and seems that this is the only part affected.