### PR TITLE
Fix: Source.__init__ silently falls back to default hour/month profiles

### DIFF
--- a/open_alaqs/core/interfaces/Source.py
+++ b/open_alaqs/core/interfaces/Source.py
@@ -7,9 +7,19 @@ class Source:
         from open_alaqs.core.tools.conversion import convertToFloat
 
         self._height = convertToFloat(val.get("height", 0), default=0.0)
-        self._hour_profile = str(val.get("hourly_profile", "default"))
+        # Database schema uses "hour_profile" / "month_profile" (see
+        # RoadwaySources.RoadwaySourcesDatabase, PointSources, etc.) but
+        # historical callers also pass "hourly_profile" / "monthly_profile".
+        # Accept either; prefer the schema names. Without this, sources
+        # silently fall back to the all-1.0 "default" profile and produce
+        # a flat hourly time series. See PR comment for full reproduction.
+        self._hour_profile = str(
+            val.get("hour_profile", val.get("hourly_profile", "default"))
+        )
         self._daily_profile = str(val.get("daily_profile", "default"))
-        self._month_profile = str(val.get("monthly_profile", "default"))
+        self._month_profile = str(
+            val.get("month_profile", val.get("monthly_profile", "default"))
+        )
         self._geometry_text = str(val.get("geometry", ""))
         self._unit_year = None
         self._emissionIndex = None

--- a/tests/test_source_profile_names_regression.py
+++ b/tests/test_source_profile_names_regression.py
@@ -1,0 +1,107 @@
+"""
+Regression test for the source profile name mismatch bug.
+
+Bug: in `core/interfaces/Source.py`, the constructor previously read
+profile names using keys "hourly_profile" / "monthly_profile", but the
+database schema (e.g. `shapes_roadways`) uses "hour_profile" /
+"month_profile". Two of three keys mismatched. Hour and month profiles
+silently fell through to the literal "default", which resolves to the
+all-1.0 default profile in user_hour_profile / user_month_profile.
+
+Effect: any roadway / point / parking / area / GSE source with non-default
+hour or month profiles produced a flat hourly time series. Annual totals
+were correct (the daily profile happened to match), but within-day and
+within-year distributions were wiped out.
+
+Fix: accept either name in Source.__init__ (schema name preferred).
+
+These tests pin both schema names and (for backward-compat) the older
+"hourly"/"monthly" names so a future refactor can't silently regress.
+"""
+
+
+class TestSourceProfileNameMismatchRegression:
+    """Pin profile-name handling against the original bug."""
+
+    def test_source_reads_schema_column_names(self):
+        """Source must accept hour_profile / month_profile (database schema)."""
+        from open_alaqs.core.interfaces.Source import Source
+
+        s = Source(
+            {
+                "hour_profile": "rush_hour_pattern",
+                "daily_profile": "weekday_pattern",
+                "month_profile": "summer_pattern",
+            }
+        )
+        assert s._hour_profile == "rush_hour_pattern"
+        assert s._daily_profile == "weekday_pattern"
+        assert s._month_profile == "summer_pattern"
+
+    def test_source_reads_alias_names(self):
+        """Backward compatibility: callers using older
+        hourly_profile / monthly_profile keys must still work."""
+        from open_alaqs.core.interfaces.Source import Source
+
+        s = Source(
+            {
+                "hourly_profile": "rush_hour_pattern",
+                "daily_profile": "weekday_pattern",
+                "monthly_profile": "summer_pattern",
+            }
+        )
+        assert s._hour_profile == "rush_hour_pattern"
+        assert s._daily_profile == "weekday_pattern"
+        assert s._month_profile == "summer_pattern"
+
+    def test_schema_names_take_precedence_when_both_present(self):
+        """If a row dict somehow has both names, the schema name wins.
+        This matches what SQLSerializable produces (only schema names)."""
+        from open_alaqs.core.interfaces.Source import Source
+
+        s = Source(
+            {
+                "hour_profile": "schema_name",
+                "hourly_profile": "alias_name",
+                "month_profile": "schema_name",
+                "monthly_profile": "alias_name",
+            }
+        )
+        assert s._hour_profile == "schema_name"
+        assert s._month_profile == "schema_name"
+
+    def test_missing_keys_fall_back_to_default(self):
+        """When neither name is provided, fall back to "default" string
+        (which resolves to the all-1.0 profile in user_hour_profile)."""
+        from open_alaqs.core.interfaces.Source import Source
+
+        s = Source({})
+        assert s._hour_profile == "default"
+        assert s._daily_profile == "default"
+        assert s._month_profile == "default"
+
+    def test_subclass_inherits_correct_profile_handling(self):
+        """Subclasses of Source must inherit the fix transparently.
+        Uses a synthetic subclass instead of RoadwaySources to keep this
+        test independent of the qgis runtime (which the standalone test
+        runner does not have)."""
+        from open_alaqs.core.interfaces.Source import Source
+
+        class _SyntheticRoadwaySource(Source):
+            def __init__(self, val=None, *args, **kwargs):
+                super().__init__(val, *args, **kwargs)
+
+        # This is the exact dict shape that SQLSerializable produces
+        # when reading a row from `shapes_roadways`.
+        r = _SyntheticRoadwaySource(
+            {
+                "roadway_id": "TEST_SEGMENT",
+                "hour_profile": "inw_test_hour",
+                "daily_profile": "inw_test_day",
+                "month_profile": "rtha_test_month",
+                "height": 0,
+            }
+        )
+        assert r.getHourProfile() == "inw_test_hour"
+        assert r.getDailyProfile() == "inw_test_day"
+        assert r.getMonthProfile() == "rtha_test_month"


