### PR TITLE
ci: also run tests on the rebuild/v5.0.0 branch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - rebuild/v5.0.0
   pull_request:
     branches:
       - main
+      - rebuild/v5.0.0
 
 jobs:
   test:


### PR DESCRIPTION
The workflow's push and pull_request triggers were limited to 'main', so PRs targeting 'rebuild/v5.0.0' (the in-progress 5.0.0 rebuild branch) silently produced no CI runs. The Actions tab shows 'No results matched your search' when filtered by any of the open fix branches against the rebuild branch.

Adding 'rebuild/v5.0.0' to both trigger lists so PRs against the rebuild branch get the same CI coverage as PRs against main. The filter still excludes feature branches, so PRs from forks continue to behave as before.