### PR TITLE
Fix an error when the aircraft has no profile available because of missing `oid`

### DIFF
--- a/open_alaqs/core/interfaces/Movement.py
+++ b/open_alaqs/core/interfaces/Movement.py
@@ -2268,11 +2268,10 @@ class MovementStore(Store, metaclass=Singleton):
         # NOTE: not dropped elements from eq_mdf to maintain index parity with
         # original mdf
         none_profile_ids = eq_mdf["profile_id"].isna()
-        mdf[none_profile_ids].apply(
-            lambda row: logger.warning(
-                f"Skip movement {row['oid']} due to nor profile {row['profile_id']} nor default value"
+        for row in mdf[none_profile_ids].itertuples():
+            logger.warning(
+                f'Skip movement "{row.oid}" due to neither a profile "{row.profile_id}" in "default_aircraft_profiles" table, nor a default value for that aircraft!'
             )
-        )
 
         # Get unique combinations of eq_mdf
         u_columns = [


### PR DESCRIPTION
It turns out the `DataFrame.apply` works differently than initially thought:
- it loops as columns if no `axis=1` passed
- the callback gets a parameter that is not subscriptable: cannot call `row["oid"]`
- the `apply` is ran even if the `DataFrame` is empty

We made the code more imperative which might have a performance penalty, but we don't care right now, since the movements table should be relatively small (expected few thousand lines max).