### PR TITLE
correctly read emissions from APU store

### DIFF
--- a/open_alaqs/core/interfaces/Aircraft.py
+++ b/open_alaqs/core/interfaces/Aircraft.py
@@ -352,7 +352,7 @@ class AircraftStore(Store, metaclass=Singleton):
                     apu = fuzzy_match(ac._apu_id, apu_val_list)
                     if apu:
                         apu_val_emissions = [
-                            v._emissions()
+                            v._emissions
                             for v in self.getAPUStore().getObjects().values()
                         ]
                         ac.setApu(apu)


### PR DESCRIPTION
wrongly read emission from a method.
Not clear why not using getEmissions(mode)
need a review by @suricactus because the above aspect is not clear to me