### PR TITLE
[gui] Remove the Advanced Options section from the Generate Emission Inventory dialog

### DIFF
--- a/open_alaqs/core/tools/create_output.py
+++ b/open_alaqs/core/tools/create_output.py
@@ -274,13 +274,12 @@ def inventory_update_tbl_inv_period(database_path, model_parameters, study_setup
 
     sql_interface.query_text(
         database_path,
-        "UPDATE tbl_InvPeriod SET interval=%d, temp_isa=%d, vert_limit=%d, apt_elev=%d, "
+        "UPDATE tbl_InvPeriod SET interval=%d, temp_isa=%d, apt_elev=%d, "
         'copert=%d, nox_corr=%d, ffm=%d, smsh=%d, mix_height=%d, min_time="%s", '
         'max_time="%s";'
         % (
             interval,
             temp_isa,
-            model_parameters["vertical_limit"],
             study_setup["airport_elevation"],
             copert,
             nox_corr,

--- a/open_alaqs/openalaqsdialog.py
+++ b/open_alaqs/openalaqsdialog.py
@@ -1692,10 +1692,6 @@ class OpenAlaqsInventory(QtWidgets.QDialog):
         self.ui.setupUi(self)
 
         # Connections
-        # TODO OPENGIS.ch: remove the Vertical limit from the form, use the one in the Emission Inventory Analysis only
-        self.ui.vert_limit_m.valueChanged.connect(self.m_to_ft)
-        self.ui.vert_limit_ft.setEnabled(False)
-
         self.ui.status_update.setText("Ready")
         self.ui.buttonBox.button(
             QtWidgets.QDialogButtonBox.StandardButton.Save
@@ -1728,8 +1724,6 @@ class OpenAlaqsInventory(QtWidgets.QDialog):
         self.ui.met_summary.setText("Meteorological file required")
         self.ui.met_summary.setStyleSheet(STATUS_STYLE_WARNING)
         self.ui.output_save_path.setStorageMode(QgsFileWidget.GetDirectory)
-        self.ui.towing_speed.setValue(10.0)
-        self.ui.vert_limit_m.setValue(914.4)
         self.ui.x_resolution.setValue(250)
         self.ui.y_resolution.setValue(250)
         self.ui.z_resolution.setValue(50)
@@ -2012,10 +2006,6 @@ class OpenAlaqsInventory(QtWidgets.QDialog):
             met_csv_path = oautk.validate_field(self.ui.met_file_path, "str")
             study_start_date = oautk.validate_field(self.ui.study_start_date, "str")
             study_end_date = oautk.validate_field(self.ui.study_end_date, "str")
-            vert_limit = self.ui.vert_limit_m.value()
-            towing_speed = self.ui.towing_speed.value()
-            #   method = self.ui.method.currentText()
-            #   met_file_path = oautk.validate_field(self, self.ui.met_file_path, "str")
             x_resolution = self.ui.x_resolution.value()
             y_resolution = self.ui.y_resolution.value()
             z_resolution = self.ui.z_resolution.value()
@@ -2029,8 +2019,6 @@ class OpenAlaqsInventory(QtWidgets.QDialog):
                 or (output_save_path is None)
                 or (study_start_date is False)
                 or (study_end_date is False)
-                or (vert_limit is False)
-                or (towing_speed is False)
                 or (x_resolution is False)
                 or (y_resolution is False)
                 or (z_resolution is False)
@@ -2080,8 +2068,6 @@ class OpenAlaqsInventory(QtWidgets.QDialog):
             model_parameters["movement_path"] = movement_file_path
             model_parameters["study_start_date"] = study_start_date
             model_parameters["study_end_date"] = study_end_date
-            model_parameters["towing_speed"] = towing_speed
-            model_parameters["vertical_limit"] = vert_limit
             model_parameters["x_resolution"] = x_resolution
             model_parameters["y_resolution"] = y_resolution
             model_parameters["z_resolution"] = z_resolution
@@ -2152,22 +2138,6 @@ class OpenAlaqsInventory(QtWidgets.QDialog):
             self.ui.status_update.setText("**Error** See log file")
             error = alaqsutils.print_error(self.create_inventory.__name__, Exception, e)
             return error
-
-    def m_to_ft(self):
-        """
-        Function that converts the user entered vertical limit in metres in feet
-         as well.
-        This isn't an essential process - more cosmetic
-        """
-        try:
-            m_value = self.ui.vert_limit_m.value()
-            ft_value = m_value * 3.2808399
-            self.ui.vert_limit_ft.setValue(ft_value)
-            # Make sure that the cell background is plain white
-            oautk.color_ui_background(self.ui.vert_limit_m, "transparent")
-        except Exception:
-            # Make the cell background red to highlight an error
-            oautk.color_ui_background(self.ui.vert_limit_m, "red")
 
     @staticmethod
     def check_state(ui_element):

--- a/open_alaqs/ui/ui_inventory.ui
+++ b/open_alaqs/ui/ui_inventory.ui
@@ -82,8 +82,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>526</width>
-        <height>660</height>
+        <width>580</width>
+        <height>525</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_6">
@@ -119,6 +119,19 @@
           </item>
          </layout>
         </widget>
+       </item>
+       <item row="4" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>10</height>
+          </size>
+         </property>
+        </spacer>
        </item>
        <item row="1" column="0">
         <widget class="QGroupBox" name="movementDataGroupBox">
@@ -428,107 +441,6 @@
          </layout>
         </widget>
        </item>
-       <item row="4" column="0">
-        <widget class="QgsCollapsibleGroupBox" name="advancedGroupBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string>Advanced Options</string>
-         </property>
-         <layout class="QGridLayout" name="advancedLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Method:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="method">
-            <item>
-             <property name="text">
-              <string>ALAQS</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_11">
-            <property name="text">
-             <string>Towing Speed:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QgsDoubleSpinBox" name="towing_speed">
-            <property name="suffix">
-             <string> km/h</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Vertical Limit:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="QgsDoubleSpinBox" name="vert_limit_m">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>1</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="suffix">
-               <string> m</string>
-              </property>
-              <property name="maximum">
-               <double>1000000.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsDoubleSpinBox" name="vert_limit_ft">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="suffix">
-               <string> ft</string>
-              </property>
-              <property name="maximum">
-               <double>1000000.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </widget>
     </widget>
@@ -577,17 +489,6 @@
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
   <customwidget>
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>


### PR DESCRIPTION
Because it was not being used and took vertical space in an already crowded interface.
(Requested by Stavros in a technical meeting earlier today)

See last section in the screenshot:
<img width="602" height="720" alt="Screenshot From 2026-03-24 10-10-28" src="https://github.com/user-attachments/assets/d75196e6-dbbe-40dc-a042-af33e9c9fb1b" />
