### PR TITLE
Move the concentration grid factor to a global constant instead of two local variables

### DIFF
--- a/open_alaqs/alaqs_config.py
+++ b/open_alaqs/alaqs_config.py
@@ -8,6 +8,9 @@ from typing import Optional, TypedDict
 
 from open_alaqs.enums import AlaqsLayerType
 
+# TODO OPENGIS.ch: Expose this as a user setting in the Generate Emissions Inventory -> Modelled Domain input group as a "Concentration Grid Factor" int field in the range [1, 100]
+DEFAULT_CONCENTRATION_GRID_FACTOR = 2
+
 
 class OsmFilter(TypedDict, total=False):
     within_aerodrome: bool

--- a/open_alaqs/core/modules/AUSTALOutputModule.py
+++ b/open_alaqs/core/modules/AUSTALOutputModule.py
@@ -13,6 +13,7 @@ from qgis.gui import QgsDoubleSpinBox, QgsSpinBox
 from qgis.PyQt import QtWidgets
 from shapely.geometry import LineString, MultiLineString, MultiPolygon, Point, Polygon
 
+from open_alaqs.alaqs_config import DEFAULT_CONCENTRATION_GRID_FACTOR
 from open_alaqs.core.alaqslogging import get_logger
 from open_alaqs.core.interfaces.AmbientCondition import AmbientCondition
 from open_alaqs.core.interfaces.DispersionModule import DispersionModule
@@ -314,16 +315,12 @@ class AUSTALDispersionModule(DispersionModule):
             ) * float(self._grid._y_resolution)
             # logger.info("getGridXYFromReferencePoint: bottom left of the EMIS grid: x0=%.0f, y0=%.0f" % (grid_origin_x, grid_origin_y))
 
-            # conc grid
-            user_set_factor = (
-                2.0  # ToDo: Enlarge Calculation Grid by Factor set by the user?
-            )
             self._x_left_border_calc_grid = float(
                 grid_origin_x
-            ) - user_set_factor * float(self._grid._x_resolution)
+            ) - DEFAULT_CONCENTRATION_GRID_FACTOR * float(self._grid._x_resolution)
             self._y_left_border_calc_grid = float(
                 grid_origin_y
-            ) - user_set_factor * float(self._grid._y_resolution)
+            ) - DEFAULT_CONCENTRATION_GRID_FACTOR * float(self._grid._y_resolution)
             # logger.info("getGridXYFromReferencePoint: bottom left of the CONC grid: xq=%.0f, yq=%.0f" % (self._x_left_border_calc_grid, self._y_left_border_calc_grid))
 
             # emissions grid == coordinates of the bottom left of the grid

--- a/open_alaqs/core/modules/ConcentrationsQGISVectorLayerOutputModule.py
+++ b/open_alaqs/core/modules/ConcentrationsQGISVectorLayerOutputModule.py
@@ -9,6 +9,7 @@ from qgis.gui import QgsDoubleSpinBox
 from qgis.PyQt import QtWidgets
 from shapely.geometry import Point, Polygon
 
+from open_alaqs.alaqs_config import DEFAULT_CONCENTRATION_GRID_FACTOR
 from open_alaqs.core.alaqslogging import get_logger
 from open_alaqs.core.interfaces.OutputModule import OutputModule
 from open_alaqs.core.plotting.ContourPlotVectorLayer import ContourPlotVectorLayer
@@ -230,15 +231,12 @@ class QGISVectorLayerDispersionModule(OutputModule):
                 float(self._grid._y_cells) / 2.0
             ) * float(self._grid._y_resolution)
 
-            user_set_factor = (
-                1.0  # ToDo: Enlarge Calculation Grid by Factor set by the user
-            )
-            self._x_left_border_grid = float(grid_origin_x) - user_set_factor * float(
-                self._grid._x_resolution
-            )
-            self._y_left_border_grid = float(grid_origin_y) - user_set_factor * float(
-                self._grid._y_resolution
-            )
+            self._x_left_border_grid = float(
+                grid_origin_x
+            ) - DEFAULT_CONCENTRATION_GRID_FACTOR * float(self._grid._x_resolution)
+            self._y_left_border_grid = float(
+                grid_origin_y
+            ) - DEFAULT_CONCENTRATION_GRID_FACTOR * float(self._grid._y_resolution)
 
             return True
         except Exception as e:


### PR DESCRIPTION

This prevents the confusion to edit both the `AUSTALOutputModule` and the `ConcentrationsQGISVectorLayerOutputModule`, as the factor is required to have the very same value on both processing stages.