### PR TITLE
[ads-b] Fix displacements in Movement emissions based on ADS-B trajectories

### DIFF
--- a/open_alaqs/core/GeoTransformation.py
+++ b/open_alaqs/core/GeoTransformation.py
@@ -365,11 +365,15 @@ class TrajectoryTransformer:
                 self._runway_direction,
                 self._taxi_route.getName(),
             )
-            runway_intersection_geographic = coord_tr.transform(runway_backup_point)
+            runway_intersection_projected = runway_backup_point
         else:
-            runway_intersection_geographic = coord_tr.transform(
+            runway_intersection_projected = (
                 runway_intersection_projected.centroid().asPoint()
             )
+
+        runway_intersection_geographic = coord_tr.transform(
+            runway_intersection_projected
+        )
 
         if not self._has_track():
             ac_trajectory = AircraftTrajectory(
@@ -378,36 +382,49 @@ class TrajectoryTransformer:
             )
             ac_trajectory.setIsCartesian(False)
 
-            for point in self._trajectory.getPoints():
+            original_trajectory_points = self._trajectory.getPoints()
+            if not original_trajectory_points:
+                return ac_trajectory
 
-                # ToDo: if CUSTOM ... then
-                if point._course == "CUSTOM":
-                    x_offset = point.getX()  # Along the runway
-                    y_offset = (
-                        point.getY()
-                    )  # Perpendicular to the runway (e.g. lateral deviation)
+            def _add_trajectory_point(original_point, new__point_projected):
+                _trajectory_point = AircraftTrajectoryPoint(original_point)
+                # Update x and y coordinates (z coordinate is not updated by distance calculation)
+                _trajectory_point.setCoordinates(
+                    new__point_projected.x(),
+                    new__point_projected.y(),
+                    original_point.getZ(),
+                )
+                ac_trajectory.addPoint(_trajectory_point)
 
-                    ref_lon = runway_intersection_geographic.x()
-                    ref_lat = runway_intersection_geographic.y()
+            if original_trajectory_points[0]._course == "CUSTOM":
+                # Project ref point (3857) to UTM
+                ref_proj_x = runway_intersection_projected.x()
+                ref_proj_y = runway_intersection_projected.y()
 
-                    utm_zone = int((ref_lon + 180) // 6) + 1
-                    utm_epsg = utm_zone + (32600 if ref_lat >= 0 else 32700)
-                    utm_wgs84_transform = spatial.create_coordinate_transform(
-                        utm_epsg, 4326
-                    )
+                utm_zone = int((runway_intersection_geographic.x() + 180) // 6) + 1
+                utm_epsg = utm_zone + (
+                    32600 if runway_intersection_projected.y() >= 0 else 32700
+                )
+                utm_3857_transform = spatial.create_coordinate_transform(utm_epsg, 3857)
 
-                    ref_utm = utm_wgs84_transform.transform(
-                        ref_lon, ref_lat, QgsCoordinateTransform.ReverseTransform
-                    )
+                ref_utm = utm_3857_transform.transform(
+                    ref_proj_x, ref_proj_y, QgsCoordinateTransform.ReverseTransform
+                )
 
-                    # Forward transformation for the reference point in utm plus the offsets
-                    target_point_geographic = utm_wgs84_transform.transform(
+                for point in original_trajectory_points:
+                    x_offset = point.getX()
+                    y_offset = point.getY()
+
+                    # Convert the utm reference point applying the offsets to 3857
+                    target_point_projected = utm_3857_transform.transform(
                         ref_utm.x() + x_offset, ref_utm.y() + y_offset
                     )
 
-                else:
-
-                    # the target point is with cartesian coordinates, therefore we can calculate the distance with Pythagorian theorem
+                    _add_trajectory_point(point, target_point_projected)
+            else:
+                for point in original_trajectory_points:
+                    # The target point is with cartesian coordinates,
+                    # therefore we can calculate the distance with Pythagorean theorem
                     distance = spatial.getDistanceXY(point.getX(), point.getY())
 
                     # get target point (calculation in 4326 projection)
@@ -417,19 +434,12 @@ class TrajectoryTransformer:
                         math.radians(runway_azimuth_deg),
                     )
 
-                target_point_projected = coord_tr.transform(
-                    target_point_geographic,
-                    QgsCoordinateTransform.ReverseTransform,
-                )
+                    target_point_projected = coord_tr.transform(
+                        target_point_geographic,
+                        QgsCoordinateTransform.ReverseTransform,
+                    )
 
-                trajectory_point = AircraftTrajectoryPoint(point)
-                # Update x and y coordinates (z coordinate is not updated by distance calculation)
-                trajectory_point.setCoordinates(
-                    target_point_projected.x(),
-                    target_point_projected.y(),
-                    point.getZ(),
-                )
-                ac_trajectory.addPoint(trajectory_point)
+                    _add_trajectory_point(point, target_point_projected)
         else:
             # Process track
             # ToDo: from track prepare trajectory points
@@ -470,13 +480,14 @@ class TrajectoryTransformer:
                 # reverse arrival track so ordering begins at runway
                 track_line_points.reverse()
 
-            (point, point_wkt) = spatial.reproject_Point(
-                runway_intersection_geographic.x(),
-                runway_intersection_geographic.y(),
-                epsg_id_target,
-                epsg_id_source,
+            track_line_points.insert(
+                0,
+                (
+                    runway_intersection_projected.x(),
+                    runway_intersection_projected.y(),
+                    0,
+                ),
             )
-            track_line_points.insert(0, (point.GetX(), point.GetY(), 0))
             track_line = LineString(track_line_points)
 
             ac_trajectory = AircraftTrajectory()

--- a/open_alaqs/core/GeoTransformation.py
+++ b/open_alaqs/core/GeoTransformation.py
@@ -348,16 +348,13 @@ class TrajectoryTransformer:
             runway_geom, qgs_d
         )
 
-        taxi_geom = QgsGeometry.fromWkt(self._taxi_route.getSegmentsAsLineString().wkt)
-        # NOTE QGIS 3.34.2 is returning and empty geometry and newer QGIS is returning a null geometry
-        runway_intersection_projected = runway_geom.buffer(1, 10).intersection(
-            taxi_geom
+        runway_intersection_projected = (
+            spatial.get_intersection_point_runway_and_taxi_route(
+                self._runway, self._taxi_route
+            )
         )
 
-        if (
-            runway_intersection_projected.isNull()
-            or runway_intersection_projected.isEmpty()
-        ):
+        if runway_intersection_projected.isEmpty():  # Checks both Empty and Null
             # TODO OPENGIS.ch: in addition to just logging here,
             # make sure the taxiway and the runway are intersecting, otherwise you cannot save the Movement
             logger.error(
@@ -366,10 +363,6 @@ class TrajectoryTransformer:
                 self._taxi_route.getName(),
             )
             runway_intersection_projected = runway_backup_point
-        else:
-            runway_intersection_projected = (
-                runway_intersection_projected.centroid().asPoint()
-            )
 
         runway_intersection_geographic = coord_tr.transform(
             runway_intersection_projected

--- a/open_alaqs/core/GeoTransformation.py
+++ b/open_alaqs/core/GeoTransformation.py
@@ -382,28 +382,28 @@ class TrajectoryTransformer:
 
                 # ToDo: if CUSTOM ... then
                 if point._course == "CUSTOM":
-
                     x_offset = point.getX()  # Along the runway
                     y_offset = (
                         point.getY()
                     )  # Perpendicular to the runway (e.g. lateral deviation)
 
-                    # Step 1: Move EAST by x_offset meters (azimuth=90°)
-                    lon_east, lat_east = qgs_d.computeSpheroidProject(
-                        runway_intersection_geographic,
-                        x_offset,
-                        math.radians(90),  # Azimuth: 90° = East
+                    ref_lon = runway_intersection_geographic.x()
+                    ref_lat = runway_intersection_geographic.y()
+
+                    utm_zone = int((ref_lon + 180) // 6) + 1
+                    utm_epsg = utm_zone + (32600 if ref_lat >= 0 else 32700)
+                    utm_wgs84_transform = spatial.create_coordinate_transform(
+                        utm_epsg, 4326
                     )
 
-                    # Step 2: Move NORTH by y_offset meters (azimuth=0°)
-                    lon_new, lat_new = qgs_d.computeSpheroidProject(
-                        QgsPointXY(lon_east, lat_east),
-                        y_offset,
-                        math.radians(0),  # Azimuth: 0° = North
+                    ref_utm = utm_wgs84_transform.transform(
+                        ref_lon, ref_lat, QgsCoordinateTransform.ReverseTransform
                     )
 
-                    # Create geographic point (EPSG:4326)
-                    target_point_geographic = QgsPointXY(lon_new, lat_new)
+                    # Forward transformation for the reference point in utm plus the offsets
+                    target_point_geographic = utm_wgs84_transform.transform(
+                        ref_utm.x() + x_offset, ref_utm.y() + y_offset
+                    )
 
                 else:
 

--- a/open_alaqs/core/alaqsdblite.py
+++ b/open_alaqs/core/alaqsdblite.py
@@ -970,7 +970,7 @@ def import_ads_b_data(ads_b_data: list, inventory_path: str) -> bool:
         inventory_path (str): Path of the Emissions Inventory DB.
 
     Returns:
-        result (bool): Whether the ADS-B data was successfully imported or not.
+        result (bool): Whether the ADS-B data were successfully imported or not.
     """
     if not ads_b_data:
         return False

--- a/open_alaqs/core/alaqsdblite.py
+++ b/open_alaqs/core/alaqsdblite.py
@@ -375,12 +375,80 @@ def add_taxiway_route(taxiway_route):
 # #################################################
 
 
-def get_closest_runway_point(longitude, latitude):
+def get_runway_closest_endpoint(runway_id, longitude, latitude):
+    """
+    Gets the closest endpoint from a given runway in the ALAQS DB
+    with respect to the input point, given in WGS84 (EPSG:4326).
+
+    NOTE: Make sure the runway_id exists in the DB before calling this method!
+
+    Args:
+        runway_id (str): Name of the base runway.
+        longitude (float): Longitude of the input point.
+        latitude (float): Latitude of the input point.
+
+    Returns:
+        runway_lon: Longitude (WGS84) of the closest runway endpoint.
+        runway_lat: Latitude (WGS84) of the closest runway endpoint.
+    """
+    sql = """
+        WITH
+        input(runway_id, longitude, latitude) AS (
+            VALUES(?, ?, ?)
+        ),
+        inputpoint AS
+            (SELECT
+                ST_Transform(
+                    ST_GeomFromText(
+                        'POINT(' || longitude || ' ' || latitude || ')', 4326
+                    ),
+                    3857
+                ) as ip
+            FROM input),
+        endpoints AS
+            (SELECT oid, shapes_runways.runway_id, ST_StartPoint(geometry) as sp, ST_EndPoint(geometry) as ep
+            FROM shapes_runways, input
+            WHERE shapes_runways.runway_id = input.runway_id),
+        multipoints AS
+            (SELECT oid, runway_id, ST_GeomFromText('MULTIPOINT((' || ST_X(sp) || ' ' || ST_Y(sp) || '), (' || ST_X(ep) || ' ' || ST_Y(ep) || '))', 3857) as mp
+            FROM endpoints),
+        closest_endpoint AS
+            (SELECT shapes_runways.oid, shapes_runways.runway_id,
+                ST_ClosestPoint(
+                    mp,
+                    inputpoint.ip
+                ) as closest_endpoint_3857,
+                ST_Transform(
+                    ST_ClosestPoint(
+                        mp,
+                        inputpoint.ip
+                    ),
+                4326) as closest_endpoint_4326
+            FROM shapes_runways, multipoints, input, inputpoint
+            where shapes_runways.runway_id = input.runway_id)
+
+        SELECT oid, runway_id, ST_X(closest_endpoint_4326) as lon, ST_Y(closest_endpoint_4326) as lat,
+            ST_X(closest_endpoint_3857) as x, ST_Y(closest_endpoint_3857) as y
+        FROM closest_endpoint;
+    """
+    res = execute_sql(sql, [runway_id, longitude, latitude])
+    runway_name = res["runway_id"]
+    runway_lon = res["lon"]
+    runway_lat = res["lat"]
+    runway_x = res["x"]
+    runway_y = res["y"]
+    logger.info(
+        f"Closest endpoint in runway {runway_name}: ({runway_x}, {runway_y})/({runway_lon}, {runway_lat}), input point: ({longitude}, {latitude})"
+    )
+    return runway_lon, runway_lat
+
+
+def get_closest_runway_endpoint(longitude, latitude):
     """
     Gets the closest runway endpoint from runways in the ALAQS DB
     with respect to the input point, given in WGS84 (EPSG:4326).
     Note that this searches the closest runway endpoint, not the closest runway point,
-    nor an endpoint in the closest runway..
+    nor an endpoint in the closest runway.
 
     Args:
         longitude (float): Longitude of the input point.

--- a/open_alaqs/core/interfaces/Store.py
+++ b/open_alaqs/core/interfaces/Store.py
@@ -47,7 +47,11 @@ class Store:
             self.setObject(key, self.getObject(key) + val)
 
     def getObject(self, key):
-        return self._objects[key] if self.hasKey(key) else None
+        if self.hasKey(key):
+            return self._objects[key]
+        else:
+            logger.warning(f"Object with key '{key}' not found in the store!")
+            return None
 
     def getObjects(self):
         return self._objects

--- a/open_alaqs/core/tools/ads_b.py
+++ b/open_alaqs/core/tools/ads_b.py
@@ -92,7 +92,7 @@ def validate_adsb_file(path: str) -> tuple[bool, str]:
             f"Invalid data: rows with no 'thrust' nor 'fuel flow' values: {no_thrust_no_fuel_flow_count}",
         )
 
-    return True, "The ADS-B data is valid!"
+    return True, "The ADS-B data are valid!"
 
 
 def import_adsb_file(csv_path: str, inventory_path: str) -> tuple[bool, str]:

--- a/open_alaqs/core/tools/ads_b.py
+++ b/open_alaqs/core/tools/ads_b.py
@@ -6,11 +6,16 @@ from pyproj import CRS, Transformer
 
 from open_alaqs.core.alaqs import get_runways
 from open_alaqs.core.alaqsdblite import (
-    get_closest_runway_point,
+    ProjectDatabase,
+    get_closest_runway_endpoint,
     get_max_profile_oid,
+    get_runway_closest_endpoint,
     import_ads_b_data,
 )
 from open_alaqs.core.alaqslogging import get_logger
+from open_alaqs.core.interfaces.Runway import RunwayStore
+from open_alaqs.core.interfaces.Taxiway import TaxiwayRoutesStore
+from open_alaqs.core.tools import spatial
 
 logger = get_logger(__name__)
 
@@ -112,6 +117,7 @@ def import_adsb_file(csv_path: str, inventory_path: str) -> tuple[bool, str]:
     id_column = "flight_id"
     anp_profiles = []
     max_profile_oid = get_max_profile_oid()
+    flight_count = 0  # For logging purposes
 
     for flight_id in adsb_data[id_column].unique():
         flight_data = adsb_data[adsb_data[id_column] == flight_id].copy()
@@ -123,18 +129,74 @@ def import_adsb_file(csv_path: str, inventory_path: str) -> tuple[bool, str]:
         )
 
         # 1.2. Convert from geographic coordinates to planar (relative) ones
+        # 1.2.1 Pick a reference point on the runway
+
+        _runway_id = (
+            flight_data.at[flight_data.index[0], "runway"]
+            if "runway" in flight_data.columns
+            else ""
+        )
+        _taxi_route_id = (
+            flight_data.at[flight_data.index[0], "taxi_route"]
+            if "taxi_route" in flight_data.columns
+            else ""
+        )
+        db_path = ProjectDatabase().path
+        runway_obj = RunwayStore(db_path).getObject(_runway_id) if _runway_id else None
+        taxi_route_obj = (
+            TaxiwayRoutesStore(db_path).getObject(_taxi_route_id)
+            if _taxi_route_id
+            else None
+        )
+
+        # 1.2.1.1 Get the reference point depending on the provided information
+        # For closest point analysis, get a point from the ADS-B track
         track_lat, track_lon = (
             flight_data[["latitude", "longitude"]].iloc[-1]
             if is_arrival
             else flight_data[["latitude", "longitude"]].iloc[0]
         )
 
-        runway_name, runway_lon, runway_lat = get_closest_runway_point(
-            track_lon, track_lat
-        )
+        if runway_obj:
+            runway_name = runway_obj.getName()
+            if taxi_route_obj:
+                intersection = spatial.get_intersection_point_runway_and_taxi_route(
+                    runway_obj, taxi_route_obj
+                )
+                if intersection.isEmpty():
+                    logger.warning(
+                        f"Ignoring ADS-B trajectory, since runway ({runway_name}) and taxi route ({taxi_route_obj.getName()}) do not intersect!"
+                    )
+                    continue
+                else:
+                    tr = spatial.create_coordinate_transform(3857, 4326)
+                    intersection_wgs84 = tr.transform(intersection)
+                    runway_lon, runway_lat = (
+                        intersection_wgs84.x(),
+                        intersection_wgs84.y(),
+                    )
+                    logger.info(
+                        "Using runway and taxi_route intersection as reference runway point for importing ADS-B data."
+                    )
+            else:
+                runway_lon, runway_lat = get_runway_closest_endpoint(
+                    runway_name, track_lon, track_lat
+                )
+                logger.info(
+                    "Using runway column for reference runway point calculation for importing ADS-B data."
+                )
+        else:
+            # No runway nor taxi route given, so get the closest runway's endpoint
+            runway_name, runway_lon, runway_lat = get_closest_runway_endpoint(
+                track_lon, track_lat
+            )
+            logger.info(
+                "Using closest runway endpoint calculation as reference runway point for importing ADS-B data."
+            )
+
         runway_alt = 0
 
-        # Apply geographic_to_relative_df_proj with the appropriate runway reference
+        # 1.2.1.2 Apply geographic_to_relative_df_proj with the appropriate runway reference
         flight_data_x_y_z = _geographic_to_relative_df(
             flight_data,
             runway_lon,
@@ -197,11 +259,13 @@ def import_adsb_file(csv_path: str, inventory_path: str) -> tuple[bool, str]:
             ]
             anp_profiles.append(anp_row)
 
+        flight_count += 1
+
     # 3. Import data to Inventory DB
     result_import = import_ads_b_data(anp_profiles, inventory_path)
 
     if result_import:
-        return True, "ADS-B successfully imported!"
+        return True, f"ADS-B successfully imported! ({flight_count} profile(s))"
     else:
         return False, "ADS-B could not be imported into the database!"
 

--- a/open_alaqs/core/tools/spatial.py
+++ b/open_alaqs/core/tools/spatial.py
@@ -22,6 +22,8 @@ from qgis.core import (
 
 from open_alaqs.core.alaqslogging import get_logger
 from open_alaqs.core.interfaces.AircraftTrajectory import TrajectoryPoint
+from open_alaqs.core.interfaces.Runway import Runway
+from open_alaqs.core.interfaces.Taxiway import TaxiwayRoute
 from open_alaqs.core.tools import conversion
 from open_alaqs.core.tools.iterator import pairwise
 
@@ -486,6 +488,20 @@ def get_line_vertices(line: QgsGeometry) -> list[QgsPoint]:
         points.extend(part.points())
 
     return points
+
+
+def get_intersection_point_runway_and_taxi_route(
+    runway: Runway, taxi_route: TaxiwayRoute
+) -> QgsGeometry:
+    """
+    Returns the entry point of a Taxiway route on the Runway.
+    Mwy return an empty geometry if there is no intersection.
+    """
+    runway_geom = QgsGeometry.fromWkt(runway.getGeometryText())
+    taxi_route_geom = QgsGeometry.fromWkt(taxi_route.getSegmentsAsLineString().wkt)
+    intersection = runway_geom.buffer(1, 10).intersection(taxi_route_geom)
+
+    return intersection if intersection.isEmpty() else intersection.centroid().asPoint()
 
 
 def clip_segment_to_grid(

--- a/open_alaqs/core/tools/spatial.py
+++ b/open_alaqs/core/tools/spatial.py
@@ -22,8 +22,6 @@ from qgis.core import (
 
 from open_alaqs.core.alaqslogging import get_logger
 from open_alaqs.core.interfaces.AircraftTrajectory import TrajectoryPoint
-from open_alaqs.core.interfaces.Runway import Runway
-from open_alaqs.core.interfaces.Taxiway import TaxiwayRoute
 from open_alaqs.core.tools import conversion
 from open_alaqs.core.tools.iterator import pairwise
 
@@ -490,12 +488,17 @@ def get_line_vertices(line: QgsGeometry) -> list[QgsPoint]:
     return points
 
 
-def get_intersection_point_runway_and_taxi_route(
-    runway: Runway, taxi_route: TaxiwayRoute
-) -> QgsGeometry:
+def get_intersection_point_runway_and_taxi_route(runway, taxi_route) -> QgsGeometry:
     """
     Returns the entry point of a Taxiway route on the Runway.
     Mwy return an empty geometry if there is no intersection.
+
+    Args:
+        runway (Runway): Runway object.
+        taxi_route (TaxiwayRoute): Taxiway route object.
+
+    Returns:
+        QgsGeometry: Geometry (point) object resulting from the intersection. It may be an EMPTY geometry.
     """
     runway_geom = QgsGeometry.fromWkt(runway.getGeometryText())
     taxi_route_geom = QgsGeometry.fromWkt(taxi_route.getSegmentsAsLineString().wkt)

--- a/open_alaqs/openalaqs.py
+++ b/open_alaqs/openalaqs.py
@@ -199,6 +199,7 @@ class OpenALAQS:
 
         # Add buttons to toolbar
         self.open_alaqs_toolbar = self.iface.addToolBar("OpenALAQS Toolbar")
+        self.open_alaqs_toolbar.setObjectName("OpenALAQS")
         self.open_alaqs_toolbar.addAction(self.actions["about"])
         self.open_alaqs_toolbar.addSeparator()
         self.open_alaqs_toolbar.addAction(self.actions["project_create"])

--- a/open_alaqs/openalaqsdialog.py
+++ b/open_alaqs/openalaqsdialog.py
@@ -2129,7 +2129,7 @@ class OpenAlaqsInventory(QtWidgets.QDialog):
                         self.ui.adsb_table_path.filePath(), inventory_path
                     )
                     if adsb_result:
-                        logger.info("ADS-B file was successfully imported!")
+                        logger.info(adsb_message)
                     else:
                         logger.warning(
                             f"The ADS-B file could not be imported! Details: {adsb_message}"


### PR DESCRIPTION
 + Unify profile creation and movement emission's trajectory creation:
      Make sure we use the same method to create profile's relative planar coordinates and to create the Movement emission trajectory. Namely, create deltas based on UTM coordinates when creating the profile (ref point to all points), and then when creating the movement emission trajectory, also use UTM and deltas from reference point to all points

  + When importing ADS-B data:
     + Use runway and taxi_route for calculating the reference runway point if these columns are given in the ADS-B CSV file. This case matches the method used when creating the movement emission calculation's trajectory.
     + If only runway is given, use it to get the closest endpoint.
     + If neither runway nor taxi_route are given, calculate the closest runway endpoint.