### PR TITLE
docs: merge old onboarding README with rebuild's technical README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,18 @@ backwards-compatible at the file-format level with the 4.x series — see the
   ordering was also realigned with the canonical template. Rows in
   legacy files are migrated transparently by `--drop-extra-columns`.
 
+- **Dual-mode BFFM2** — the BFFM2 path accepts a `bffm2_ff_source` config
+  field (`trajectory` default, or `mode_anchor`). Exposed in the Generate
+  Emission Inventory dialog via a dropdown.
+
+- **Create Output dialog "Advanced Options" group removed** — the Method
+  dropdown (with "ALAQS" as the sole choice), Towing Speed, and Vertical
+  Limit fields have been removed. Method was never routed to any consumer,
+  Towing Speed was written to a dict key no downstream code read, and
+  Vertical Limit wrote to a DB column nothing queried — the actual LTO
+  ceiling is `EmissionCalculatorService.vertical_limit_m = 914.4` m (CAEP
+  standard), hardcoded at the calculation boundary.
+
 ### Removed
 
 - **18 legacy 4.x-era tables** are no longer part of the canonical schema
@@ -118,6 +130,95 @@ backwards-compatible at the file-format level with the 4.x series — see the
   QGIS does not see phantom layers when opening the migrated file.
   Regression test:
   `tests/test_migrate_legacy_spatialite_metadata_regression.py`.
