### PR TITLE
Point to QPIP v1.2.0 as dependency

### DIFF
--- a/open_alaqs/metadata.txt
+++ b/open_alaqs/metadata.txt
@@ -40,7 +40,7 @@ deprecated=False
 # Since QGIS 3.8, a comma separated list of plugins to be installed
 # (or upgraded) can be specified.
 # Check the documentation for more information.
-plugin_dependencies=qpip
+plugin_dependencies=qpip==1.2.0
 
 Category of the plugin: Raster, Vector, Database or Web
 # category=


### PR DESCRIPTION
Since that's the QPIP version from which Python dependency checks are run on plugin installation (see https://github.com/opengisch/qpip/releases/tag/v1.2.0)