### PR DESCRIPTION
## Bug

The `Source` constructor in `core/interfaces/Source.py` reads profile names from the row dict using keys `"hourly_profile"` and `"monthly_profile"`, but the database schema defined in this same codebase (e.g. `RoadwaySources.RoadwaySourcesDatabase.__init__` lines 188–190 in main, unchanged in `rebuild/v5.0.0`) uses `"hour_profile"` and `"month_profile"`:

```python
("hour_profile", "TEXT"),
("daily_profile", "TEXT"),
("month_profile", "TEXT"),
```

Two of three keys mismatch. Hour and month profiles silently fall through to the literal string `"default"`, which resolves to the all-1.0 default profile in `user_hour_profile` / `user_month_profile`. Daily profile works because the name accidentally matches.

## Symptom

Annual totals are correct, but within-day and within-year distributions are flattened. A roadway segment with a 24× peak/trough hourly profile produces output with only 2 distinct hourly values per year (one for weekday, one for weekend, from the day profile alone) instead of the expected ~46.

## Reproduction

I observed this end-to-end on an EHRD road inventory study. Roadway segment `Rijksweg_A13_016` configured with INWEVA empirical hour profile `inw_326005327110` (peak h15=1.89, trough h02=0.08), daily profile `inw_326005327110_d`, and flat monthly profile `rtha_hv_month`. Expected annual NOx 3,878.15 kg, hour-by-hour values ranging 0.031 to 0.884 kg/hr.

Before fix: 2 unique hourly values (0.467601 weekday, 0.380486 weekend), correct annual total, no diurnal variation.

After fix: 46 unique hourly values, min 0.030762, max 0.883975, annual total 3,878.7484. Hour-by-hour Pearson R=1.000000 against an independent reference computed from the same profile factors.

## Fix

Two-line change in `Source.__init__`. Accepts either name (schema name preferred) so existing callers passing `"hourly_profile"` / `"monthly_profile"` continue to work.

## Tests

Adds `tests/test_source_profile_names_regression.py` with 5 cases:

1. Schema column names work (`hour_profile`, `month_profile`)
2. Alias names still work (`hourly_profile`, `monthly_profile`) — backward compatibility
3. Schema names take precedence when both are present
4. Missing keys fall back to `"default"`
5. Subclasses inherit the fix transparently

I verified that 3 of 5 fail without the fix (proving the test catches the bug) and all 5 pass with the fix. No regressions in the rest of the standalone test suite.

## Sequencing with #306

Suggesting we land this before #306 merges so the bug doesn't ship in 5.0.0.