+
+- **Profile product normalisation** —
+  `SourceWithTimeProfileModule.getRelativeActivityPerHour` now divides by
+  the calendar-weighted mean of (hour × weekday × month) over the inventory
+  year. Profiles whose mean was not exactly 1.0 previously rescaled the
+  annual emission silently away from `EF × unit_year`. Profiles authored to
+  the OpenALAQS template convention (mean = 1.0) are unchanged byte-for-byte.
+
+- **`instudy='0'` filter** — sources marked excluded from the study via the
+  `instudy` column are now filtered out at calculation time. The column had
+  been declared in the schema for roadways, parking, gates, point sources,
+  area sources, and runways but was never read by any module — the rows
+  were silently included in totals.
+
+- **`Source.__init__` profile-name aliasing** — Source rows now correctly
+  read `hourly_profile`, `daily_profile`, and `monthly_profile` from the
+  database. A key mismatch had caused the loader to fall back to the
+  default profile silently for any source where the user had set a
+  non-default value.
+
+- **AmbientCondition NULL handling + METAR VRB winds** —
+  `AmbientCondition.__init__` now uses explicit numeric defaults for every
+  field instead of returning `None` on empty cells. The METAR-to-meteo
+  converter writes `999` (AUSTAL calm-variable convention) for VRB winds
+  instead of empty string. Together these prevent a `TypeError: must be
+  real number, not NoneType` crash in `AUSTALOutputModule` on inventories
+  with VRB METAR observations.
+
+- **Parking cold-start at trip scale** — the COPERT5 cold-start contribution
+  is now applied once per parking trip rather than once per road segment
+  when `parking_include_cold_start=True`. Default behaviour (cold start
+  off) is unchanged.
+
+- **Taxi Mach state-leak isolation** —
+  `TaxiingEmissionCalculator.calculate_emissions` now forces
+  `mach_number = 0.0` for taxi operations. The shared `method["config"]`
+  dict was being mutated per flight segment by `FlightEmissionCalculator`,
+  leaking the previous segment's terminal Mach (typically 0.15-0.40) into
+  taxi BFFM2 lookups and producing 0.5-3% under-prediction on taxi fuel
+  flow. CAEP14 v14 spec says ground operations are M=0.
+
+- **Climbout installation correction** — `MovementSourceModule` CAEP14 v14
+  installation correction for Climbout corrected from 1.012 to 1.013 (the
+  1.012 override disagreed with the `bffm2.py` docstring, comment, and
+  default).
+
+- **MES double-count fix** — single-engine taxi main-engine-start emissions
+  are now added exactly once per movement instead of once per taxi segment
+  inside the MES window. Affects movements with `gate_emissions_code=1`
+  AND a non-null `set_time_of_main_engine_start_after_block_off_in_s` (or
+  the before-takeoff variant) AND multi-segment taxi routes.
+
+- **Gate emissions gating** — `MovementSourceModule` now forwards the
+  movement's `gate_emissions_code` to the gate emissions path, so `code=0`
+  movements no longer leak POLYGON-geometry entries.
+
+- **Stop-and-go engine count** — stop-and-go emissions now multiply by
+  `number_of_engines`, matching the convention used for taxi and queuing
+  time. Affects movements with `number_of_stop_and_gos > 0`; no effect on
+  engine-only validation scope where stops are zeroed out.
+
+- **CO/HC interpolation alignment with CAEP14 v14** — in the standard
+  SL/HL-intersection case, EI now snaps to the horizontal mean value for
+  any segment fuel flow above the APP anchor (SAE AIR-5715 "HC_CO Slope To
+  Mean Value" rule). The previous smoothed step disagreed with v14 by up
+  to 8× EI at warm-humid AP-anchor conditions.
+
+- **Log-noise suppression** — `OutputModule`,
+  `TableViewWidgetOutputModule`, and `AUSTALOutputModule` no longer log
+  ERROR for zero-valued placeholder emissions synthesised for empty
+  periods. Real missing-geometry bugs still surface.
+
+- **AUSTAL diagnostic level + day-window correction** —
+  `checkTimeIntervalinResults` now logs at ERROR level (was DEBUG) when
+  `series.dmna` and `austal.txt` files disagree. `checkHoursinResults`
+  warning text and `end_date` assignment are now consistent at start +
+  23 h (AUSTAL convention: a day is 24 inclusive timestamps from
+  01:00..00:00).
+
+- **Below-MSL airport elevation entry** — `spinBoxAirportElevation` and
+  `spinBoxAirportTemperature` now declare explicit `minimum` properties.
+  Below-MSL airports (EHRD, EHAM, LLEY, etc.) and cold-climate annual
+  means now round-trip correctly. Without the minimum, Qt clamped any
+  negative value to 0 silently.
+
+- **CSV receptor altitude optional** — the receptor CSV loader now accepts
+  a 3-column file (`id, longitude, latitude`) without silently producing
+  an empty GeoDataFrame. Default receptor breathing height (1.5 m) is
+  applied downstream by `AUSTALOutputModule.getGridXYFromReferencePoint`.
 
 ### Migration
 

--- a/README.md
+++ b/README.md
@@ -1,241 +1,250 @@
-# Open-ALAQS — QGIS plugin for airport emissions inventory
+# Open-ALAQS
 
-Open-ALAQS is a QGIS plugin that produces Eurocontrol ALAQS airport emissions
-inventories from movement data, meteorological data, and airport layout.
-This release adds dual-mode BFFM2, corrects several calculation paths, and
-validates against the CAEP14 reference spreadsheet (v14) across 13
-representative segment conditions.
+QGIS plugin for airport emissions inventory and dispersion. Builds an annual emissions inventory from runway, taxiway, gate, stationary, and movement sources, and exports AUSTAL-ready dispersion inputs.
+
+<img src="./open_alaqs/assets/oa-logo.jpg" alt="Open-ALAQS logo" width="50%">
+
+## Table of contents
+
+- [Open-ALAQS](#open-alaqs)
+  - [Table of contents](#table-of-contents)
+  - [Installation](#installation)
+    - [Install QGIS](#install-qgis)
+    - [Install dependencies](#install-dependencies)
+    - [Install Open-ALAQS](#install-open-alaqs)
+  - [Quick start](#quick-start)
+    - [Example files](#example-files)
+    - [Training example study](#training-example-study)
+    - [Beta: Standalone Emissions + AUSTAL Inputs export script](#beta-standalone-emissions--austal-inputs-export-script)
+  - [Workflow](#workflow)
+  - [Emission calculation methods](#emission-calculation-methods)
+  - [Meteorological data](#meteorological-data)
+  - [GSE Application](#gse-application)
+  - [Development](#development)
+    - [Code style](#code-style)
+    - [Debugging](#debugging)
+    - [Updating the Open-ALAQS database templates](#updating-the-open-alaqs-database-templates)
+    - [Unit tests](#unit-tests)
+  - [Validation](#validation)
+  - [Recent changes](#recent-changes)
+  - [Contribute](#contribute)
+  - [License](#license)
+  - [Contact](#contact)
 
 ## Installation
 
-Clone into the QGIS plugin directory:
+[(Back to top)](#table-of-contents)
 
-- Windows: `%APPDATA%\QGIS\QGIS3\profiles\default\python\plugins\open_alaqs\`
-- macOS: `~/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins/open_alaqs/`
-- Linux: `~/.local/share/QGIS/QGIS3/profiles/default/python/plugins/open_alaqs/`
+To use Open-ALAQS you need to install QGIS, plus a few external Python libraries the plugin depends on.
 
-Then enable Open-ALAQS in the QGIS Plugin Manager.
+### Install QGIS
+
+Download and install QGIS for your operating system following the official [QGIS documentation](https://qgis.org/download/).
+
+If you are running on Windows, install via the [OSGeo4W installer](https://qgis.org/resources/installation-guide/#osgeo4w-installer) following the `Advanced Install` route.
+
+> **Note:** If not installed using the OSGeo4W Network Installer, please uninstall any old version and install the new version using OSGeo4W or follow the QGIS installation guide. During installation, accept the unmet dependencies and license agreements.
+
+### Install dependencies
+
+Open-ALAQS is built on top of QGIS and a few external libraries that require separate installation. The full list is in `requirements.txt`.
+
+**Primary method:** Use QPIP (Python Dependency Manager for QGIS Plugins) to check and install the required dependencies directly inside QGIS. See the **Install Open-ALAQS** section below for details.
+
+**Alternative method:** Install the libraries manually using `pip install` in the Python environment used by QGIS:
+
+```bash
+pip install -r requirements.txt
+```
+
+<details>
+<summary>OSGeo4W manual installation</summary>
+
+Find and install these packages from the OSGeo4W shell:
+
+- `qgis-ltr-full` (3.34.x or newer)
+- `python3-fiona`
+- `python3-geopandas` (2.x.x)
+
+</details>
+
+### Install Open-ALAQS
+
+Open-ALAQS is published as a QGIS plugin. The cleanest way to install it is to clone the repository into the QGIS plugin directory for your platform:
+
+- **Windows**: `%APPDATA%\QGIS\QGIS3\profiles\default\python\plugins\open_alaqs\`
+- **macOS**: `~/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins/open_alaqs/`
+- **Linux**: `~/.local/share/QGIS/QGIS3/profiles/default/python/plugins/open_alaqs/`
+
+Then enable Open-ALAQS in the QGIS Plugin Manager (Plugins → Manage and Install Plugins → Installed → tick "Open-ALAQS").
+
+The first time the plugin loads, QPIP will detect missing dependencies and offer to install them in the QGIS Python environment:
+
+<img src="./open_alaqs/assets/install_dependencies_via_qpip.png" alt="QPIP dependency dialog" width="80%">
+
+<img src="./open_alaqs/assets/install_plugin_dependencies.png" alt="QPIP install dialog" width="80%">
+
+After dependencies are installed, restart QGIS once and Open-ALAQS will be available from the menu and toolbar:
+
+<img src="./open_alaqs/assets/screenshot.png" alt="Open-ALAQS in QGIS" width="80%">
+
+## Quick start
+
+[(Back to top)](#table-of-contents)
+
+### Example files
+
+Two example studies ship with the repository:
+
+- `example/training/` — a self-contained study used for tutorials and validation, including pre-computed reference values to compare your run against.
+- `tests/data/AIRPORT_A/` — the same study used by the regression test suite, with full pre-computed emissions tables and APU/CAEP14 comparison spreadsheets.
+
+### Training example study
+
+The training study lives in `example/training/` and contains:
+
+- `training.alaqs` — the unprocessed study database (geometry, sources, study setup)
+- `training_out.alaqs` — the processed inventory database (Generate Emission Inventory output)
+- `training_movements.csv` — aircraft movements input
+- `training_meteo.csv` — hourly meteorological input
+- `training_ads_b_data.csv` — ADS-B trajectory input (used by the BFFM2 trajectory method)
+- `training_validation_reference.xlsx` — reference values for verifying your installation
+
+For a step-by-step walk-through of opening, configuring, and running a study, see the [User Guide](documents/USER_GUIDE.md).
+
+### Beta: Standalone Emissions + AUSTAL Inputs export script
+
+A beta standalone script generates emissions exports (CSV/GeoJSON) and AUSTAL input files outside the QGIS plugin. It is experimental and may contain incomplete features.
+
+- Script location: [`scripts/emissions_austal/run_emissions_austal.py`](scripts/emissions_austal/run_emissions_austal.py)
+- Usage: see [`scripts/emissions_austal/README.md`](scripts/emissions_austal/README.md)
+- A METAR-to-meteo converter is provided in [`scripts/metar_to_alaqs_meteo.py`](scripts/metar_to_alaqs_meteo.py) (see [`scripts/README_metar_to_alaqs_meteo.md`](scripts/README_metar_to_alaqs_meteo.md)) for producing the meteo CSV from raw METAR observations.
+- A schema migration tool for upgrading legacy `.alaqs` files to the current schema is provided in [`scripts/migrate_alaqs.py`](scripts/migrate_alaqs.py).
+
+See [`scripts/README.md`](scripts/README.md) for the full inventory of standalone scripts.
 
 ## Workflow
 
-1. Build the airport study (runways, taxiways, gates, stationary sources) in a
-   QGIS project.
-2. Open *Create Output* to bake the study into an inventory database, supplying
-   a movements CSV and a meteorological CSV (see below).
-3. Run *Generate Emission Inventory* on the baked inventory to calculate
-   emissions with the selected method.
+[(Back to top)](#table-of-contents)
+
+1. Build the airport study (runways, taxiways, gates, stationary sources) in a QGIS project.
+2. Open *Create Output* to bake the study into an inventory database, supplying a movements CSV and a meteorological CSV (see [Meteorological data](#meteorological-data)).
+3. Run *Generate Emission Inventory* on the baked inventory to calculate emissions with the selected method.
+4. For dispersion runs, see [`documents/AUSTAL/AUSTAL_OPERATION.md`](documents/AUSTAL/AUSTAL_OPERATION.md).
 
 ## Emission calculation methods
 
+[(Back to top)](#table-of-contents)
+
 Open-ALAQS ships three aircraft emission methods selectable at run time:
 
-- **bymode** — multiplies anchor-mode fuel flow × anchor-mode EI × time × engine
-  count. No ambient corrections. Use as a tautological baseline.
-- **BFFM2 (trajectory)** — default BFFM2 path. For each trajectory segment
-  resolves fuel flow from the segment's sub-mode power setting via the twin-
-  quadratic fit, applies SAE AIR-5715 atmospheric corrections for NOx, and
-  snaps CO/HC to the horizontal mean(CL, TO) value above the APP anchor in the
-  standard-intersection case (CAEP14 v14 rule).
-- **BFFM2 (mode_anchor)** — uses the mode anchor fuel flow (IDLE/APP/CL/TO EEDB
-  values) as the BFFM2 input, still applying ambient corrections. Useful when
-  trajectories lack per-segment sub-mode fidelity.
+- **bymode** — multiplies anchor-mode fuel flow × anchor-mode EI × time × engine count. No ambient corrections. Use as a tautological baseline.
+- **BFFM2 (trajectory)** — default BFFM2 path. For each trajectory segment resolves fuel flow from the segment's sub-mode power setting via the twin-quadratic fit, applies SAE AIR-5715 atmospheric corrections for NOx, and snaps CO/HC to the horizontal mean(CL, TO) value above the APP anchor in the standard-intersection case (CAEP14 v14 rule).
+- **BFFM2 (mode_anchor)** — uses the mode anchor fuel flow (IDLE/APP/CL/TO EEDB values) as the BFFM2 input, still applying ambient corrections. Useful when trajectories lack per-segment sub-mode fidelity.
 
-PM is via MEEM V1 at LTO (EEDB nvPM anchors unchanged at LTO altitudes). The
-MEEM V2 base method (ICAO CAEP/13-WG3) is also implemented for non-LTO
-altitudes. The MDG4 / Staged Combustion update is not implemented.
+PM is via MEEM V1 at LTO (EEDB nvPM anchors unchanged at LTO altitudes). The MEEM V2 base method (ICAO CAEP/13-WG3) is also implemented for non-LTO altitudes. The MDG4 / Staged Combustion update is not implemented.
+
+For BFFM2 implementation details see [`documents/BFFM2_validation/BFFM2.md`](documents/BFFM2_validation/BFFM2.md).
 
 ## Meteorological data
 
-Open-ALAQS expects an hourly meteo CSV during output creation. A standalone
-utility for producing it from a METAR stream ships in `scripts/`:
+[(Back to top)](#table-of-contents)
 
-- `scripts/metar_to_alaqs_meteo.py` — parses METAR observations from stdin or a
-  file, computes relative humidity from T/Td, buckets hourly, writes the
-  ALAQS-schema CSV.
-- `scripts/README_metar_to_alaqs_meteo.md` — usage and notes on where to fetch
-  METAR data (NOAA Aviation Weather Center, ogimet.com, metar-taf.com API,
-  python-metar). Fetching is deliberately left to the user; the script focuses
-  on parsing and resampling.
+Open-ALAQS expects an hourly meteo CSV during output creation. A standalone utility for producing it from a METAR stream ships in `scripts/`:
 
-A migration tool is also provided for upgrading legacy `.alaqs` files to the
-current schema:
+- [`scripts/metar_to_alaqs_meteo.py`](scripts/metar_to_alaqs_meteo.py) — parses METAR observations from stdin or a file, computes relative humidity from T/Td, buckets hourly, writes the ALAQS-schema CSV.
+- [`scripts/README_metar_to_alaqs_meteo.md`](scripts/README_metar_to_alaqs_meteo.md) — usage and notes on where to fetch METAR data (NOAA Aviation Weather Center, ogimet.com, metar-taf.com API, python-metar). Fetching is deliberately left to the user; the script focuses on parsing and resampling.
 
-- `scripts/migrate_alaqs.py` — comparative schema diff against
-  the current blank-study template. Adds missing tables/columns, runs
-  data-preserving renames (e.g. legacy 1D axial profile → 3D Cartesian),
-  reports extras without dropping them by default. Single-transaction with
-  automatic rollback + backup-restore on failure.
+## GSE Application
 
-See `scripts/README.md` for the full inventory.
+[(Back to top)](#table-of-contents)
 
-## Validation state
+A separate companion utility for ground support equipment (GSE) emissions lives in `gse_application/`. Launch with:
 
-The plugin is validated against `CAEP14_FBE_Engines_Emissions_Calculation_Sheet_v14.xlsx`.
-
-- **Cross-platform**: QGIS on Windows and the same pipeline on Linux produce
-  identical grand totals to 4 decimal places across 13 movements × 4 pollutants
-  × 3 methods (156 values, 0.00 % drift).
-- **BFFM2 vs CAEP14 v14**: plugin matches CAEP14 v14 to floating-point
-  precision on all metrics (fuel, CO, HC, NOx, CO2) across Bymode, BFFM2
-  trajectory, and BFFM2 mode_anchor methods. See
-  `CAEP14_v14_validation.xlsx` (delivered alongside the plugin) for the
-  per-movement comparison sheets. Validation covers 2 engines (LEAP-1A26,
-  CF34-8E5), 4 modes (TX/AP/CL/TO), and 3 meteo scenarios (cold-moist,
-  mild-dry, warm-humid), both trajectory and anchor sub-modes.
-- **MEEM V1 at LTO**: non-volatile PM matches EEDB anchors exactly
-  (0.684 / 2.989 / 1.235 / 1.627 mg/kg for 01P20CM128).
-- **Grand totals (AIRPORT_A, 13 movements, engine-only scope)**:
-
-  | method | CO (kg) | HC (kg) | NOx (kg) | fuel (kg) |
-  |---|---|---|---|---|
-  | bymode | 21.97 | 1.234 | 23.49 | 1742.80 |
-  | BFFM2 trajectory | 22.24 | 1.248 | 14.07 | 1544.14 |
-  | BFFM2 anchor | 21.73 | 1.246 | 21.21 | 1744.56 |
-
-  Every column above agrees with the CAEP14 v14 reference to floating-point
-  precision (0.000 % drift). Paired comparison with CAEP14 v14 reference is
-  in `CAEP14_v14_validation.xlsx`.
-
-## Notable corrections in this release
-
-- **Taxi Mach state-leak isolation** — `TaxiingEmissionCalculator.calculate_emissions`
-  now forces `mach_number = 0.0` for taxi operations. The shared
-  `method["config"]` dict was being mutated per flight segment by
-  `FlightEmissionCalculator`, leaking the previous segment's terminal Mach
-  (typically 0.15-0.40) into taxi BFFM2 lookups and producing 0.5-3 %
-  under-prediction on taxi fuel flow. CAEP14 v14 spec says ground operations
-  are M=0.
-- **Climbout installation correction** — `MovementSourceModule` CAEP14 v14
-  installation correction for Climbout corrected from 1.012 to 1.013
-  (agreement with the `bffm2.py` docstring, comment, and default — the 1.012
-  override was a typo).
-- **MES double-count fix** — single-engine taxi main-engine-start emissions
-  are now added exactly once per movement instead of once per taxi segment
-  inside the MES window. Affects movements with `gate_emissions_code=1` AND
-  `set_time_of_main_engine_start_after_block_off_in_s` (or the before-takeoff
-  variant) set AND multi-segment taxi routes.
-- **Gate emissions gating** — `MovementSourceModule` now forwards the movement's
-  `gate_emissions_code` to the gate emissions path, so `code=0` movements no
-  longer leak POLYGON-geometry entries.
-- **Stop-and-Go engine-count** — stop-and-go emissions now multiply by
-  `number_of_engines`, matching the convention used for taxi and queuing time.
-  Affects movements with `number_of_stop_and_gos > 0`; no effect on
-  engine-only validation scope where stops are zeroed out.
-- **CO/HC interpolation alignment with CAEP14 v14** — in the standard
-  SL/HL-intersection case, EI now snaps to the horizontal mean value for any
-  segment fuel flow above the APP anchor (SAE AIR-5715 "HC_CO Slope To Mean
-  Value" rule). The previous implementation smoothed the step by
-  interpolating up to the intersection; that disagreed with v14 by up to 8×
-  EI at warm-humid AP-anchor conditions.
-- **Log-noise suppression** — `OutputModule`, `TableViewWidgetOutputModule`,
-  and `AUSTALOutputModule` no longer log ERROR for zero-valued placeholder
-  emissions synthesised for empty periods. Real missing-geometry bugs still
-  surface.
-- **AUSTAL diagnostic fixes** — `checkTimeIntervalinResults` now logs at
-  ERROR level (was DEBUG) when the series.dmna / austal.txt files disagree,
-  and `checkHoursinResults` warning text and end_date assignment are now
-  consistent at start + 23 h (AUSTAL convention: a day is 24 inclusive
-  timestamps from 01:00..00:00).
-- **Dual-mode BFFM2** — the BFFM2 path accepts a `bffm2_ff_source` config
-  field (`trajectory` default, or `mode_anchor`). Exposed in the Generate
-  Emission Inventory dialog via a dropdown.
-- **UI simplification** — the Create Output dialog's "Advanced Options"
-  group (Method dropdown with "ALAQS" as the sole choice, Towing Speed, and
-  Vertical Limit) has been removed. Method was never routed to any consumer,
-  Towing Speed was written to a dict key no downstream code read, and Vertical
-  Limit wrote to a DB column nothing queried — the actual LTO ceiling is
-  `EmissionCalculatorService.vertical_limit_m = 914.4` m (CAEP standard),
-  hardcoded at the calculation boundary.
-- **Below-MSL airport elevation entry** — `spinBoxAirportElevation` and
-  `spinBoxAirportTemperature` now declare explicit `minimum` properties.
-  Without them, Qt defaulted to 0 and silently clamped any negative value,
-  so picking EHRD (Rotterdam, AIP -5 m) populated the form with 0 m.
-  Below-MSL airports (EHRD, EHAM, LLEY, etc.) and cold-climate annual
-  means now round-trip correctly.
-- **CSV receptor altitude optional** — the receptor CSV loader now accepts a
-  3-column file (id, longitude, latitude) without silently producing an
-  empty GeoDataFrame. Default receptor breathing height (1.5 m) is applied
-  downstream by `AUSTALOutputModule.getGridXYFromReferencePoint`.
-
-- **Runway form simplification** — `max_queue_speed` and `peak_queue_time`
-  columns dropped from `shapes_runways`. Both were dead weight: defined in
-  the schema, the Runway interface getters/setters, and the form widget,
-  but no downstream consumer ever read them (`getQueueSpeed` / `getPeakQueueTime`
-  had zero call sites outside `Runway.py`). The remaining `capacity` and
-  `touchdown` fields are still defined for future use (capacity is real
-  airport metadata; touchdown_offset is needed for proper arrival-emission
-  placement past the threshold).
-- **ADS-B CSV schema simplification** — `track`, `vertical_rate`,
-  `groundspeed`, `nodes`, `taxi` columns dropped from the documented schema.
-  None of them were ever consumed by the validator or importer. The
-  `taxi` column in particular was a soft warning that ground-taxi GPS
-  points should not be in the trajectory CSV (the plugin handles ground
-  emissions via taxiway routes); it is now documented in the validator
-  docstring instead. Required columns: `flight_id, latitude, longitude,
-  altitude, tas`. At least one of: `power_setting, fuel_flow`. Any
-  additional columns in the user's CSV (aircraft_type, registration,
-  squawk, callsign, weather, etc.) are silently ignored — real-world
-  ADS-B exports rarely contain only the required columns.
-- **`thrust` renamed to `power_setting`** — the column the validator and
-  BFFM2 twin-quad fit treats as a 0..1 engine power-setting fraction is
-  now named accordingly. Validator rejects values outside `[0, 1.5]`
-  (rare values up to ~1.05 occur during high-power takeoff segments;
-  anything above is almost certainly a unit error like raw Newtons).
-  Legacy `thrust` column accepted as an alias with a deprecation warning;
-  values from the legacy alias bypass the range check to keep old files
-  loading.
-- **Analysis-window source-list refresh** — picking a different inventory
-  file in the Emissions Inventory Analysis dialog now correctly re-loads
-  the source list. Prior bug: every Source store
-  (`AreaSourcesStore`, `AircraftStore`, `AircraftTrajectoryStore`, etc.)
-  uses the `Singleton` metaclass; `__call__` ignores the `db_path`
-  argument on subsequent constructs and returns the cached instance bound
-  to the FIRST file. The reset only fired during `EmissionCalculation.__init__`
-  at calc time, leaving the source-listing dropdowns stale. Fixed in
-  `result_file_path_changed` by calling `Singleton.reset_all()` and
-  re-binding `ProjectDatabase().path` immediately after path validation.
-- **Emissions legend deduplication** — the QGIS "nox Emissions" /
-  "co Emissions" / etc. layer legends previously showed two zero entries
-  (a gray "0 - 0" from a degenerate Jenks bin and a white "0" from the
-  explicit transparent range). Most grid cells in an emissions raster
-  are exactly zero, so Jenks classification was emitting a "0 - 0"
-  bin that was never stripped before the explicit transparent zero
-  range was added. `setColorGradientRenderer` now deletes any
-  zero-width range from the Jenks output before adding the explicit
-  zero range.
-
-- **Emissions Inventory layer dedup** — switching the BFFM2 fuel-flow
-  source dropdown from "trajectory" to "mode_anchor" and re-running the
-  Add to map action no longer leaves a stale "nox Emissions" / "co
-  Emissions" / etc. layer alongside the new one. Prior code iterated
-  `mapCanvas().layers()` for name-based dedup, which excludes any
-  layer the user has hidden in the legend or that has been removed
-  from the canvas's render set without being deleted from the project.
-  QGIS does not auto-dedup layer names (two layers can coexist with the
-  same name; layers are keyed by id). Now iterates
-  `QgsProject.instance().mapLayers()` so any prior layer with the
-  matching name is removed regardless of canvas state.
-- **Meteo CSV schema drift fixed** — the GUI validator at
-  `OpenAlaqsInventory.examine_met_file` and the loader at
-  `AmbientCondition.initAmbientCondition` previously had two separate
-  copies of the meteo CSV schema dict. An earlier unit fix
-  (`RelativeHumidity(%)` → `(0-1)`, `SeaLevelPressure(mb)` → `(Pa)`)
-  was applied to the loader only, so every CSV satisfying the loader
-  failed the GUI validator with a "Headers of meteo csv file do not
-  match" popup. Schema is now hoisted to a module-level constant
-  `METEO_CSV_HEADERS` in `core/interfaces/AmbientCondition.py` and
-  imported by both consumers. Drift is impossible.
-
-## Test suite
-
+```bash
+python3 gse_application/gse.py
 ```
-cd /path/to/open_alaqs
+
+See [`gse_application/README.md`](gse_application/README.md) for full documentation.
+
+## Development
+
+[(Back to top)](#table-of-contents)
+
+### Code style
+
+Open-ALAQS uses `pre-commit` to enforce code style and basic checks (autoflake, isort, black, flake8). Hooks run on every commit if `pre-commit` is installed in your local clone:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+### Debugging
+
+For debugging the plugin inside QGIS, you can enable QGIS's Python console (Plugins → Python Console) and use standard Python debugging tools.
+
+### Updating the Open-ALAQS database templates
+
+The plugin's `.alaqs` files are cloned from two template databases at `open_alaqs/core/templates/project.alaqs` (the project file users edit in QGIS) and `open_alaqs/core/templates/inventory.alaqs` (the inventory output file produced by Generate Emission Inventory).
+
+Templates are built by `tools/template_build/generate_templates.py` from three inputs:
+
+- `tools/template_build/spatialite_base.alaqs` — the bare SpatiaLite scaffold
+- `tools/template_build/sql/*.sql` — table-creation scripts
+- `open_alaqs/database/data/*.csv` — frozen reference-data CSVs
+
+To regenerate the templates after editing source files:
+
+```bash
+python3 tools/template_build/generate_templates.py
+```
+
+The script needs a working QGIS Python environment; see [`tools/template_build/README.md`](tools/template_build/README.md) for the exact invocation on each platform.
+
+### Unit tests
+
+The full test suite runs offscreen and requires no display:
+
+```bash
 QT_QPA_PLATFORM=offscreen PYTHONPATH=$PWD python3 -m pytest tests/
 ```
 
-Current status: 290 passed, 5 skipped, 0 failed.
+## Validation
+
+[(Back to top)](#table-of-contents)
+
+Open-ALAQS is validated against the CAEP14 v14 reference spreadsheet (`CAEP14_FBE_Engines_Emissions_Calculation_Sheet_v14.xlsx`) to floating-point precision across bymode, BFFM2 trajectory, and BFFM2 mode_anchor methods, with non-volatile PM matching EEDB anchors exactly via MEEM V1 at LTO.
+
+The full validation matrix, per-engine results, and cross-platform agreement evidence are in [`documents/BFFM2_validation/BFFM2.md`](documents/BFFM2_validation/BFFM2.md).
+
+## Recent changes
+
+[(Back to top)](#table-of-contents)
+
+See [`CHANGELOG.md`](CHANGELOG.md) for fixes and behaviour changes in this and previous releases.
+
+## Contribute
+
+[(Back to top)](#table-of-contents)
+
+Contributions are welcome. Please open an issue to discuss substantive changes before submitting a pull request, so the work is aligned with what the project needs. For small fixes (typos, documentation corrections, missing test cases), a direct pull request is fine.
+
+When opening a pull request:
+
+- Run the test suite locally and confirm it passes.
+- Run `pre-commit run --all-files` and confirm all hooks pass.
+- Include a regression test for any behaviour change.
+- Reference the issue number in the PR title or body.
 
 ## License
 
-EUPL-1.2 with EUROCONTROL amendments. See `LICENCE.md` and
-`AMENDMENT_TO_EUPL_license.md`.
+[(Back to top)](#table-of-contents)
+
+This software is published under European Union Public Licence v. 1.2 ([`LICENCE.md`](LICENCE.md)) with certain amendments described in [`AMENDMENT_TO_EUPL_license.md`](AMENDMENT_TO_EUPL_license.md), reflecting EUROCONTROL's status as an international organisation.
+
+## Contact
+
+[(Back to top)](#table-of-contents)
+
+For questions, bug reports, or feature requests, please open an issue on the [GitHub repository](https://github.com/eurocontrol-asu/open_alaqs/issues).


### PR DESCRIPTION
The 5.0.0 rebuild (PR #306) replaced the README with a release-style document focused on workflow, calculation methods, and validation. The previous README served as the user-facing front door (installation, quick start, GSE application, development setup).

This commit:

- Restores the old Installation, Quick start, GSE Application, and Development sections, with paths updated to match the rebuild's directory restructure (tests/data/EHRD/ -> AIRPORT_A, open_alaqs/scripts/ -> top-level scripts/, and template build moved to tools/template_build/).

- Keeps the rebuild's Workflow, Emission calculation methods, and Meteorological data sections, and adds pointers to the existing AUSTAL operation guide and BFFM2 validation document.

- Replaces the long inline "Notable corrections" and "Validation state" sections with brief pointers to CHANGELOG.md and documents/BFFM2_validation/BFFM2.md respectively, keeping the README focused on getting users started.

- Migrates the inline "Notable corrections" entries into the CHANGELOG's [5.0.0] section under ### Fixed and ### Changed, including the five fixes merged via PRs #307-#311 (profile-name aliasing, parking cold start, profile normalisation, instudy filter, ambient/METAR handling).