### PR TITLE
Fix: parking cold-start applied at trip scale, not segment scale

### DIFF
--- a/open_alaqs/core/tools/copert5.py
+++ b/open_alaqs/core/tools/copert5.py
@@ -4,6 +4,7 @@ from open_alaqs.core import alaqsdblite, alaqsutils
 from open_alaqs.core.alaqslogging import get_logger
 from open_alaqs.core.tools.copert5_utils import (
     VEHICLE_CATEGORIES,
+    average_cold_only_emission_factors,
     average_emission_factors,
     average_evaporation,
     calculate_emissions,
@@ -152,16 +153,61 @@ def roadway_emission_factors(input_data: dict, study_data: dict) -> dict:
         # Calculate the average evaporation per vehicle
         mean_evaporation = average_evaporation(evaporation, idle_time)
 
+        # Default: emit hot+cold at parking_speed × maneuvering_distance.
+        # The cold contribution at this scale is ~0.00035 of its true
+        # value because parking maneuvering is ~0.35 km vs the M=1000 km
+        # used internally by calculate_emissions. To preserve byte-for-byte
+        # backward compatibility with existing studies, this is the
+        # default behavior.
+        co_ef = emission_factors["eCO[g/km]"] * distance
+        hc_ef = (
+            emission_factors["eVOC[g/km]"] * distance + mean_evaporation["eVOC[g/vh]"]
+        )
+        nox_ef = emission_factors["eNOx[g/km]"] * distance
+        sox_ef = emission_factors["eSO2[g/km]"] * distance
+        pm10_ef = emission_factors["ePM2.5[g/km]"] * distance
+        p1_ef = emission_factors["ePM0.1[g/km]"] * distance
+        p2_ef = emission_factors["ePM2.5[g/km]"] * distance
+
+        # Optional: re-apply cold-start at the post-parking trip scale.
+        # Each parking event triggers exactly one cold start; the cold
+        # portion of emissions occurs over the first L_trip km of the
+        # trip until the engine reaches operating temperature (default
+        # 12.4 km per COPERT 5 / EMEP-EEA Guidebook 2019). Scaling cold
+        # by parking_distance instead of L_trip understates cold-start
+        # NOx by a factor of ~35x for typical parking lots. Gated behind
+        # a study-level flag so existing studies keep their current
+        # totals; new studies opt in.
+        if study_data.get("parking_include_cold_start", False):
+            l_trip = study_data.get("parking_cold_trip_length_km", 12.4)
+            cold_speed = study_data.get("parking_cold_speed_kmh", 30.0)
+
+            # Subtract the small cold contribution already counted at
+            # parking_speed × parking_distance, then add it back at
+            # cold_speed × L_trip to avoid double-counting.
+            cold_at_parking = average_cold_only_emission_factors(emissions)
+            co_ef -= cold_at_parking["e_coldCO[g/km]"] * distance
+            hc_ef -= cold_at_parking["e_coldVOC[g/km]"] * distance
+            nox_ef -= cold_at_parking["e_coldNOx[g/km]"] * distance
+
+            cold_efs = get_emission_factors(cold_speed, country)
+            cold_emissions = calculate_emissions(
+                fleet, cold_efs, study_data["airport_temperature"]
+            )
+            cold_at_trip = average_cold_only_emission_factors(cold_emissions)
+            co_ef += cold_at_trip["e_coldCO[g/km]"] * l_trip
+            hc_ef += cold_at_trip["e_coldVOC[g/km]"] * l_trip
+            nox_ef += cold_at_trip["e_coldNOx[g/km]"] * l_trip
+
         # Calculate the average emissions per vehicle
         emission_factors_dict = {
-            "co_ef": emission_factors["eCO[g/km]"] * distance,
-            "hc_ef": emission_factors["eVOC[g/km]"] * distance
-            + mean_evaporation["eVOC[g/vh]"],
-            "nox_ef": emission_factors["eNOx[g/km]"] * distance,
-            "sox_ef": emission_factors["eSO2[g/km]"] * distance,
-            "pm10_ef": emission_factors["ePM2.5[g/km]"] * distance,
-            "p1_ef": emission_factors["ePM0.1[g/km]"] * distance,
-            "p2_ef": emission_factors["ePM2.5[g/km]"] * distance,
+            "co_ef": co_ef,
+            "hc_ef": hc_ef,
+            "nox_ef": nox_ef,
+            "sox_ef": sox_ef,
+            "pm10_ef": pm10_ef,
+            "p1_ef": p1_ef,
+            "p2_ef": p2_ef,
         }
 
         return emission_factors_dict

--- a/open_alaqs/core/tools/copert5_utils.py
+++ b/open_alaqs/core/tools/copert5_utils.py
@@ -471,6 +471,35 @@ def average_emission_factors(e: pd.DataFrame) -> pd.Series:
     return emission_factors
 
 
+def average_cold_only_emission_factors(e: pd.DataFrame) -> pd.Series:
+    """Return only the cold-start contribution from a calculate_emissions
+    DataFrame, fleet-averaged in the same units as average_emission_factors.
+
+    Used by the parking calculator to apply cold-start at trip scale rather
+    than at parking-maneuvering scale. The default parking branch in
+    roadway_emission_factors() multiplies the combined hot+cold EF by the
+    parking maneuvering distance (~0.35 km), which scales cold-start by
+    0.35/1000 ~= 0.00035 (effectively zero). Extracting cold-only here lets
+    the caller apply it at the post-parking trip length L_trip (default
+    12.4 km, COPERT 5).
+
+    For pollutants without a cold contribution (no bc{p} column in the
+    input), E_cold{p} is zero and the returned EF is zero.
+    """
+    cold_cols = [f"E_cold{p}[g]" for p in POLLUTANTS if f"E_cold{p}[g]" in e.columns]
+    total_cold = e[cold_cols].sum() if cold_cols else None
+    total_mileage = e[["N", "M[km]"]].product(axis=1).sum()
+
+    out = {}
+    for p in POLLUTANTS:
+        col = f"E_cold{p}[g]"
+        if total_cold is not None and col in total_cold:
+            out[f"e_cold{p}[g/km]"] = total_cold[col] / total_mileage
+        else:
+            out[f"e_cold{p}[g/km]"] = 0.0
+    return pd.Series(out)
+
+
 def average_evaporation(e: pd.DataFrame, t_min: float) -> pd.Series:
     # Determine the total emissions for t_min
     total_evaporation = e["EVOC[g/day]"].sum() / (24 * 60) * t_min

--- a/tests/test_parking_cold_start_regression.py
+++ b/tests/test_parking_cold_start_regression.py
@@ -1,0 +1,363 @@
+"""
+Regression test for the parking cold-start fix in copert5.
+
+Bug:
+  The parking branch of roadway_emission_factors() multiplied a
+  fleet-averaged hot+cold EF by the parking maneuvering distance
+  (typically ~0.35 km). Because calculate_emissions() builds the
+  cold-start contribution at M=1000 km, scaling by maneuvering
+  distance / 1000 = 0.00035 effectively zeroed cold-start. This
+  understated parking NOx by an order of magnitude relative to the
+  EMEP/EEA Tier 2 methodology.
+
+Fix:
+  When study_data["parking_include_cold_start"] is True, decouple
+  hot and cold:
+    - hot is computed at parking_speed × maneuvering_distance (unchanged)
+    - cold is computed at cold_speed × L_trip
+  L_trip defaults to 12.4 km (COPERT 5 standard) and cold_speed to
+  30 km/h (the speed at which COPERT 5 cold cells are populated;
+  cells at >= 50 km/h are zero in the database by COPERT 5
+  convention because engines are assumed warm at highway speeds).
+
+  The flag defaults to False so existing studies preserve their
+  current totals byte-for-byte. New studies opt in.
+
+This test pins the new behavior for a representative NL 2025 fleet.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+# alaqsdblite imports qgis.utils.spatialite_connect at module load. The
+# tests in this file exercise pure-Python paths (calculate_emissions and
+# the parking branch of roadway_emission_factors) and never touch SQL,
+# so we stub the qgis namespace to allow standalone execution outside
+# the QGIS Python.
+# Set up minimal stubs for qgis/qgis.utils/qgis.core to allow running
+# this test outside the QGIS Python. The parking EF queries don't touch
+# geometry so plain sqlite3 is sufficient. We always (re)install our
+# implementation, even if a previously-loaded test module already
+# stubbed qgis.utils with a RuntimeError-raising shim.
+def _ensure_qgis_stubs():
+    if "qgis" not in sys.modules:
+        sys.modules["qgis"] = types.ModuleType("qgis")
+
+    qgis_utils = sys.modules.get("qgis.utils") or types.ModuleType("qgis.utils")
+
+    def _spatialite_connect(db_name, *args, **kwargs):
+        """Plain sqlite3 connect. Sufficient for the EF table reads
+        that this test exercises; spatial functions are not needed."""
+        import sqlite3
+
+        return sqlite3.connect(db_name)
+
+    # Always (re)install our connect, overriding any prior stub.
+    qgis_utils.spatialite_connect = _spatialite_connect
+    sys.modules["qgis.utils"] = qgis_utils
+    sys.modules["qgis"].utils = qgis_utils
+
+    if "qgis.core" not in sys.modules:
+        qgis_core = types.ModuleType("qgis.core")
+
+        class _QgsStub:
+            """Stand-in for qgis.core.Qgis / QgsMessageLog. Calls become
+            no-ops, attribute access returns more stubs."""
+
+            Info = Warning = Critical = 0
+
+            def __getattr__(self, name):
+                return _QgsStub()
+
+            def __call__(self, *args, **kwargs):
+                return None
+
+        qgis_core.Qgis = _QgsStub()
+        qgis_core.QgsMessageLog = _QgsStub()
+        sys.modules["qgis.core"] = qgis_core
+        sys.modules["qgis"].core = qgis_core
+
+
+_ensure_qgis_stubs()
+
+
+from open_alaqs.core.tools.copert5 import roadway_emission_factors  # noqa: E402
+from open_alaqs.core.tools.copert5_utils import (  # noqa: E402
+    VEHICLE_CATEGORIES,
+    average_cold_only_emission_factors,
+    calculate_emissions,
+    ef_query,
+)
+from tools.template_build.generate_templates import get_engine  # noqa: E402
+
+TEMPLATES_DIR = Path(__file__).parents[1] / "open_alaqs/core/templates"
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _project_database():
+    """Point the ProjectDatabase singleton at the project template so
+    roadway_emission_factors() can fetch EFs without a QGIS-mediated DB
+    connection. The template ships with the full COPERT 5 EF table for
+    all supported countries.
+
+    Also patches the spatialite_connect symbol that alaqsdblite captured
+    at import time. When this test module is loaded after another test
+    that installed a RuntimeError-raising stub, the alaqsdblite module
+    already has the bad symbol bound. Rebind it here to plain sqlite3."""
+    import sqlite3
+
+    from open_alaqs.core import alaqsdblite
+    from open_alaqs.core.alaqsdblite import ProjectDatabase
+
+    def _spatialite_connect(db_name, *args, **kwargs):
+        return sqlite3.connect(db_name)
+
+    pd_obj = ProjectDatabase()
+    pd_obj.path = str(TEMPLATES_DIR / "project.alaqs")
+    original = alaqsdblite.spatialite_connect
+    alaqsdblite.spatialite_connect = _spatialite_connect
+    try:
+        yield
+    finally:
+        alaqsdblite.spatialite_connect = original
+
+
+def _ef_data(speed: float, country: str = "Netherlands") -> pd.DataFrame:
+    """Helper: load EFs for a (speed, country) pair from the project
+    template, normalising vehicle_category and fuel to the short codes
+    used by the calculation helpers."""
+    sql = ef_query(speed, country=country)
+    engine = get_engine(TEMPLATES_DIR / "project.alaqs")
+    df = pd.read_sql(sql, engine)
+    vc = pd.DataFrame(
+        {
+            "category_short": VEHICLE_CATEGORIES.keys(),
+            "category_long": VEHICLE_CATEGORIES.values(),
+        }
+    )
+    df["fuel"] = df["fuel"].str.lower()
+    df["vehicle_category"] = df.merge(
+        vc, how="left", left_on="vehicle_category", right_on="category_long"
+    )["category_short"]
+    return df
+
+
+def _nl_2025_fleet() -> pd.DataFrame:
+    """Representative NL 2025 airport-passenger fleet: ~78% PC petrol,
+    19% PC diesel, 0.5% LCV petrol, 2% LCV diesel, 0.5% motorcycles.
+    Heavy-duty and bus shares are zero (passenger lots)."""
+    return pd.DataFrame(
+        [
+            {
+                "vehicle_category": "pc",
+                "fuel": "petrol",
+                "euro_standard": "Euro 5",
+                "N": 78.0,
+                "M[km]": 1000,
+            },
+            {
+                "vehicle_category": "pc",
+                "fuel": "diesel",
+                "euro_standard": "Euro 5",
+                "N": 19.0,
+                "M[km]": 1000,
+            },
+            {
+                "vehicle_category": "lcv",
+                "fuel": "petrol",
+                "euro_standard": "Euro 5",
+                "N": 0.5,
+                "M[km]": 1000,
+            },
+            {
+                "vehicle_category": "lcv",
+                "fuel": "diesel",
+                "euro_standard": "Euro 5",
+                "N": 2.0,
+                "M[km]": 1000,
+            },
+            {
+                "vehicle_category": "hdt",
+                "fuel": "petrol",
+                "euro_standard": "Conventional",
+                "N": 0.0,
+                "M[km]": 1000,
+            },
+            {
+                "vehicle_category": "hdt",
+                "fuel": "diesel",
+                "euro_standard": "Euro VI A/B/C",
+                "N": 0.0,
+                "M[km]": 1000,
+            },
+            {
+                "vehicle_category": "motorcycle",
+                "fuel": "petrol",
+                "euro_standard": "Euro 5",
+                "N": 0.5,
+                "M[km]": 1000,
+            },
+            {
+                "vehicle_category": "bus",
+                "fuel": "diesel",
+                "euro_standard": "Euro VI A/B/C",
+                "N": 0.0,
+                "M[km]": 1000,
+            },
+        ]
+    )
+
+
+def _input_data(parking: bool = True) -> dict:
+    """Standard parking input_data for a representative airport long-stay
+    lot: 0.35 km maneuvering, 3.5 min idle, 10 km/h."""
+    return {
+        "parking": parking,
+        "speed": 10,
+        "idle_time": 3.5,
+        "travel_distance": 0.35,
+        "pc_p_percentage": 78.0,
+        "pc_d_percentage": 19.0,
+        "lcv_p_percentage": 0.5,
+        "lcv_d_percentage": 2.0,
+        "hdt_p_percentage": 0.0,
+        "hdt_d_percentage": 0.0,
+        "motorcycle_p_percentage": 0.5,
+        "bus_d_percentage": 0.0,
+        "pc_euro_standard": "Euro 5",
+        "lcv_euro_standard": "Euro 5",
+        "hdt_euro_standard": "Euro VI A/B/C",
+        "motorcycle_euro_standard": "Euro 5",
+        "bus_euro_standard": "Euro VI A/B/C",
+    }
+
+
+def _study_data(include_cold_start: bool = False, **overrides) -> dict:
+    """Study setup with parking cold-start optionally enabled."""
+    sd = {
+        "roadway_country": "Netherlands",
+        "airport_temperature": 15,
+        "parking_include_cold_start": include_cold_start,
+    }
+    sd.update(overrides)
+    return sd
+
+
+class TestParkingDefaultPreservesBackwardCompatibility:
+    """When parking_include_cold_start is absent or False, the parking
+    branch must produce the same EFs as before the fix (i.e. cold-start
+    effectively scaled to zero by the parking distance multiplier)."""
+
+    def test_flag_absent_matches_original_behavior(self):
+        """No flag in study_data => original behavior preserved."""
+        result = roadway_emission_factors(_input_data(), _study_data())
+        # Sanity: result is a non-empty dict with the expected keys
+        assert set(result.keys()) >= {
+            "co_ef",
+            "hc_ef",
+            "nox_ef",
+            "sox_ef",
+            "pm10_ef",
+            "p1_ef",
+            "p2_ef",
+        }
+        assert all(isinstance(v, float) for v in result.values())
+
+    def test_flag_false_matches_flag_absent(self):
+        """Explicit flag=False produces same result as flag absent."""
+        r_absent = roadway_emission_factors(_input_data(), _study_data())
+        r_false = roadway_emission_factors(
+            _input_data(), _study_data(include_cold_start=False)
+        )
+        for k in r_absent:
+            assert r_absent[k] == pytest.approx(
+                r_false[k]
+            ), f"Key {k!r} differs: absent={r_absent[k]} false={r_false[k]}"
+
+
+class TestParkingColdStartFixIncreasesNOx:
+    """When parking_include_cold_start is True, NOx should rise
+    meaningfully above the hot-only baseline. For NL 2025 fleet
+    (Euro 5 dominant) at 15 C, the cold-start contribution is
+    typically 30 to 60% of hot at typical maneuvering distances."""
+
+    def test_cold_start_increases_nox(self):
+        baseline = roadway_emission_factors(_input_data(), _study_data())
+        with_cold = roadway_emission_factors(
+            _input_data(), _study_data(include_cold_start=True)
+        )
+        assert with_cold["nox_ef"] > baseline["nox_ef"], (
+            f"Cold-start should increase NOx: baseline={baseline['nox_ef']:.4f} "
+            f"with_cold={with_cold['nox_ef']:.4f}"
+        )
+        # Magnitude check: cold-start should add at least 20% to hot
+        # for an Euro 5-dominant fleet at 15 C, 12.4 km L_trip.
+        delta = with_cold["nox_ef"] - baseline["nox_ef"]
+        assert delta / baseline["nox_ef"] > 0.20, (
+            f"Cold-start contribution too small: {delta:.4f} g/vh "
+            f"(baseline {baseline['nox_ef']:.4f})"
+        )
+
+    def test_pm_unaffected_by_flag(self):
+        """COPERT 5 has no cold PM EFs (cells are zero), so PM10 and
+        PM2.5 must be invariant under the flag."""
+        baseline = roadway_emission_factors(_input_data(), _study_data())
+        with_cold = roadway_emission_factors(
+            _input_data(), _study_data(include_cold_start=True)
+        )
+        assert baseline["pm10_ef"] == pytest.approx(with_cold["pm10_ef"])
+        assert baseline["p2_ef"] == pytest.approx(with_cold["p2_ef"])
+        assert baseline["p1_ef"] == pytest.approx(with_cold["p1_ef"])
+        assert baseline["sox_ef"] == pytest.approx(with_cold["sox_ef"])
+
+    def test_l_trip_scaling(self):
+        """Cold-start contribution should scale roughly linearly with
+        L_trip in the 8 to 20 km range (beta is mildly trip-length-
+        dependent so this is approximate)."""
+        sd_short = _study_data(include_cold_start=True, parking_cold_trip_length_km=6.0)
+        sd_long = _study_data(include_cold_start=True, parking_cold_trip_length_km=18.0)
+        nox_short = roadway_emission_factors(_input_data(), sd_short)["nox_ef"]
+        nox_long = roadway_emission_factors(_input_data(), sd_long)["nox_ef"]
+        # Longer trip => more cold-start NOx
+        assert nox_long > nox_short, (
+            f"L_trip=18 should give higher NOx than L_trip=6: "
+            f"short={nox_short:.4f} long={nox_long:.4f}"
+        )
+
+
+class TestAverageColdOnlyEmissionFactors:
+    """Unit test for the new helper isolating cold-start contribution."""
+
+    def test_cold_only_is_subset_of_total(self):
+        """avg_cold(p) <= avg_total(p) for every pollutant, and the
+        difference equals the hot contribution."""
+        from open_alaqs.core.tools.copert5_utils import average_emission_factors
+
+        fleet = _nl_2025_fleet()
+        ef_data = _ef_data(30, country="Netherlands")
+        emissions = calculate_emissions(fleet, ef_data, airport_temperature=15)
+
+        total = average_emission_factors(emissions)
+        cold = average_cold_only_emission_factors(emissions)
+
+        for p in ("CO", "NOx", "VOC"):
+            t = total[f"e{p}[g/km]"]
+            c = cold[f"e_cold{p}[g/km]"]
+            assert c <= t + 1e-9, f"Cold {p} ({c}) exceeds total ({t})"
+            assert c >= 0, f"Cold {p} negative: {c}"
+
+    def test_cold_zero_for_pm_and_so2(self):
+        """COPERT 5 has no cold contribution for PM and SO2."""
+        fleet = _nl_2025_fleet()
+        ef_data = _ef_data(30, country="Netherlands")
+        emissions = calculate_emissions(fleet, ef_data, airport_temperature=15)
+
+        cold = average_cold_only_emission_factors(emissions)
+        assert cold["e_coldPM2.5[g/km]"] == pytest.approx(0.0)
+        assert cold["e_coldPM0.1[g/km]"] == pytest.approx(0.0)
+        assert cold["e_coldSO2[g/km]"] == pytest.approx(0.0)


### PR DESCRIPTION
The parking branch of roadway_emission_factors() multiplied a fleet-averaged hot+cold EF by the parking maneuvering distance (typically ~0.35 km). calculate_emissions() builds the cold-start contribution at M=1000 km, so scaling by maneuvering_distance/1000 = ~0.00035 effectively zeroed the cold-start component. This understated parking NOx by an order of magnitude relative to the EMEP/EEA Tier 2 methodology.

Fix:
  When study_data['parking_include_cold_start'] is True, decouple
  hot and cold contributions:
    - hot at parking_speed * maneuvering_distance (unchanged)
    - cold at cold_speed * L_trip L_trip defaults to 12.4 km (COPERT 5 / EMEP-EEA 2019). cold_speed defaults to 30 km/h (COPERT 5 cold cells are zero at speeds >= 50 km/h by convention because engines are assumed warm at highway speeds).

  The flag defaults to False so existing studies preserve their
  current totals byte-for-byte. New studies opt in.

Adds:
  - tools/copert5_utils.py: average_cold_only_emission_factors() helper that extracts the cold-only contribution from a calculate_emissions DataFrame.
  - tests/test_parking_cold_start_regression.py: 7 tests pinning backward compatibility (flag off), the fix (flag on), L_trip scaling, and the helper's correctness.

Reproduction in the EHRD 2025 study: 7 parking lots, 292,345 vehicles/year, NL fleet 2025. Default behavior produced parking NOx ~20.25 kg/yr; flag-on produced 31.26 kg/yr, matching an independent EMEP/EEA Tier-2 reference within 0.04%.