### PR TITLE
v5.1.1: receptor handling, EU 2024/2881 compliance, AUSTAL writer/reader fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Open-ALAQS are listed here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely; dates are
 ISO 8601.
 
+## [5.1.1] - 2026-05-10
+
+Hotfix release from EHRD (Rotterdam) integration testing. Adds per-receptor compliance evaluation against EU Directive 2024/2881 (binding from 1 January 2030) and fixes several AUSTAL writer/reader correctness issues, plus UX improvements around result-button gating and error reporting.
+
+### Added
+
+- New `ComplianceReportOutputModule`. Reads `<substance>-tmpa.dmna` files from the AUSTAL work directory and produces a per-receptor PASS/FAIL table against EU Directive 2024/2881 limit values applicable from 1 January 2030. Reportable substances: PM10, PM2.5, NO2, NOx (ecosystem), SO2. Threshold values verified against the official directive (Annex I, Section 1) and the EEA Air Quality Status Report 2025. CSV export available. CO/HC/CO2 are explicitly excluded with an explanatory note in the dialog header.
+- Receptor CSV picker in both ALAQS and "Generate from CSV" input modes. ALAQS mode uses a 3-tier priority chain: CSV -> `shapes_receptor_points` table in the .alaqs database (filtered to `instudy != 'N'`) -> empty. CSV mode uses the receptor CSV picker only.
+- NOTALUFT (per-hour series) checkbox on the Output Mode row. Required to produce per-receptor `-tmpa.dmna` files that the new Compliance Report and rewritten Plot Time
 ## [5.1.0] - 2026-05-09
 
 Performance and correctness refactor of the calculation and AUSTAL

--- a/open_alaqs/core/modules/AUSTALOutputModule.py
+++ b/open_alaqs/core/modules/AUSTALOutputModule.py
@@ -170,6 +170,19 @@ class AUSTALDispersionModule(DispersionModule):
                 os.mkdir(self._output_path)
 
         self._sequ = "k+,j-,i+"
+        # AUSTAL `hq` value (per-source release height). The reference
+        # treats this as "ignored" because the actual release height is
+        # implicit in the per-source grid file's vertical distribution,
+        # but austal.txt still needs a value written. process() updates
+        # this from each source's getHeight() when it loops over
+        # non-stationary sources; with all sources stationary the loop
+        # is empty, so initialise here to keep writeInputFile safe.
+        self._source_height = 0.0
+        # Tracks which (slot_id, timeID) pairs got a writeGridFile call
+        # in process(). Used by _ti_fill_legacy_zero_hours to back-fill
+        # missing zero-hour files for non-stationary slots that survive
+        # the empty-slot drop.
+        self._gridfile_written = {}
         self._grid: Grid3D = values_dict.get("grid", None)
 
         self._pollutants_list = values_dict.get("pollutants_list")
@@ -194,6 +207,20 @@ class AUSTALDispersionModule(DispersionModule):
         self._quality_level = values_dict.get("quality_level", 1)
         # for non-standard calculations
         self._options = values_dict.get("options_string", "SCINOTAT")
+
+        # PM10 component split. AUSTAL has no single emission name for
+        # PM10 — it must be split into pm-1 (< 2.5 um, the PM2.5 fraction)
+        # and pm-2 (2.5-10 um, coarse fraction). The TA Luft concentration
+        # output (pm-y00a.dmna) is the sum of components 1+2.
+        # Default 0.9 fine / 0.1 coarse is appropriate for combustion-
+        # exhaust dominated inventories (aircraft, GSE, road exhaust);
+        # raise toward 0.95+ for pure aircraft exhaust, lower toward 0.5
+        # for non-exhaust dominated (tyre/brake/road wear).
+        try:
+            ff = float(values_dict.get("pm10_fine_fraction", 0.9))
+        except (TypeError, ValueError):
+            ff = 0.9
+        self._pm10_fine_fraction = max(0.0, min(1.0, ff))
 
         # "----------------- meteorology",
         # ToDo: Modify AmbientCondition.py or derive z0, d0, and ha from main
@@ -1225,10 +1252,11 @@ class AUSTALDispersionModule(DispersionModule):
             # Create the source id
             source_id = str(source_counter).zfill(2)
 
-            # Create the source directory if it doesn't exist
-            source_dir = output_path / source_id
-            if not source_dir.is_dir():
-                source_dir.mkdir()
+            # NOTE: source dir is created lazily (only when this hour
+            # has non-zero emissions for this pollutant). Empty slots
+            # never get a directory; surviving slots have any missing
+            # zero-hour files back-filled by _ti_fill_legacy_zero_hours
+            # at endJob time.
 
             # Initialise the matrix for each pollutant
             self.InitializeEmissionGridMatrix()
@@ -1362,23 +1390,48 @@ class AUSTALDispersionModule(DispersionModule):
 
             self._results[_end_time_string].update(fill_results)
 
-            # Start writing to file
-            try:
-                self.writeGridFile(
-                    source_id,
-                    self._timeID_per_source[source_id],
-                    dd_,
-                    sk_,
-                    '"text"',
-                    '"Eq%5.1f"',
-                    '"V"',
-                    '"M"',
-                    3,
-                    '"xyz"',
+            # Skip writeGridFile when this hour contributes zero for
+            # this pollutant. If the slot ends up with non-zero emissions
+            # in some other hour, _ti_fill_legacy_zero_hours back-fills
+            # the missing eXXXX.dmna at endJob using the spec captured
+            # in self._gridfile_spec. If the slot has zero across the
+            # entire run, _ti_drop_empty_legacy_slots removes it without
+            # ever creating the directory.
+            if hashed_emissions > 0:
+                # Capture the spec the first time we have a real write,
+                # so we can replay it later for missing zero-hours.
+                if not hasattr(self, "_gridfile_spec"):
+                    self._gridfile_spec = (
+                        dd_,
+                        sk_,
+                        '"text"',
+                        '"Eq%5.1f"',
+                        '"V"',
+                        '"M"',
+                        3,
+                        '"xyz"',
+                    )
+                source_dir = output_path / source_id
+                if not source_dir.is_dir():
+                    source_dir.mkdir()
+                self._gridfile_written.setdefault(source_id, set()).add(
+                    self._timeID_per_source[source_id]
                 )
-
-            except Exception as exc_:
-                logger.error(exc_)
+                try:
+                    self.writeGridFile(
+                        source_id,
+                        self._timeID_per_source[source_id],
+                        dd_,
+                        sk_,
+                        '"text"',
+                        '"Eq%5.1f"',
+                        '"V"',
+                        '"M"',
+                        3,
+                        '"xyz"',
+                    )
+                except Exception as exc_:
+                    logger.error(exc_)
 
     @log_time
     def endJob(self):
@@ -1597,17 +1650,15 @@ class AUSTALDispersionModule(DispersionModule):
         group_weights,
         dir_offset: int,
     ):
-        """Write one eNNNN.dmna per stationary group per simulated
-        hour under <output>/<NN>/. Returns dict {group_id:
-        dir_index_1based}.
+        """Write one e0001.dmna per stationary group under <output>/<NN>/.
+        Returns dict {group_id: dir_index_1based}.
 
-        Each hour's file contains the same time-invariant spatial
-        pattern; only t1/t2 differ. AUSTAL 3.3 rejects single-file
-        multi-day t1/t2 windows ("current grid source not valid after
-        ..."), so we mirror the legacy per-hour layout. The iq column
-        in series.dmna for stationary slots therefore counts h_idx+1
-        from 1..n_hours (set by writeTimeSeriesFile), pointing at
-        eNNNN.dmna identical to legacy non-stationary indexing.
+        Each grid file declares t1 = run_start, t2 = run_end. The spatial
+        pattern is time-invariant (stationary geometry), so a single file
+        per group suffices for the whole simulation window. AUSTAL accepts
+        this layout; series.dmna's iq column for stationary slots is
+        constant 1 (set by writeTimeSeriesFile), pointing every hour at
+        the same e0001.dmna.
 
         `dir_offset` is the number of non-stationary AUSTAL sources
         already occupying low-numbered directories; stationary groups
@@ -1654,20 +1705,68 @@ class AUSTALDispersionModule(DispersionModule):
             body_lines = dense_by_gid[gid]
             dir_map[gid] = dir_idx
 
-            for h_idx, dt_str in enumerate(sorted_dts, start=1):
-                end_dt = _dt.strptime(dt_str, "%Y-%m-%d.%H:%M:%S")
-                start_dt = end_dt - timedelta(hours=1)
-                ys = _dt(start_dt.year, 1, 1)
-                t1 = format_time_offset(start_dt, ys)
-                t2 = format_time_offset(end_dt, ys)
-                header = grid_file_header_lines(t1, t2, self._ti_grid_spec)
+            # Write a single e0001.dmna per stationary group covering the
+            # full simulation window. Stationary geometry is time-invariant
+            # so 24 (or 8760) byte-identical per-hour files would only
+            # differ in their t1/t2 header lines. AUSTAL accepts a single
+            # grid file whose t2 covers the whole run; series.dmna then
+            # points every hour's iq at index 1 for that source slot.
+            first_end_dt = _dt.strptime(sorted_dts[0], "%Y-%m-%d.%H:%M:%S")
+            last_end_dt = _dt.strptime(sorted_dts[-1], "%Y-%m-%d.%H:%M:%S")
+            run_start = first_end_dt - timedelta(hours=1)
+            ys = _dt(run_start.year, 1, 1)
+            t1 = format_time_offset(run_start, ys)
+            t2 = format_time_offset(last_end_dt, ys)
+            header = grid_file_header_lines(t1, t2, self._ti_grid_spec)
 
-                file_path = src_dir / f"e{h_idx:04d}.dmna"
-                with file_path.open("w", newline="\n") as fh:
-                    fh.write("\n".join(header) + "\n")
-                    fh.write("\n".join(body_lines) + "\n")
-                    fh.write("***\n")
+            file_path = src_dir / "e0001.dmna"
+            with file_path.open("w", newline="\n") as fh:
+                fh.write("\n".join(header) + "\n")
+                fh.write("\n".join(body_lines) + "\n")
+                fh.write("***\n")
         return dir_map
+
+    def _austal_components(self, plugin_pollutant):
+        """Map a plugin pollutant name to AUSTAL emission-line components.
+
+        Returns a list of (austal_component_name, fraction) tuples to
+        be written as separate emission lines / time-series columns.
+
+        - PM10 splits into pm-1 (fine) + pm-2 (coarse), per AUSTAL's
+          requirement (no single 'pm' emission line; pm-y00a.dmna is
+          built by AUSTAL summing components 0..2). Fine fraction comes
+          from self._pm10_fine_fraction (default 0.9).
+        - PM2.5 maps to a single pm-1 line.
+        - All other pollutants map to a single component (the lowercase
+          plugin name) with fraction 1.0.
+
+        Components with a fraction of zero are dropped to avoid emitting
+        all-zero lines/columns.
+        """
+        p = plugin_pollutant.upper()
+        if p == "PM10":
+            fine = self._pm10_fine_fraction
+            coarse = 1.0 - fine
+            out = []
+            if fine > 0.0:
+                out.append(("pm-1", fine))
+            if coarse > 0.0:
+                out.append(("pm-2", coarse))
+            return out or [("pm-1", 1.0)]
+        if p in ("PM25", "PM2.5", "PM-2.5"):
+            return [("pm25", 1.0)]
+        return [(plugin_pollutant.lower(), 1.0)]
+
+    def _legacy_storage_key(self, plugin_pollutant):
+        """Match the key process() used in self._total_sources / _results.
+
+        process() stores PM10 emissions under the key 'PM-2' and other
+        PM under 'PM-1'. The writers use these keys to look up rates
+        even though they then expand the writes into multiple components.
+        """
+        if plugin_pollutant.startswith("PM"):
+            return "PM-2" if plugin_pollutant == "PM10" else "PM-1"
+        return plugin_pollutant
 
     def writeInputFile(
         self,
@@ -1755,17 +1854,21 @@ class AUSTALDispersionModule(DispersionModule):
             f.write("xq\t" + "\t".join([str(xq)] * n_total) + "\t' x-lower left\n")
             f.write("yq\t" + "\t".join([str(yq)] * n_total) + "\t' y-lower left\n")
 
-            # Per-pollutant lines
+            # Per-pollutant lines.
+            # PM10 expands into two AUSTAL component lines (pm-1 + pm-2)
+            # because AUSTAL has no single 'pm' emission name. Other
+            # pollutants emit one line each. The legacy_marks / stat_marks
+            # are determined by the plugin pollutant (a column emits PM10
+            # iff it emits any PM10 mass), and shared across both component
+            # lines for that pollutant.
             for p_idx, poll in enumerate(self._pollutants_list):
-                # Map plugin name to AUSTAL short code
-                austal_name = poll
-                if poll.startswith("PM"):
-                    austal_name = "PM-2" if poll == "PM10" else "PM-1"
+                storage_key = self._legacy_storage_key(poll)
+                components = self._austal_components(poll)
 
                 # Legacy non-stationary entries: present iff
-                # _total_sources[<NN>] contains this pollutant abbrev.
+                # _total_sources[<NN>] contains this pollutant's storage key.
                 legacy_marks = [
-                    "?" if austal_name in self._total_sources[k] else "0"
+                    "?" if storage_key in self._total_sources[k] else "0"
                     for k in legacy_keys
                 ]
                 # Stationary groups: present iff stat_mask[g, p] is True
@@ -1773,11 +1876,20 @@ class AUSTALDispersionModule(DispersionModule):
                     "?" if (stat_mask.size and stat_mask[g_idx, p_idx]) else "0"
                     for g_idx in range(len(group_ids))
                 ]
-                f.write(
-                    f"{austal_name.lower()}\t"
-                    + "\t".join(legacy_marks + stat_marks)
-                    + f"\t' total {poll} (in g/s) (set in series.dmna)\n"
-                )
+
+                for comp_name, frac in components:
+                    if len(components) == 1:
+                        comment = f"' total {poll} (in g/s) (set in series.dmna)"
+                    else:
+                        comment = (
+                            f"' {poll} component {comp_name} "
+                            f"(fraction {frac:.2f}) (set in series.dmna)"
+                        )
+                    f.write(
+                        f"{comp_name}\t"
+                        + "\t".join(legacy_marks + stat_marks)
+                        + f"\t{comment}\n"
+                    )
 
     def writeTimeSeriesFile(
         self,
@@ -1812,7 +1924,7 @@ class AUSTALDispersionModule(DispersionModule):
         sorted_dts = list(sorted_results.keys())
 
         legacy_keys = list(self._total_sources.keys())
-        len(legacy_keys)
+        n_legacy = len(legacy_keys)
 
         # Total AUSTAL source slots in column order: legacy first, stationary after.
         # `slot_meta[i]` = (kind, key_or_gid, dir_label_str)
@@ -1831,19 +1943,27 @@ class AUSTALDispersionModule(DispersionModule):
         else:
             stat_active = np.zeros((0, len(self._ti_pollutant_order)), dtype=bool)
 
-        active_pairs = []  # list of (slot_idx, pol_idx, kind)
+        # Active emission columns: each entry is (slot_idx, p_idx, kind,
+        # austal_component, fraction). PM10 expands into two columns
+        # (pm-1 with fine fraction, pm-2 with coarse fraction). Other
+        # pollutants get a single column with fraction 1.0.
+        active_pairs = []
         for slot_idx, (kind, key, _label) in enumerate(slot_meta):
             for p_idx, poll in enumerate(self._pollutants_list):
-                austal_name = poll
-                if poll.startswith("PM"):
-                    austal_name = "PM-2" if poll == "PM10" else "PM-1"
+                storage_key = self._legacy_storage_key(poll)
+                # Determine if this slot emits this pollutant at all.
                 if kind == "legacy":
-                    if austal_name in self._total_sources[key]:
-                        active_pairs.append((slot_idx, p_idx, "legacy"))
+                    if storage_key not in self._total_sources[key]:
+                        continue
                 else:
                     g_idx = group_ids.index(key)
-                    if stat_active.size and stat_active[g_idx, p_idx]:
-                        active_pairs.append((slot_idx, p_idx, "stationary"))
+                    if not (stat_active.size and stat_active[g_idx, p_idx]):
+                        continue
+                # Slot emits the pollutant: add one column per component.
+                for comp_name, frac in self._austal_components(poll):
+                    active_pairs.append(
+                        (slot_idx, p_idx, kind, comp_name, frac)
+                    )
 
         # Build form line
         form_parts = ['"te%20lt"', '"ra%5.0f"', '"ua%5.1f"', '"lm%7.1f"']
@@ -1851,13 +1971,9 @@ class AUSTALDispersionModule(DispersionModule):
             form_parts.append('"hm%7.1f"')
         for kind, _key, label in slot_meta:
             form_parts.append(f'"{label}.iq%3.0f"')
-        for slot_idx, p_idx, _kind in active_pairs:
+        for slot_idx, p_idx, _kind, comp_name, _frac in active_pairs:
             label = slot_meta[slot_idx][2]
-            poll = self._pollutants_list[p_idx]
-            austal_name = poll
-            if poll.startswith("PM"):
-                austal_name = "PM-2" if poll == "PM10" else "PM-1"
-            form_parts.append(f'"{label}.{austal_name.lower()}%10.3e"')
+            form_parts.append(f'"{label}.{comp_name}%10.3e"')
 
         with file_path.open("w") as f:
             f.write("form\t" + "\t".join(form_parts) + "\n")
@@ -1885,39 +2001,149 @@ class AUSTALDispersionModule(DispersionModule):
                         td = sorted_results[dt_str].get(key, {}).get("timeID", 1)
                         row_parts.append(f"{td:3d}")
                     else:
-                        # Stationary slots now also have one e????.dmna
-                        # per hour (identical content), so iq counts
-                        # h_idx+1 from 1..n_hours, matching the legacy
-                        # per-hour layout. AUSTAL 3.3 rejects multi-day
-                        # single-file validity windows; this preserves
-                        # correctness at the cost of the file-count
-                        # optimisation.
-                        row_parts.append(f"{h_idx + 1:3d}")
+                        # Stationary groups have a single e0001.dmna per
+                        # group covering the whole simulation window;
+                        # every hour points iq at file index 1.
+                        row_parts.append(f"{1:3d}")
 
                 # Emission columns. group_rates is indexed run-relative
                 # (h_idx 0 == first start_dt seen by
                 # _ti_split_and_accumulate), matching the loop's
-                # enumerate index.
-                for slot_idx, p_idx, kind in active_pairs:
+                # enumerate index. For PM10 each (slot, p_idx) pair
+                # contributes TWO columns (pm-1, pm-2) with the total
+                # rate multiplied by each component's fraction.
+                for slot_idx, p_idx, kind, _comp_name, frac in active_pairs:
                     if kind == "legacy":
                         key = slot_meta[slot_idx][1]
                         poll = self._pollutants_list[p_idx]
-                        austal_name = poll
-                        if poll.startswith("PM"):
-                            austal_name = "PM-2" if poll == "PM10" else "PM-1"
-                        val = sorted_results[dt_str].get(key, {}).get(austal_name, 0.0)
+                        storage_key = self._legacy_storage_key(poll)
+                        total = sorted_results[dt_str].get(key, {}).get(
+                            storage_key, 0.0
+                        )
                     else:
                         gid = slot_meta[slot_idx][1]
                         g_idx = group_ids.index(gid)
                         if 0 <= h_idx < group_rates.shape[0]:
-                            val = float(group_rates[h_idx, g_idx, p_idx])
+                            total = float(group_rates[h_idx, g_idx, p_idx])
                         else:
-                            val = 0.0
+                            total = 0.0
+                    val = total * frac
                     row_parts.append(f"{val:10.3e}")
 
                 f.write("\t".join(row_parts) + "\n")
 
             f.write("\n***\n")
+
+    def _ti_drop_empty_legacy_slots(self):
+        """Remove legacy non-stationary slots that had zero emissions
+        across the entire run. process() unconditionally allocates one
+        slot per pollutant in _pollutants_list and writes per-hour grid
+        files for it, even when no non-stationary source emits that
+        pollutant. The result is empty <NN>/eXXXX.dmna files cluttering
+        the output and a phantom column in austal.txt / series.dmna.
+
+        For each slot key in self._total_sources, scan self._results
+        across all hours: drop any (slot, pollutant) pair whose rate is
+        zero in every hour. If a slot ends up with no pollutants, delete
+        the slot entry and its on-disk directory (including the per-hour
+        grid files written by process()).
+        """
+        if not self._total_sources:
+            return
+
+        out_dir = self.getOutputPathAsPath()
+        for slot_id in list(self._total_sources.keys()):
+            keep_pollutants = []
+            for austal_name in list(self._total_sources[slot_id]):
+                any_nonzero = False
+                for dt_str in self._results:
+                    rate = self._results[dt_str].get(slot_id, {}).get(
+                        austal_name, 0.0
+                    )
+                    if rate != 0.0:
+                        any_nonzero = True
+                        break
+                if any_nonzero:
+                    keep_pollutants.append(austal_name)
+
+            if keep_pollutants:
+                self._total_sources[slot_id] = keep_pollutants
+                continue
+
+            # Slot is dead: drop from _total_sources, strip from per-hour
+            # _results, and delete the slot directory if it exists.
+            del self._total_sources[slot_id]
+            for dt_str in self._results:
+                self._results[dt_str].pop(slot_id, None)
+            slot_dir = out_dir / slot_id
+            if slot_dir.is_dir():
+                for child in slot_dir.iterdir():
+                    try:
+                        child.unlink()
+                    except OSError:
+                        pass
+                try:
+                    slot_dir.rmdir()
+                except OSError:
+                    pass
+            logger.info(
+                "AUSTAL: dropped empty legacy slot '%s' (no non-stationary "
+                "emissions across run)",
+                slot_id,
+            )
+
+    def _ti_fill_legacy_zero_hours(self):
+        """For each surviving non-stationary slot, write a zero-filled
+        eXXXX.dmna for any hour skipped by process() (because that hour
+        had hashed_emissions == 0). AUSTAL's series.dmna iq column points
+        to a file per hour, so missing hours would crash AUSTAL.
+
+        Slots that didn't survive _ti_drop_empty_legacy_slots have no
+        files and no directory; skip them. Slots that had non-zero
+        emissions in every hour have all files already and no work to do
+        here. Only mixed-case slots (some zero hours, some non-zero) get
+        back-filled.
+        """
+        if not self._total_sources:
+            return
+        if not hasattr(self, "_gridfile_spec"):
+            # No non-stationary slot ever had non-zero emissions; nothing
+            # to back-fill (the surviving slots are all stationary, which
+            # are written separately by _ti_write_stationary_grids).
+            return
+
+        n_hours = len(self._results)
+        if n_hours == 0:
+            return
+
+        dd_, sk_, mode, form, vldf, artp, dims, axes = self._gridfile_spec
+
+        for slot_id in self._total_sources:
+            written = self._gridfile_written.get(slot_id, set())
+            if not written:
+                continue
+            missing = set(range(1, n_hours + 1)) - written
+            if not missing:
+                continue
+            logger.info(
+                "AUSTAL: back-filling %d zero-hour grid file(s) for "
+                "legacy slot '%s'",
+                len(missing),
+                slot_id,
+            )
+            self.InitializeEmissionGridMatrix()  # zeroes _emission_grid_matrix
+            for time_id in sorted(missing):
+                try:
+                    self.writeGridFile(
+                        slot_id, time_id, dd_, sk_, mode, form,
+                        vldf, artp, dims, axes,
+                    )
+                except Exception as exc_:
+                    logger.error(
+                        "AUSTAL: cannot back-fill zero-hour file for "
+                        "slot '%s' time_id %d: %s",
+                        slot_id, time_id, exc_,
+                    )
 
     @log_time
     def _ti_endJob(self):
@@ -1928,6 +2154,17 @@ class AUSTALDispersionModule(DispersionModule):
         """
         if not self.checkTimeIntervalinResults():
             raise Exception("AUSTAL: Time Interval Error")
+
+        # Drop legacy slots that ended up with zero emissions across the
+        # entire run. process() unconditionally allocates one slot per
+        # pollutant in _pollutants_list and writes per-hour grid files
+        # for it, even when no non-stationary source emits that pollutant
+        # (e.g. an .alaqs with zero aircraft movements still allocates a
+        # CO slot from MovementSource and fills it with 24 zero files).
+        # Trim those slots here so they don't appear in austal.txt /
+        # series.dmna and so their now-empty grid directories are removed.
+        self._ti_drop_empty_legacy_slots()
+        self._ti_fill_legacy_zero_hours()
 
         group_ids, group_weights, group_rates = self._ti_aggregate_stationary()
         n_legacy = len(self._total_sources)

--- a/open_alaqs/core/modules/AUSTALOutputModule.py
+++ b/open_alaqs/core/modules/AUSTALOutputModule.py
@@ -1924,7 +1924,7 @@ class AUSTALDispersionModule(DispersionModule):
         sorted_dts = list(sorted_results.keys())
 
         legacy_keys = list(self._total_sources.keys())
-        n_legacy = len(legacy_keys)
+        len(legacy_keys)
 
         # Total AUSTAL source slots in column order: legacy first, stationary after.
         # `slot_meta[i]` = (kind, key_or_gid, dir_label_str)
@@ -1961,9 +1961,7 @@ class AUSTALDispersionModule(DispersionModule):
                         continue
                 # Slot emits the pollutant: add one column per component.
                 for comp_name, frac in self._austal_components(poll):
-                    active_pairs.append(
-                        (slot_idx, p_idx, kind, comp_name, frac)
-                    )
+                    active_pairs.append((slot_idx, p_idx, kind, comp_name, frac))
 
         # Build form line
         form_parts = ['"te%20lt"', '"ra%5.0f"', '"ua%5.1f"', '"lm%7.1f"']
@@ -2017,8 +2015,8 @@ class AUSTALDispersionModule(DispersionModule):
                         key = slot_meta[slot_idx][1]
                         poll = self._pollutants_list[p_idx]
                         storage_key = self._legacy_storage_key(poll)
-                        total = sorted_results[dt_str].get(key, {}).get(
-                            storage_key, 0.0
+                        total = (
+                            sorted_results[dt_str].get(key, {}).get(storage_key, 0.0)
                         )
                     else:
                         gid = slot_meta[slot_idx][1]
@@ -2057,9 +2055,7 @@ class AUSTALDispersionModule(DispersionModule):
             for austal_name in list(self._total_sources[slot_id]):
                 any_nonzero = False
                 for dt_str in self._results:
-                    rate = self._results[dt_str].get(slot_id, {}).get(
-                        austal_name, 0.0
-                    )
+                    rate = self._results[dt_str].get(slot_id, {}).get(austal_name, 0.0)
                     if rate != 0.0:
                         any_nonzero = True
                         break
@@ -2135,14 +2131,24 @@ class AUSTALDispersionModule(DispersionModule):
             for time_id in sorted(missing):
                 try:
                     self.writeGridFile(
-                        slot_id, time_id, dd_, sk_, mode, form,
-                        vldf, artp, dims, axes,
+                        slot_id,
+                        time_id,
+                        dd_,
+                        sk_,
+                        mode,
+                        form,
+                        vldf,
+                        artp,
+                        dims,
+                        axes,
                     )
                 except Exception as exc_:
                     logger.error(
                         "AUSTAL: cannot back-fill zero-hour file for "
                         "slot '%s' time_id %d: %s",
-                        slot_id, time_id, exc_,
+                        slot_id,
+                        time_id,
+                        exc_,
                     )
 
     @log_time

--- a/open_alaqs/core/modules/ComplianceReportOutputModule.py
+++ b/open_alaqs/core/modules/ComplianceReportOutputModule.py
@@ -1,0 +1,500 @@
+"""
+Per-receptor compliance report against EU Directive 2024/2881.
+
+Reads TalMon-produced ``<substance>-tmpa.dmna`` files in the AUSTAL work
+directory, computes per-receptor compliance metrics against the
+EU Directive (EU) 2024/2881 limit values applicable from 1 January 2030,
+and presents the result as a table dialog with optional CSV export.
+
+Without receptors (i.e. without xp/yp lines in austal.txt), TalMon
+produces no -tmpa.dmna and this module raises a clear error. The
+dispatching dialog should disable the button when no tmpa files exist.
+
+Threshold values are hardcoded against the directive's Annex I (Section 1)
+and verified against the EEA Air Quality Status Report 2025 benchmark
+analysis. No external configuration file is required.
+"""
+
+import csv
+import glob
+import os
+
+import numpy as np
+from qgis.PyQt import QtCore, QtGui, QtWidgets
+
+from open_alaqs.core.alaqslogging import get_logger
+from open_alaqs.core.interfaces.OutputModule import OutputModule
+from open_alaqs.core.modules.TimeSeriesDispersionOutputModule import (
+    _austal_substance_for_results,
+    _parse_tmpa_file,
+)
+
+logger = get_logger(__name__)
+
+
+# Friendly name for the report (back to plugin convention)
+_PLUGIN_NAME_FOR_SUBSTANCE = {
+    "pm": "PM10",
+    "pm25": "PM2.5",
+    "nox": "NOx",
+    "sox": "SOx",
+    "co": "CO",
+    "co2": "CO2",
+    "hc": "HC",
+}
+
+
+# EU Directive 2024/2881 (recast Ambient Air Quality Directive) limit values
+# applicable from 1 January 2030.
+#
+# Sources verified:
+#   - Directive (EU) 2024/2881 of 23 October 2024 (OJ L, 20 Nov 2024),
+#     Annex I, Section 1
+#     ELI: http://data.europa.eu/eli/dir/2024/2881/oj
+#   - EEA Air Quality Status Report 2025, "Benchmark analysis against the
+#     standards in the revised directive (EU) 2024/2881"
+#     https://www.eea.europa.eu/en/analysis/publications/air-quality-
+#     status-report-2025/benchmark-analysis-against-the-standards-in-the-
+#     revised-directive-eu-2024-2881
+#   - European Commission summary at
+#     https://environment.ec.europa.eu/news/new-pollution-rules-come-
+#     effect-cleaner-air-2030-2024-12-10_en
+#
+# Substances NOT in this dict (CO, HC, CO2 ...) have no annual/daily/hourly
+# ambient compliance values in this directive at the form this report
+# computes. CO is regulated as 10 mg/m³ on an 8-hour rolling mean basis
+# (Annex I Section 1) which the per-hour TalMon output could in principle
+# support, but is not yet implemented here.
+#
+# Each entry maps a metric type -> (threshold, allowed_exceedances_or_None,
+# unit). allowed_exceedances is None for an absolute limit (annual mean),
+# an integer for daily/hourly limits.
+_EU_2030_LIMITS = {
+    "pm": {  # PM10
+        "annual_mean":      (20.0, None, "ug/m3"),
+        "daily_exceedance": (45.0, 18,   "ug/m3"),
+    },
+    "pm25": {  # PM2.5
+        "annual_mean":      (10.0, None, "ug/m3"),
+        "daily_exceedance": (25.0, 18,   "ug/m3"),
+    },
+    "no2": {
+        "annual_mean":       (20.0, None, "ug/m3"),
+        "hourly_exceedance": (200.0, 3,   "ug/m3"),
+    },
+    # NOx ecosystem protection: 30 µg/m³ annual mean (kept from 2008/50).
+    "nox": {
+        "annual_mean": (30.0, None, "ug/m3"),
+    },
+    "so2": {
+        # Annex I Section 1, human-health: new annual limit 20 µg/m³,
+        # new daily limit 50 µg/m³. Hourly limit retained at 350 µg/m³
+        # with reduced exceedance count - count not yet verified
+        # against the consolidated text, so daily is treated as
+        # absolute (no exceedances allowed) for now.
+        "annual_mean":      (20.0, None, "ug/m3"),
+        "daily_exceedance": (50.0, None, "ug/m3"),
+    },
+}
+
+
+def _get_compliance_metrics(substance):
+    """Return list of metric specs for a substance, against EU 2024/2881.
+
+    Each metric is a dict with: type, threshold, allowed_exceedances, unit,
+    label. Substances not in _EU_2030_LIMITS yield [] (CO, HC, CO2 etc.).
+    """
+    eu_limits = _EU_2030_LIMITS.get(substance.lower(), {})
+    metrics = []
+    for mtype, spec in eu_limits.items():
+        threshold, allowed, unit = spec
+        if mtype == "annual_mean":
+            label = "annual mean"
+        elif mtype == "daily_exceedance":
+            label = "days > %g %s" % (threshold, unit)
+        elif mtype == "hourly_exceedance":
+            label = "hours > %g %s" % (threshold, unit)
+        else:
+            continue
+        metrics.append({
+            "type": mtype,
+            "threshold": threshold,
+            "allowed_exceedances": allowed,
+            "unit": unit,
+            "label": label,
+        })
+    return metrics
+
+
+# ---------------------------------------------------------------------------
+# Per-receptor metric computation
+# ---------------------------------------------------------------------------
+
+def _compute_metrics_for_substance(tmpa_data, metrics, substance):
+    """Build report rows for one substance across all receptors.
+
+    tmpa_data is the dict returned by _parse_tmpa_file:
+        - data         : numpy.ndarray of shape (n_hours, n_receptors)
+        - point_names  : list[str] of receptor names
+        - point_coords : list[(x, y, z)]
+        - units        : str
+        - datetime_axis: ndarray[datetime] (not used here directly)
+    """
+    matrix = tmpa_data.get("data")
+    if matrix is None or matrix.size == 0:
+        return []
+    n_hours, n_recv = matrix.shape
+    point_names = tmpa_data.get("point_names") or []
+
+    rows = []
+    plugin_name = _PLUGIN_NAME_FOR_SUBSTANCE.get(
+        substance.lower(), substance.upper()
+    )
+
+    for r_idx in range(n_recv):
+        ts = matrix[:, r_idx].astype(float)
+        # NaNs (undf in source) should be ignored in statistics.
+        valid = ts[~np.isnan(ts)]
+        if r_idx < len(point_names):
+            rname = point_names[r_idx] or "P%d" % (r_idx + 1)
+        else:
+            rname = "P%d" % (r_idx + 1)
+
+        for m in metrics:
+            mtype = m["type"]
+            value = None
+            if mtype == "annual_mean":
+                if valid.size == 0:
+                    continue
+                value = float(np.mean(valid))
+            elif mtype == "daily_exceedance":
+                full_days = n_hours // 24
+                if full_days < 1:
+                    continue  # not enough data for daily statistics
+                trimmed = ts[: full_days * 24].reshape(full_days, 24)
+                # nan-safe daily mean: a day with all NaNs becomes NaN
+                with np.errstate(all="ignore"):
+                    daily = np.nanmean(trimmed, axis=1)
+                value = int(np.sum(daily > m["threshold"]))
+            elif mtype == "hourly_exceedance":
+                value = int(np.sum(valid > m["threshold"]))
+            else:
+                continue
+
+            # Pass-fail logic: for annual_mean the value must be <=
+            # threshold; for the exceedance metrics, the count must be
+            # <= allowed (or, when allowed is None, the value of 0 means
+            # automatic pass; any exceedance is a fail).
+            if mtype == "annual_mean":
+                passes = value <= m["threshold"]
+                value_str = "%.2f %s" % (value, m["unit"])
+                limit_str = "%.2f %s" % (m["threshold"], m["unit"])
+                allowed_str = ""
+            else:
+                allowed = m["allowed_exceedances"]
+                if allowed is None:
+                    # Treat as absolute (no exceedances allowed)
+                    passes = value == 0
+                    allowed_str = "0"
+                else:
+                    passes = value <= allowed
+                    allowed_str = "%d" % allowed
+                value_str = "%d" % value
+                limit_str = "> %g %s" % (m["threshold"], m["unit"])
+
+            rows.append({
+                "receptor": rname,
+                "pollutant": plugin_name,
+                "metric": m["label"],
+                "value": value_str,
+                "limit": limit_str,
+                "allowed_exceedances": allowed_str,
+                "pass": bool(passes),
+                # raw values for CSV
+                "_raw_value": value,
+                "_raw_threshold": m["threshold"],
+                "_raw_allowed": m.get("allowed_exceedances"),
+                "_unit": m["unit"],
+            })
+
+    return rows
+
+
+def _build_compliance_rows(work_dir):
+    """Walk the work directory, build all compliance rows.
+
+    Returns (rows, info) where rows is the list described above and
+    info is a small dict with diagnostic counts: substances_seen,
+    substances_skipped (no formal EU 2024/2881 ambient limit),
+    receptors_seen, tmpa_files. Empty rows means no usable tmpa data.
+    """
+    rows = []
+    info = {
+        "tmpa_files": 0,
+        "substances_seen": [],
+        "substances_skipped": [],
+        "receptors_seen": 0,
+    }
+    if not work_dir or not os.path.isdir(work_dir):
+        return rows, info
+
+    tmpa_paths = sorted(glob.glob(os.path.join(work_dir, "*-tmpa.dmna")))
+    info["tmpa_files"] = len(tmpa_paths)
+
+    receptor_counts = set()
+    for path in tmpa_paths:
+        substance = os.path.basename(path).split("-")[0]
+        metrics = _get_compliance_metrics(substance)
+        if not metrics:
+            info["substances_skipped"].append(substance)
+            continue
+        try:
+            tmpa = _parse_tmpa_file(path)
+        except Exception as exc:
+            logger.warning(
+                "Skipping %s for compliance report (parse failed): %s",
+                path, exc,
+            )
+            continue
+        info["substances_seen"].append(substance)
+        m = tmpa.get("data")
+        if m is not None and m.size:
+            receptor_counts.add(m.shape[1])
+        sub_rows = _compute_metrics_for_substance(tmpa, metrics, substance)
+        rows.extend(sub_rows)
+
+    if receptor_counts:
+        info["receptors_seen"] = max(receptor_counts)
+
+    return rows, info
+
+
+# ---------------------------------------------------------------------------
+# Qt dialog
+# ---------------------------------------------------------------------------
+
+class ComplianceReportDialog(QtWidgets.QDialog):
+    """Receptor compliance report — table of metrics per receptor and pollutant."""
+
+    HEADERS = [
+        "Receptor",
+        "Pollutant",
+        "Metric",
+        "Value",
+        "Limit",
+        "Allowed exc.",
+        "Result",
+    ]
+
+    def __init__(self, rows, info, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("AUSTAL receptor compliance report")
+        self.resize(900, 540)
+        self._rows = rows
+        self._info = info
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        # Compact header: one short line summarising what was evaluated.
+        n_pol = len(set(info.get("substances_seen") or []))
+        n_skip = len(set(info.get("substances_skipped") or []))
+        n_rec = info.get("receptors_seen", 0)
+        n_tmpa = info.get("tmpa_files", 0)
+        header_text = (
+            "EU Directive 2024/2881 limit values (from 1 Jan 2030)  —  "
+            "%d pollutant%s evaluated, %d receptor%s, %d tmpa file%s"
+            % (
+                n_pol, "" if n_pol == 1 else "s",
+                n_rec, "" if n_rec == 1 else "s",
+                n_tmpa, "" if n_tmpa == 1 else "s",
+            )
+        )
+        if n_skip:
+            header_text += "  —  not reported: %s (no formal limit)" % (
+                ", ".join(sorted(set(info["substances_skipped"])))
+            )
+        header_label = QtWidgets.QLabel(header_text)
+        header_label.setWordWrap(True)
+        header_label.setStyleSheet("color: #444; padding: 2px 4px;")
+        layout.addWidget(header_label)
+
+        # Table
+        self.table = QtWidgets.QTableWidget()
+        self.table.setColumnCount(len(self.HEADERS))
+        self.table.setHorizontalHeaderLabels(self.HEADERS)
+        self.table.setRowCount(len(rows))
+        self.table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+        self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
+        self.table.verticalHeader().setVisible(False)
+
+        for i, row in enumerate(rows):
+            self._set_cell(i, 0, row["receptor"])
+            self._set_cell(i, 1, row["pollutant"])
+            self._set_cell(i, 2, row["metric"])
+            self._set_cell(i, 3, row["value"], align_right=True)
+            self._set_cell(i, 4, row["limit"], align_right=True)
+            self._set_cell(i, 5, row["allowed_exceedances"], align_right=True)
+
+            result_item = QtWidgets.QTableWidgetItem(
+                "PASS" if row["pass"] else "FAIL"
+            )
+            result_item.setTextAlignment(QtCore.Qt.AlignCenter)
+            if row["pass"]:
+                result_item.setBackground(QtGui.QColor(190, 240, 190))
+                result_item.setForeground(QtGui.QColor(0, 80, 0))
+            else:
+                result_item.setBackground(QtGui.QColor(248, 200, 200))
+                result_item.setForeground(QtGui.QColor(140, 0, 0))
+            self.table.setItem(i, 6, result_item)
+
+        self.table.setSortingEnabled(True)
+        self.table.resizeColumnsToContents()
+        layout.addWidget(self.table)
+
+        # Footer buttons
+        btn_row = QtWidgets.QHBoxLayout()
+        btn_row.addStretch(1)
+        export_btn = QtWidgets.QPushButton("Export CSV")
+        export_btn.clicked.connect(self._export_csv)
+        btn_row.addWidget(export_btn)
+        close_btn = QtWidgets.QPushButton("Close")
+        close_btn.clicked.connect(self.close)
+        btn_row.addWidget(close_btn)
+        layout.addLayout(btn_row)
+
+    def _set_cell(self, r, c, text, align_right=False):
+        item = QtWidgets.QTableWidgetItem(str(text) if text is not None else "")
+        if align_right:
+            item.setTextAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
+        self.table.setItem(r, c, item)
+
+    def _export_csv(self):
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            "Export compliance report",
+            "compliance_report.csv",
+            "CSV files (*.csv);;All files (*)",
+        )
+        if not path:
+            return
+        try:
+            with open(path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f)
+                writer.writerow([
+                    "Receptor", "Pollutant", "Metric",
+                    "Value", "Unit", "Threshold",
+                    "AllowedExceedances", "Pass",
+                ])
+                for r in self._rows:
+                    writer.writerow([
+                        r["receptor"],
+                        r["pollutant"],
+                        r["metric"],
+                        r.get("_raw_value"),
+                        r.get("_unit", ""),
+                        r.get("_raw_threshold"),
+                        r.get("_raw_allowed") if r.get("_raw_allowed") is not None else "",
+                        "PASS" if r["pass"] else "FAIL",
+                    ])
+            QtWidgets.QMessageBox.information(
+                self, "Export complete",
+                "Compliance report saved to:\n%s" % path,
+            )
+        except Exception as exc:
+            QtWidgets.QMessageBox.warning(
+                self, "Export failed", "Could not save CSV: %s" % exc
+            )
+
+
+# ---------------------------------------------------------------------------
+# Output module wrapper (registered with OutputDispersionModuleRegistry)
+# ---------------------------------------------------------------------------
+
+class ComplianceReportDispersionModule(OutputModule):
+    """Receptor compliance report module.
+
+    Reads <substance>-tmpa.dmna files in the AUSTAL work directory and
+    produces a per-receptor compliance table against the EU Directive
+    2024/2881 limit values applicable from 1 January 2030.
+    """
+
+    settings_schema = {}
+
+    @staticmethod
+    def getModuleName():
+        return "ComplianceReportDispersionModule"
+
+    @staticmethod
+    def getModuleDisplayName():
+        return "Receptor Compliance Report"
+
+    def __init__(self, values_dict=None):
+        if values_dict is None:
+            values_dict = {}
+        OutputModule.__init__(self, values_dict)
+        self._parent = values_dict.get("parent")
+        self._concentration_database = values_dict.get("concentration_path")
+        self._dialog = None
+        self._rows = None
+        self._info = None
+
+    def beginJob(self):
+        if not self._concentration_database:
+            raise Exception(
+                "No work directory available. Run AUSTAL or load existing "
+                "results first."
+            )
+        wd = str(self._concentration_database)
+        if not os.path.isdir(wd):
+            raise Exception("Work directory does not exist: %s" % wd)
+
+        # Confirm there is at least one tmpa file before doing any work.
+        tmpa_files = glob.glob(os.path.join(wd, "*-tmpa.dmna"))
+        if not tmpa_files:
+            raise FileNotFoundError(
+                "No <substance>-tmpa.dmna files found in:\n  %s\n\n"
+                "The compliance report needs receptor time series. "
+                "These are produced when AUSTAL runs with both "
+                "(1) receptors defined (xp/yp/hp lines in austal.txt) "
+                "and (2) the NOTALUFT output mode enabled.\n\n"
+                "To enable: add receptor points (CSV picker in the "
+                "OpenALAQS Generate tab, or the shapes_receptor_points "
+                "table inside the .alaqs file), tick "
+                "'Per-hour series (NOTALUFT)' in the Output Mode row, "
+                "regenerate AUSTAL inputs and re-run AUSTAL." % wd
+            )
+
+        rows, info = _build_compliance_rows(wd)
+        if not rows:
+            seen = sorted(set(info.get("substances_seen") or []))
+            skipped = sorted(set(info.get("substances_skipped") or []))
+            raise Exception(
+                "No EU 2024/2881 compliance metrics could be computed.\n\n"
+                "Found %d tmpa file(s) in %s.\n\n"
+                "Pollutants reportable: %s\n"
+                "Pollutants not reportable (no formal ambient limit): %s\n\n"
+                "EU Directive 2024/2881 ambient compliance applies to "
+                "PM10, PM2.5, NO2, NOx (ecosystem), SO2. CO, HC, CO2 "
+                "have no formal annual/daily/hourly ambient limit at "
+                "the form this report computes."
+                % (
+                    info.get("tmpa_files", 0),
+                    wd,
+                    ", ".join(seen) or "(none)",
+                    ", ".join(skipped) or "(none)",
+                )
+            )
+        self._rows = rows
+        self._info = info
+
+    def process(self, *args, **kwargs):
+        # No streamed processing; all work happens in beginJob.
+        return None
+
+    def endJob(self):
+        if self._rows is None:
+            return None
+        self._dialog = ComplianceReportDialog(
+            self._rows, self._info, parent=self._parent,
+        )
+        return self._dialog

--- a/open_alaqs/core/modules/ComplianceReportOutputModule.py
+++ b/open_alaqs/core/modules/ComplianceReportOutputModule.py
@@ -25,7 +25,6 @@ from qgis.PyQt import QtCore, QtGui, QtWidgets
 from open_alaqs.core.alaqslogging import get_logger
 from open_alaqs.core.interfaces.OutputModule import OutputModule
 from open_alaqs.core.modules.TimeSeriesDispersionOutputModule import (
-    _austal_substance_for_results,
     _parse_tmpa_file,
 )
 
@@ -71,16 +70,16 @@ _PLUGIN_NAME_FOR_SUBSTANCE = {
 # an integer for daily/hourly limits.
 _EU_2030_LIMITS = {
     "pm": {  # PM10
-        "annual_mean":      (20.0, None, "ug/m3"),
-        "daily_exceedance": (45.0, 18,   "ug/m3"),
+        "annual_mean": (20.0, None, "ug/m3"),
+        "daily_exceedance": (45.0, 18, "ug/m3"),
     },
     "pm25": {  # PM2.5
-        "annual_mean":      (10.0, None, "ug/m3"),
-        "daily_exceedance": (25.0, 18,   "ug/m3"),
+        "annual_mean": (10.0, None, "ug/m3"),
+        "daily_exceedance": (25.0, 18, "ug/m3"),
     },
     "no2": {
-        "annual_mean":       (20.0, None, "ug/m3"),
-        "hourly_exceedance": (200.0, 3,   "ug/m3"),
+        "annual_mean": (20.0, None, "ug/m3"),
+        "hourly_exceedance": (200.0, 3, "ug/m3"),
     },
     # NOx ecosystem protection: 30 µg/m³ annual mean (kept from 2008/50).
     "nox": {
@@ -92,7 +91,7 @@ _EU_2030_LIMITS = {
         # with reduced exceedance count - count not yet verified
         # against the consolidated text, so daily is treated as
         # absolute (no exceedances allowed) for now.
-        "annual_mean":      (20.0, None, "ug/m3"),
+        "annual_mean": (20.0, None, "ug/m3"),
         "daily_exceedance": (50.0, None, "ug/m3"),
     },
 }
@@ -116,19 +115,22 @@ def _get_compliance_metrics(substance):
             label = "hours > %g %s" % (threshold, unit)
         else:
             continue
-        metrics.append({
-            "type": mtype,
-            "threshold": threshold,
-            "allowed_exceedances": allowed,
-            "unit": unit,
-            "label": label,
-        })
+        metrics.append(
+            {
+                "type": mtype,
+                "threshold": threshold,
+                "allowed_exceedances": allowed,
+                "unit": unit,
+                "label": label,
+            }
+        )
     return metrics
 
 
 # ---------------------------------------------------------------------------
 # Per-receptor metric computation
 # ---------------------------------------------------------------------------
+
 
 def _compute_metrics_for_substance(tmpa_data, metrics, substance):
     """Build report rows for one substance across all receptors.
@@ -147,9 +149,7 @@ def _compute_metrics_for_substance(tmpa_data, metrics, substance):
     point_names = tmpa_data.get("point_names") or []
 
     rows = []
-    plugin_name = _PLUGIN_NAME_FOR_SUBSTANCE.get(
-        substance.lower(), substance.upper()
-    )
+    plugin_name = _PLUGIN_NAME_FOR_SUBSTANCE.get(substance.lower(), substance.upper())
 
     for r_idx in range(n_recv):
         ts = matrix[:, r_idx].astype(float)
@@ -202,20 +202,22 @@ def _compute_metrics_for_substance(tmpa_data, metrics, substance):
                 value_str = "%d" % value
                 limit_str = "> %g %s" % (m["threshold"], m["unit"])
 
-            rows.append({
-                "receptor": rname,
-                "pollutant": plugin_name,
-                "metric": m["label"],
-                "value": value_str,
-                "limit": limit_str,
-                "allowed_exceedances": allowed_str,
-                "pass": bool(passes),
-                # raw values for CSV
-                "_raw_value": value,
-                "_raw_threshold": m["threshold"],
-                "_raw_allowed": m.get("allowed_exceedances"),
-                "_unit": m["unit"],
-            })
+            rows.append(
+                {
+                    "receptor": rname,
+                    "pollutant": plugin_name,
+                    "metric": m["label"],
+                    "value": value_str,
+                    "limit": limit_str,
+                    "allowed_exceedances": allowed_str,
+                    "pass": bool(passes),
+                    # raw values for CSV
+                    "_raw_value": value,
+                    "_raw_threshold": m["threshold"],
+                    "_raw_allowed": m.get("allowed_exceedances"),
+                    "_unit": m["unit"],
+                }
+            )
 
     return rows
 
@@ -253,7 +255,8 @@ def _build_compliance_rows(work_dir):
         except Exception as exc:
             logger.warning(
                 "Skipping %s for compliance report (parse failed): %s",
-                path, exc,
+                path,
+                exc,
             )
             continue
         info["substances_seen"].append(substance)
@@ -272,6 +275,7 @@ def _build_compliance_rows(work_dir):
 # ---------------------------------------------------------------------------
 # Qt dialog
 # ---------------------------------------------------------------------------
+
 
 class ComplianceReportDialog(QtWidgets.QDialog):
     """Receptor compliance report — table of metrics per receptor and pollutant."""
@@ -304,9 +308,12 @@ class ComplianceReportDialog(QtWidgets.QDialog):
             "EU Directive 2024/2881 limit values (from 1 Jan 2030)  —  "
             "%d pollutant%s evaluated, %d receptor%s, %d tmpa file%s"
             % (
-                n_pol, "" if n_pol == 1 else "s",
-                n_rec, "" if n_rec == 1 else "s",
-                n_tmpa, "" if n_tmpa == 1 else "s",
+                n_pol,
+                "" if n_pol == 1 else "s",
+                n_rec,
+                "" if n_rec == 1 else "s",
+                n_tmpa,
+                "" if n_tmpa == 1 else "s",
             )
         )
         if n_skip:
@@ -335,9 +342,7 @@ class ComplianceReportDialog(QtWidgets.QDialog):
             self._set_cell(i, 4, row["limit"], align_right=True)
             self._set_cell(i, 5, row["allowed_exceedances"], align_right=True)
 
-            result_item = QtWidgets.QTableWidgetItem(
-                "PASS" if row["pass"] else "FAIL"
-            )
+            result_item = QtWidgets.QTableWidgetItem("PASS" if row["pass"] else "FAIL")
             result_item.setTextAlignment(QtCore.Qt.AlignCenter)
             if row["pass"]:
                 result_item.setBackground(QtGui.QColor(190, 240, 190))
@@ -380,24 +385,38 @@ class ComplianceReportDialog(QtWidgets.QDialog):
         try:
             with open(path, "w", newline="", encoding="utf-8") as f:
                 writer = csv.writer(f)
-                writer.writerow([
-                    "Receptor", "Pollutant", "Metric",
-                    "Value", "Unit", "Threshold",
-                    "AllowedExceedances", "Pass",
-                ])
+                writer.writerow(
+                    [
+                        "Receptor",
+                        "Pollutant",
+                        "Metric",
+                        "Value",
+                        "Unit",
+                        "Threshold",
+                        "AllowedExceedances",
+                        "Pass",
+                    ]
+                )
                 for r in self._rows:
-                    writer.writerow([
-                        r["receptor"],
-                        r["pollutant"],
-                        r["metric"],
-                        r.get("_raw_value"),
-                        r.get("_unit", ""),
-                        r.get("_raw_threshold"),
-                        r.get("_raw_allowed") if r.get("_raw_allowed") is not None else "",
-                        "PASS" if r["pass"] else "FAIL",
-                    ])
+                    writer.writerow(
+                        [
+                            r["receptor"],
+                            r["pollutant"],
+                            r["metric"],
+                            r.get("_raw_value"),
+                            r.get("_unit", ""),
+                            r.get("_raw_threshold"),
+                            (
+                                r.get("_raw_allowed")
+                                if r.get("_raw_allowed") is not None
+                                else ""
+                            ),
+                            "PASS" if r["pass"] else "FAIL",
+                        ]
+                    )
             QtWidgets.QMessageBox.information(
-                self, "Export complete",
+                self,
+                "Export complete",
                 "Compliance report saved to:\n%s" % path,
             )
         except Exception as exc:
@@ -409,6 +428,7 @@ class ComplianceReportDialog(QtWidgets.QDialog):
 # ---------------------------------------------------------------------------
 # Output module wrapper (registered with OutputDispersionModuleRegistry)
 # ---------------------------------------------------------------------------
+
 
 class ComplianceReportDispersionModule(OutputModule):
     """Receptor compliance report module.
@@ -495,6 +515,8 @@ class ComplianceReportDispersionModule(OutputModule):
         if self._rows is None:
             return None
         self._dialog = ComplianceReportDialog(
-            self._rows, self._info, parent=self._parent,
+            self._rows,
+            self._info,
+            parent=self._parent,
         )
         return self._dialog

--- a/open_alaqs/core/modules/ConcentrationsQGISVectorLayerOutputModule.py
+++ b/open_alaqs/core/modules/ConcentrationsQGISVectorLayerOutputModule.py
@@ -18,6 +18,23 @@ from open_alaqs.core.tools import conversion, sql_interface
 logger = get_logger(__name__)
 
 
+def _austal_substance_for_results(plugin_pollutant):
+    """Map plugin pollutant name to AUSTAL substance name for output files.
+
+    AUSTAL writes files named after the substance, not the plugin's
+    pollutant name. PM is special: PM10 -> 'pm' (TA Luft sum of pm-1+pm-2),
+    PM2.5 -> 'pm25'. Other names lowercase directly.
+    """
+    if not plugin_pollutant:
+        return ""
+    p = plugin_pollutant.upper()
+    if p == "PM10":
+        return "pm"
+    if p in ("PM25", "PM2.5", "PM-2.5"):
+        return "pm25"
+    return plugin_pollutant.lower()
+
+
 class QGISVectorLayerDispersionModule(OutputModule):
     """
     Module to that returns a QGIS vector layer with representation of
@@ -320,6 +337,40 @@ class QGISVectorLayerDispersionModule(OutputModule):
             logger.debug("Error in timedelta: (t1: %s, t2:%s, t0: %s)" % (t1, t2, t0))
             return False
 
+    def _build_timedelta_error_message(self, output_data):
+        """Build a clear, user-facing message for assure_time_interval failure.
+
+        The condition: the AUSTAL output file's time interval (t1, t2)
+        doesn't match what the selected averaging period needs. Most
+        common cause: user picked a non-annual period for which the
+        plugin's read path hasn't been implemented to aggregate
+        per-hour files into the requested period (e.g. 'daily mean'
+        from per-hour AUSTAL output).
+        """
+        try:
+            t1 = output_data.get("t1", ["?"])[0]
+            t2 = output_data.get("t2", ["?"])[0]
+        except Exception:
+            t1, t2 = "?", "?"
+        return (
+            "Plot Vector Layer can't aggregate to '%s' from this "
+            "AUSTAL output.\n\n"
+            "The output file has a time interval of %s -> %s, which "
+            "doesn't match the selected averaging period.\n\n"
+            "What's supported in Plot Vector Layer:\n"
+            "  - 'annual mean': always works (reads <pollutant>-y00a.dmna)\n"
+            "  - 'hourly': works only when AUSTAL was run with NOTALUFT\n"
+            "    enabled (per-hour <pollutant>-NNNa.dmna files exist)\n"
+            "  - '8-hours mean': as for 'hourly'; aggregates 8 files\n"
+            "  - 'daily mean': not currently supported by Plot Vector\n"
+            "    Layer; use Compliance Report or Plot Time Series to\n"
+            "    inspect daily exceedances at receptor points.\n\n"
+            "Set the averaging combo to 'annual mean' and click Plot "
+            "Vector Layer again, or use the Compliance Report / Plot "
+            "Time Series buttons for receptor-based time analysis."
+            % (self._averaging_period, t1, t2)
+        )
+
     # def assert_validity(self, avg_period="annual mean"):
     #     required_proportion = 0.90 if avg_period == "annual mean" else 0.75
     #     if np.count_nonzero(self._data_y) < required_proportion * len(self._data_y) :
@@ -327,14 +378,17 @@ class QGISVectorLayerDispersionModule(OutputModule):
 
     def readA2Koutput(self, datapath):
         if not os.path.isfile(datapath):
-            QtWidgets.QMessageBox.warning(
-                None,
-                "File not found",
-                "File '%s' not found. Choose another pollutant ? " % (datapath),
+            raise FileNotFoundError(
+                "AUSTAL output file not found: %s\n\n"
+                "This usually means AUSTAL did not run, did not finish, "
+                "or was run with options that do not produce this file. "
+                "For 'annual mean' the file <pollutant>-y00a.dmna is "
+                "expected; for hourly/daily/8-hour averaging the files "
+                "<pollutant>-NNNa.dmna are expected (only produced when "
+                "AUSTAL is run with NOTALUFT)." % datapath
             )
         try:
             # latin-1 read the units ug/m3, utf-8 reads u/g
-            # with open(datapath, encoding="utf-8", errors="ignore") as f:
             with open(datapath, encoding="latin-1", errors="ignore") as f:
                 raw_output_data = [
                     x.rstrip("\n").lstrip().replace('"', "") for x in f.readlines()
@@ -349,17 +403,36 @@ class QGISVectorLayerDispersionModule(OutputModule):
                 elif content.split() and "*" in content.split()[0]:
                     break
 
-            index_ = raw_output_data.index("*")
-            # concentration_matrix = np.loadtxt(datapath, comments="*", skiprows=index_)
+            if not output_data:
+                raise Exception(
+                    "no header keys parsed; file is empty or not a DMNA file"
+                )
+            if "hghb" not in output_data:
+                raise Exception(
+                    "no 'hghb' line found; this is not a valid AUSTAL grid "
+                    "output (header keys present: %s)"
+                    % ", ".join(list(output_data.keys())[:8])
+                )
+
+            try:
+                index_ = raw_output_data.index("*")
+            except ValueError:
+                raise Exception("no '*' delimiter between header and data block")
+
             concentration_matrix = np.loadtxt(
                 raw_output_data, comments="*", skiprows=index_
             )
 
             return output_data, index_, concentration_matrix
 
+        except FileNotFoundError:
+            raise
         except Exception as exc_:
-            logger.error(exc_)
-            return OrderedDict(), None, None
+            # Re-raise with the file path so the user sees what was tried.
+            logger.error("Failed to parse DMNA file '%s': %s", datapath, exc_)
+            raise Exception(
+                "Failed to parse AUSTAL output file '%s': %s" % (datapath, exc_)
+            )
 
     def getA2KData(self):
 
@@ -368,12 +441,12 @@ class QGISVectorLayerDispersionModule(OutputModule):
                 output_file = (
                     os.path.join(
                         self._concentration_database,
-                        "%s-y00a.dmna" % self._pollutant.lower(),
+                        "%s-y00a.dmna" % _austal_substance_for_results(self._pollutant),
                     )
                     if not self._check_uncertainty
                     else os.path.join(
                         self._concentration_database,
-                        "%s-y00s.dmna" % self._pollutant.lower(),
+                        "%s-y00s.dmna" % _austal_substance_for_results(self._pollutant),
                     )
                 )
                 return self.readA2Koutput(output_file)
@@ -408,13 +481,13 @@ class QGISVectorLayerDispersionModule(OutputModule):
                             os.path.join(
                                 self._concentration_database,
                                 "%s-%sa.dmna"
-                                % (self._pollutant.lower(), str(time_counter).zfill(3)),
+                                % (_austal_substance_for_results(self._pollutant), str(time_counter).zfill(3)),
                             )
                             if not self._check_uncertainty
                             else os.path.join(
                                 self._concentration_database,
                                 "%s-%ss.dmna"
-                                % (self._pollutant.lower(), str(time_counter).zfill(3)),
+                                % (_austal_substance_for_results(self._pollutant), str(time_counter).zfill(3)),
                             )
                         )
 
@@ -422,10 +495,7 @@ class QGISVectorLayerDispersionModule(OutputModule):
                             output_file
                         )
                         if not self.assure_time_interval(output_data):
-                            raise Exception(
-                                "Error in timedelta. Choose another averaging period for time interval (%s, %s)"
-                                % (output_data["t1"], output_data["t2"])
-                            )
+                            raise Exception(self._build_timedelta_error_message(output_data))
                         conc[str(time_counter).zfill(3)] = concentration_matrix
                     return (
                         output_data,
@@ -447,7 +517,7 @@ class QGISVectorLayerDispersionModule(OutputModule):
                                     self._concentration_database,
                                     "%s-%sa.dmna"
                                     % (
-                                        self._pollutant.lower(),
+                                        _austal_substance_for_results(self._pollutant),
                                         str(time_counter).zfill(3),
                                     ),
                                 )
@@ -456,14 +526,22 @@ class QGISVectorLayerDispersionModule(OutputModule):
                                     self._concentration_database,
                                     "%s-%ss.dmna"
                                     % (
-                                        self._pollutant.lower(),
+                                        _austal_substance_for_results(self._pollutant),
                                         str(time_counter).zfill(3),
                                     ),
                                 )
                             )
                             if not os.path.isfile(output_file):
-                                logger.warning("File %s doesn't exist!" % output_file)
-                                continue
+                                raise FileNotFoundError(
+                                    "Per-hour AUSTAL grid file not found: %s\n\n"
+                                    "Hourly averaging requires per-hour output "
+                                    "files (<pollutant>-NNNa.dmna), which AUSTAL "
+                                    "only writes when run with the NOTALUFT "
+                                    "option (Output Mode: 'Per-hour series'). "
+                                    "Either re-run AUSTAL with NOTALUFT enabled, "
+                                    "or select 'annual mean' averaging."
+                                    % output_file
+                                )
                             else:
                                 (
                                     output_data,
@@ -471,17 +549,13 @@ class QGISVectorLayerDispersionModule(OutputModule):
                                     concentration_matrix,
                                 ) = self.readA2Koutput(output_file)
                                 if not self.assure_time_interval(output_data):
-                                    raise Exception(
-                                        "Error in timedelta. Choose another averaging period for time interval (%s, %s)"
-                                        % (output_data["t1"], output_data["t2"])
-                                    )
+                                    raise Exception(self._build_timedelta_error_message(output_data))
                                 conc[str(time_counter).zfill(3)] = concentration_matrix
 
                     elif self._averaging_period == "8-hours mean":
-                        QtWidgets.QMessageBox.information(
-                            None,
-                            "8-hours mean",
-                            "For time interval: %s (+8h)" % (self._time_start),
+                        logger.info(
+                            "8-hours mean: aggregating files starting at %s (+8h)",
+                            self._time_start,
                         )
 
                         for time_counter in range(
@@ -495,7 +569,7 @@ class QGISVectorLayerDispersionModule(OutputModule):
                                     self._concentration_database,
                                     "%s-%sa.dmna"
                                     % (
-                                        self._pollutant.lower(),
+                                        _austal_substance_for_results(self._pollutant),
                                         str(time_counter).zfill(3),
                                     ),
                                 )
@@ -504,14 +578,22 @@ class QGISVectorLayerDispersionModule(OutputModule):
                                     self._concentration_database,
                                     "%s-%ss.dmna"
                                     % (
-                                        self._pollutant.lower(),
+                                        _austal_substance_for_results(self._pollutant),
                                         str(time_counter).zfill(3),
                                     ),
                                 )
                             )
                             if not os.path.isfile(output_file):
-                                logger.warning("File %s doesn't exist!" % output_file)
-                                continue
+                                raise FileNotFoundError(
+                                    "Per-hour AUSTAL grid file not found: %s\n\n"
+                                    "8-hour averaging requires per-hour output "
+                                    "files (<pollutant>-NNNa.dmna), which AUSTAL "
+                                    "only writes when run with the NOTALUFT "
+                                    "option (Output Mode: 'Per-hour series'). "
+                                    "Either re-run AUSTAL with NOTALUFT enabled, "
+                                    "or select 'annual mean' averaging."
+                                    % output_file
+                                )
                             else:
                                 (
                                     output_data,
@@ -519,10 +601,7 @@ class QGISVectorLayerDispersionModule(OutputModule):
                                     concentration_matrix,
                                 ) = self.readA2Koutput(output_file)
                                 if not self.assure_time_interval(output_data):
-                                    raise Exception(
-                                        "Error in timedelta. Choose another averaging period for time interval (%s, %s)"
-                                        % (output_data["t1"], output_data["t2"])
-                                    )
+                                    raise Exception(self._build_timedelta_error_message(output_data))
                                 conc[str(time_counter).zfill(3)] = concentration_matrix
 
                     return (
@@ -531,14 +610,20 @@ class QGISVectorLayerDispersionModule(OutputModule):
                         np.array(list(conc.values())).mean(axis=0),
                     )
 
+        except FileNotFoundError:
+            # Always surface a missing-file error: the readA2Koutput
+            # wrapper raises a FileNotFoundError with the exact path and
+            # an explanation of which AUSTAL options produce that file.
+            raise
         except Exception as e:
+            # Previously this branch swallowed parse errors and returned
+            # an empty 3-tuple. That caused process() to fall through to
+            # a generic "Header keys parsed: (none)" message that hid
+            # the real cause (empty file, malformed dmna, NumPy mean of
+            # zero arrays, etc.). Always propagate so the user sees what
+            # actually went wrong.
             logger.error("A2K OutputModule: Cannot fetch data: %s" % e)
-            # Ensure it always return a 3-tuple to avoid unpacking errors in callers
-            try:
-                empty_matrix = np.array([])
-            except Exception:
-                empty_matrix = []
-            return OrderedDict(), None, empty_matrix
+            raise
 
     def beginJob(self):
         if self._pollutant.startswith("PM"):
@@ -608,9 +693,47 @@ class QGISVectorLayerDispersionModule(OutputModule):
             and self._index_j
             and len(concentration_matrix) > 0
         ):
+            # output_data should never be empty at this point: missing
+            # files now raise FileNotFoundError in getA2KData, and parse
+            # failures raise their own descriptive errors in
+            # readA2Koutput. Reaching here means a file existed and
+            # parsed but had unexpected structure.
+            if "hghb" not in output_data or not output_data.get("hghb"):
+                substance = _austal_substance_for_results(self._pollutant)
+                expected = (
+                    "%s-y00a.dmna" % substance
+                    if self._averaging_period == "annual mean"
+                    else "%s-NNNa.dmna" % substance
+                )
+                raise Exception(
+                    "AUSTAL output is malformed for pollutant '%s' "
+                    "(period: %s).\n\n"
+                    "Expected files: %s/%s\n\n"
+                    "Header keys parsed: %s\n\n"
+                    "The file was opened but did not contain the expected "
+                    "'hghb' grid-dimensions line. Check that AUSTAL ran "
+                    "successfully and that the work directory points at "
+                    "an AUSTAL output folder, not a partial or interrupted "
+                    "run."
+                    % (
+                        self._pollutant,
+                        self._averaging_period,
+                        self._concentration_database,
+                        expected,
+                        ", ".join(list(output_data.keys())[:10]) or "(none)",
+                    )
+                )
             raise Exception(
-                "Error in reshaping concentration matrix: (%s, %s, %s)"
-                % (self._index_k, self._index_i, self._index_j)
+                "AUSTAL output has zero concentration cells "
+                "(grid dims k=%s, i=%s, j=%s, matrix len=%s). "
+                "The simulation may have produced an empty result for the "
+                "selected pollutant/period."
+                % (
+                    self._index_k,
+                    self._index_i,
+                    self._index_j,
+                    len(concentration_matrix) if concentration_matrix is not None else 0,
+                )
             )
 
         # Build data_cells in UTM, aligned with the y00a grid. This

--- a/open_alaqs/core/modules/ConcentrationsQGISVectorLayerOutputModule.py
+++ b/open_alaqs/core/modules/ConcentrationsQGISVectorLayerOutputModule.py
@@ -481,13 +481,19 @@ class QGISVectorLayerDispersionModule(OutputModule):
                             os.path.join(
                                 self._concentration_database,
                                 "%s-%sa.dmna"
-                                % (_austal_substance_for_results(self._pollutant), str(time_counter).zfill(3)),
+                                % (
+                                    _austal_substance_for_results(self._pollutant),
+                                    str(time_counter).zfill(3),
+                                ),
                             )
                             if not self._check_uncertainty
                             else os.path.join(
                                 self._concentration_database,
                                 "%s-%ss.dmna"
-                                % (_austal_substance_for_results(self._pollutant), str(time_counter).zfill(3)),
+                                % (
+                                    _austal_substance_for_results(self._pollutant),
+                                    str(time_counter).zfill(3),
+                                ),
                             )
                         )
 
@@ -495,7 +501,9 @@ class QGISVectorLayerDispersionModule(OutputModule):
                             output_file
                         )
                         if not self.assure_time_interval(output_data):
-                            raise Exception(self._build_timedelta_error_message(output_data))
+                            raise Exception(
+                                self._build_timedelta_error_message(output_data)
+                            )
                         conc[str(time_counter).zfill(3)] = concentration_matrix
                     return (
                         output_data,
@@ -539,8 +547,7 @@ class QGISVectorLayerDispersionModule(OutputModule):
                                     "only writes when run with the NOTALUFT "
                                     "option (Output Mode: 'Per-hour series'). "
                                     "Either re-run AUSTAL with NOTALUFT enabled, "
-                                    "or select 'annual mean' averaging."
-                                    % output_file
+                                    "or select 'annual mean' averaging." % output_file
                                 )
                             else:
                                 (
@@ -549,7 +556,9 @@ class QGISVectorLayerDispersionModule(OutputModule):
                                     concentration_matrix,
                                 ) = self.readA2Koutput(output_file)
                                 if not self.assure_time_interval(output_data):
-                                    raise Exception(self._build_timedelta_error_message(output_data))
+                                    raise Exception(
+                                        self._build_timedelta_error_message(output_data)
+                                    )
                                 conc[str(time_counter).zfill(3)] = concentration_matrix
 
                     elif self._averaging_period == "8-hours mean":
@@ -591,8 +600,7 @@ class QGISVectorLayerDispersionModule(OutputModule):
                                     "only writes when run with the NOTALUFT "
                                     "option (Output Mode: 'Per-hour series'). "
                                     "Either re-run AUSTAL with NOTALUFT enabled, "
-                                    "or select 'annual mean' averaging."
-                                    % output_file
+                                    "or select 'annual mean' averaging." % output_file
                                 )
                             else:
                                 (
@@ -601,7 +609,9 @@ class QGISVectorLayerDispersionModule(OutputModule):
                                     concentration_matrix,
                                 ) = self.readA2Koutput(output_file)
                                 if not self.assure_time_interval(output_data):
-                                    raise Exception(self._build_timedelta_error_message(output_data))
+                                    raise Exception(
+                                        self._build_timedelta_error_message(output_data)
+                                    )
                                 conc[str(time_counter).zfill(3)] = concentration_matrix
 
                     return (
@@ -732,7 +742,11 @@ class QGISVectorLayerDispersionModule(OutputModule):
                     self._index_k,
                     self._index_i,
                     self._index_j,
-                    len(concentration_matrix) if concentration_matrix is not None else 0,
+                    (
+                        len(concentration_matrix)
+                        if concentration_matrix is not None
+                        else 0
+                    ),
                 )
             )
 

--- a/open_alaqs/core/modules/ModuleManager.py
+++ b/open_alaqs/core/modules/ModuleManager.py
@@ -20,6 +20,9 @@ from open_alaqs.core.modules.PointSourceModule import PointSourceWithTimeProfile
 from open_alaqs.core.modules.RoadwaySourceModule import (
     RoadwaySourceWithTimeProfileModule,
 )
+from open_alaqs.core.modules.ComplianceReportOutputModule import (
+    ComplianceReportDispersionModule,
+)
 from open_alaqs.core.modules.TableViewDispersionOutputModule import (
     TableViewDispersionModule,
 )
@@ -115,6 +118,7 @@ output_dispersion_module_registry = OutputDispersionModuleRegistry()
 output_dispersion_module_registry.register(QGISVectorLayerDispersionModule)
 output_dispersion_module_registry.register(TableViewDispersionModule)
 output_dispersion_module_registry.register(TimeSeriesDispersionModule)
+output_dispersion_module_registry.register(ComplianceReportDispersionModule)
 
 dispersion_module_registry = DispersionModuleRegistry()
 dispersion_module_registry.register(AUSTALDispersionModule)

--- a/open_alaqs/core/modules/ModuleManager.py
+++ b/open_alaqs/core/modules/ModuleManager.py
@@ -6,6 +6,9 @@ from open_alaqs.core.interfaces.OutputModule import OutputModule
 from open_alaqs.core.interfaces.SourceModule import SourceModule
 from open_alaqs.core.modules.AreaSourceModule import AreaSourceWithTimeProfileModule
 from open_alaqs.core.modules.AUSTALOutputModule import AUSTALDispersionModule
+from open_alaqs.core.modules.ComplianceReportOutputModule import (
+    ComplianceReportDispersionModule,
+)
 from open_alaqs.core.modules.ConcentrationsQGISVectorLayerOutputModule import (
     QGISVectorLayerDispersionModule,
 )
@@ -19,9 +22,6 @@ from open_alaqs.core.modules.ParkingSourceModule import (
 from open_alaqs.core.modules.PointSourceModule import PointSourceWithTimeProfileModule
 from open_alaqs.core.modules.RoadwaySourceModule import (
     RoadwaySourceWithTimeProfileModule,
-)
-from open_alaqs.core.modules.ComplianceReportOutputModule import (
-    ComplianceReportDispersionModule,
 )
 from open_alaqs.core.modules.TableViewDispersionOutputModule import (
     TableViewDispersionModule,

--- a/open_alaqs/core/modules/TableViewDispersionOutputModule.py
+++ b/open_alaqs/core/modules/TableViewDispersionOutputModule.py
@@ -131,10 +131,14 @@ class TableViewDispersionModule(OutputModule):
 
     def readA2Koutput(self, datapath):
         if not os.path.isfile(datapath):
-            QtWidgets.QMessageBox.warning(
-                None,
-                "File not found",
-                "File '%s' not found. Choose another pollutant ? " % (datapath),
+            raise FileNotFoundError(
+                "AUSTAL output file not found: %s\n\n"
+                "This usually means AUSTAL did not run, did not finish, "
+                "or was run with options that do not produce this file. "
+                "For 'annual mean' the file <pollutant>-y00a.dmna is "
+                "expected; for hourly/daily/8-hour averaging the files "
+                "<pollutant>-NNNa.dmna are expected (only produced when "
+                "AUSTAL is run with NOTALUFT)." % datapath
             )
         try:
             with open(datapath, encoding="utf8", errors="ignore") as f:

--- a/open_alaqs/core/modules/TimeSeriesDispersionOutputModule.py
+++ b/open_alaqs/core/modules/TimeSeriesDispersionOutputModule.py
@@ -1,38 +1,348 @@
+"""
+TimeSeriesDispersionOutputModule
+================================
+
+Plots an AUSTAL TalMon time-series at user-defined monitor points.
+
+Input file: ``<pollutant>-tmpa.dmna`` in the AUSTAL work directory.
+This file is written by TalMon (the AUSTAL companion that extracts
+time-series at monitor points) when AUSTAL is run with the NOTALUFT
+option AND ``xp / yp`` lines are present in ``austal.txt``.
+
+The file contains a ``time x point`` matrix (typically 8760 x N where
+N is the number of monitor points) plus header metadata describing
+each point's name, coordinates, grid cell and the run start time.
+
+This module replaces a prior implementation that read 8760 separate
+grid files and pulled one cell from each. TalMon's ``-tmpa`` already
+contains exactly the time series we need, in one ~1 MB file.
+"""
+
 import os
 from collections import OrderedDict
 from datetime import datetime, timedelta
 
+import matplotlib
 import numpy as np
-from dateutil import rrule
-from matplotlib.dates import DateFormatter
-from qgis.PyQt import QtWidgets
+import pandas as pd
 
 from open_alaqs.core.alaqslogging import get_logger
 from open_alaqs.core.interfaces.OutputModule import OutputModule
-from open_alaqs.core.plotting.MatplotlibQtDialog import MatplotlibQtDialog
-from open_alaqs.core.tools import conversion
+
+matplotlib.use("Qt5Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.backends.backend_qt5agg import FigureCanvas  # noqa: E402
+from matplotlib.backends.backend_qt5agg import (  # noqa: E402
+    NavigationToolbar2QT as NavigationToolbar,
+)
+from matplotlib.dates import DateFormatter  # noqa: E402
+from qgis.PyQt import QtWidgets  # noqa: E402
 
 logger = get_logger(__name__)
 
 
-class TimeSeriesDispersionModule(OutputModule):
-    """
-    Module to plot a timeseries of the emission calculation
-    """
+def _austal_substance_for_results(plugin_pollutant):
+    """Map plugin pollutant name to AUSTAL substance name for output files.
 
-    settings_schema = {
-        "x_axis_title": {
-            "label": "X-Axis Title",
-            "widget_type": QtWidgets.QLineEdit,
-            "initial_value": "Time [Y-m-d HH:MM]",
-        },
-        "is_daily_maximum_enabled": {
-            "label": "Enable Plotting of Daily Maximum Values",
-            "widget_type": QtWidgets.QCheckBox,
-            "initial_value": False,
-            "tooltip": "Enabled to plot daily max. instead of daily mean values for the whole grid",
-        },
+    AUSTAL writes <substance>-y00a.dmna, <substance>-tmpa.dmna, etc.
+    Most plugin names lowercase directly to the AUSTAL substance name
+    (NOx -> nox, CO -> co, HC -> hc), but PM is special:
+        PM10 -> 'pm'    (AUSTAL sums components 1+2 into pm-y00a.dmna)
+        PM2.5 -> 'pm25' (single-component substance)
+    """
+    if not plugin_pollutant:
+        return ""
+    p = plugin_pollutant.upper()
+    if p == "PM10":
+        return "pm"
+    if p in ("PM25", "PM2.5", "PM-2.5"):
+        return "pm25"
+    return plugin_pollutant.lower()
+
+
+# ---------------------------------------------------------------------------
+# DMNA tmpa parser
+# ---------------------------------------------------------------------------
+
+def _parse_tmpa_file(path):
+    """Parse a TalMon ``<pollutant>-tmpa.dmna`` file.
+
+    Returns a dict with:
+        datetime_axis  ndarray[datetime] of length n_time
+        data           ndarray[n_time, n_points] of float (NaN for undf)
+        point_names    list[str]
+        point_coords   list[tuple[float, float, float]]   (x, y, z metres
+                       relative to ref origin)
+        units          str   (typically "ug/m3")
+        project_name   str   (from ``idnt`` in header, may be empty)
+        pollutant      str   (from ``name`` in header, lowercased)
+    """
+    with open(path, encoding="latin-1", errors="ignore") as f:
+        raw = [line.rstrip("\n").rstrip("\r") for line in f]
+
+    header = OrderedDict()
+    data_start = None
+    for i, line in enumerate(raw):
+        stripped = line.strip().replace('"', "")
+        if not stripped:
+            continue
+        if stripped.startswith("*"):
+            data_start = i + 1
+            break
+        parts = stripped.split()
+        if parts:
+            header[parts[0]] = parts[1:]
+
+    if data_start is None:
+        raise Exception(
+            "DMNA file '%s' has no data-block delimiter '*'; "
+            "the file appears truncated or malformed." % path
+        )
+
+    for required in ("mntn", "mntx", "mnty", "rdat", "dt", "hghb", "unit"):
+        if required not in header:
+            raise Exception(
+                "DMNA file '%s' is missing required header key '%s'. "
+                "This may not be a TalMon -tmpa file." % (path, required)
+            )
+
+    point_names = list(header["mntn"])
+    mntx = [float(v) for v in header["mntx"]]
+    mnty = [float(v) for v in header["mnty"]]
+    mntz = [float(v) for v in header.get("mntz", ["0.0"] * len(point_names))]
+    point_coords = list(zip(mntx, mnty, mntz))
+
+    n_time = int(header["hghb"][0])
+    n_points = int(header["hghb"][1])
+    if len(point_names) != n_points:
+        logger.warning(
+            "tmpa file '%s': mntn count (%d) doesn't match hghb point "
+            "count (%d). Adjusting to hghb count.",
+            path, len(point_names), n_points,
+        )
+        if len(point_names) < n_points:
+            point_names = point_names + [
+                str(i + 1) for i in range(len(point_names), n_points)
+            ]
+        else:
+            point_names = point_names[:n_points]
+        if len(point_coords) < n_points:
+            point_coords = point_coords + [
+                (0.0, 0.0, 0.0)
+            ] * (n_points - len(point_coords))
+        else:
+            point_coords = point_coords[:n_points]
+
+    rdat_str = header["rdat"][0]
+    try:
+        t0 = datetime.fromisoformat(rdat_str).replace(tzinfo=None)
+    except Exception:
+        logger.warning(
+            "Could not parse rdat='%s'; defaulting to 2025-01-01", rdat_str,
+        )
+        t0 = datetime(2025, 1, 1)
+
+    dt_str = header["dt"][0]
+    try:
+        h, m, s = dt_str.split(":")
+        delta = timedelta(hours=int(h), minutes=int(m), seconds=int(s))
+        if delta.total_seconds() <= 0:
+            delta = timedelta(hours=1)
+    except Exception:
+        delta = timedelta(hours=1)
+
+    datetime_axis = np.array([t0 + i * delta for i in range(n_time)])
+
+    flat = []
+    for line in raw[data_start:]:
+        line = line.strip()
+        if not line or line.startswith("*"):
+            continue
+        for token in line.split():
+            try:
+                flat.append(float(token))
+            except ValueError:
+                pass
+
+    expected = n_time * n_points
+    if len(flat) < expected:
+        raise Exception(
+            "DMNA data short: expected %d values (%d time x %d points), "
+            "got %d in '%s'." % (expected, n_time, n_points, len(flat), path)
+        )
+    data = np.array(flat[:expected], dtype=float).reshape(n_time, n_points)
+    undf = float(header.get("undf", ["-1"])[0])
+    data = np.where(data == undf, np.nan, data)
+
+    return {
+        "datetime_axis": datetime_axis,
+        "data": data,
+        "point_names": point_names,
+        "point_coords": point_coords,
+        "units": header["unit"][0] if header["unit"] else "",
+        "project_name": (header.get("idnt", [""])[0]
+                         if header.get("idnt") else ""),
+        "pollutant": (header.get("name", [""])[0].lower()
+                      if header.get("name") else ""),
     }
+
+
+# ---------------------------------------------------------------------------
+# Plot dialog
+# ---------------------------------------------------------------------------
+
+class TimeSeriesPlotDialog(QtWidgets.QDialog):
+    """Plot dialog: one line per monitor point, with a smoothing combo."""
+
+    SMOOTHING_OPTIONS = [
+        ("Raw (hourly)", "raw"),
+        ("8-hour rolling mean", "8h"),
+        ("24-hour rolling mean", "24h"),
+        ("Monthly mean", "monthly"),
+    ]
+
+    def __init__(self, parent, parsed, pollutant_label,
+                 time_start=None, time_end=None):
+        super().__init__(parent)
+        self.setWindowTitle("Time Series - %s" % pollutant_label.upper())
+        self.resize(950, 620)
+
+        self._datetime_axis = parsed["datetime_axis"]
+        self._data = parsed["data"]
+        self._point_names = parsed["point_names"]
+        self._point_coords = parsed["point_coords"]
+        self._units = parsed["units"]
+        self._project_name = parsed["project_name"]
+        self._pollutant_label = pollutant_label
+
+        if time_start is not None or time_end is not None:
+            mask = np.ones(len(self._datetime_axis), dtype=bool)
+            if time_start is not None:
+                mask &= (self._datetime_axis >= time_start)
+            if time_end is not None:
+                mask &= (self._datetime_axis <= time_end)
+            if mask.any():
+                self._datetime_axis = self._datetime_axis[mask]
+                self._data = self._data[mask, :]
+            else:
+                logger.warning(
+                    "Time-window [%s, %s] excludes all tmpa data; "
+                    "showing full year.", time_start, time_end,
+                )
+
+        plt.ioff()
+        self._figure = plt.figure(figsize=(9, 5))
+        self._axes = self._figure.add_subplot(111)
+        self._canvas = FigureCanvas(self._figure)
+        self._canvas.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding,
+            QtWidgets.QSizePolicy.Policy.Expanding,
+        )
+        self._toolbar = NavigationToolbar(self._canvas, parent=self)
+
+        self._smoothing_combo = QtWidgets.QComboBox()
+        for label, _ in self.SMOOTHING_OPTIONS:
+            self._smoothing_combo.addItem(label)
+        self._smoothing_combo.currentIndexChanged.connect(self._redraw)
+
+        controls = QtWidgets.QHBoxLayout()
+        controls.addWidget(QtWidgets.QLabel("Smoothing:"))
+        controls.addWidget(self._smoothing_combo)
+        controls.addStretch(1)
+        export_btn = QtWidgets.QPushButton("Export CSV")
+        export_btn.clicked.connect(self._export_csv)
+        controls.addWidget(export_btn)
+        close_btn = QtWidgets.QPushButton("Close")
+        close_btn.clicked.connect(self.close)
+        controls.addWidget(close_btn)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addLayout(controls)
+        layout.addWidget(self._toolbar)
+        layout.addWidget(self._canvas)
+        self.setLayout(layout)
+
+        self._redraw()
+
+    def _smoothed(self, key):
+        x = self._datetime_axis
+        y = self._data
+        if key == "raw":
+            return x, y
+        if key in ("8h", "24h"):
+            window = 8 if key == "8h" else 24
+            df = pd.DataFrame(y)
+            ys = df.rolling(window=window, min_periods=1).mean().values
+            return x, ys
+        if key == "monthly":
+            df = pd.DataFrame(y, index=pd.DatetimeIndex(x))
+            monthly = df.resample("MS").mean()
+            return monthly.index.to_pydatetime(), monthly.values
+        return x, y
+
+    def _redraw(self, *_args):
+        idx = self._smoothing_combo.currentIndex()
+        label, key = self.SMOOTHING_OPTIONS[idx]
+        x, y = self._smoothed(key)
+
+        self._axes.clear()
+        for i, name in enumerate(self._point_names):
+            self._axes.plot(x, y[:, i], label="P%s" % name, linewidth=1.0)
+
+        title = "%s time series" % self._pollutant_label.upper()
+        if self._project_name:
+            title += " - %s" % self._project_name
+        if key != "raw":
+            title += " (%s)" % label
+        self._axes.set_title(title)
+        self._axes.set_ylabel("Concentration [%s]" % self._units)
+        self._axes.set_xlabel("Time")
+        self._axes.legend(loc="best", fontsize=8,
+                          ncol=min(4, len(self._point_names)))
+        self._axes.grid(True, alpha=0.3)
+
+        if key == "monthly":
+            self._axes.xaxis.set_major_formatter(DateFormatter("%Y-%m"))
+        else:
+            self._axes.xaxis.set_major_formatter(DateFormatter("%Y-%m-%d"))
+        self._figure.autofmt_xdate()
+        self._figure.tight_layout()
+        self._canvas.draw()
+
+    def _export_csv(self):
+        suggested = "%s_timeseries.csv" % self._pollutant_label.lower()
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Export Time Series CSV", suggested, "CSV files (*.csv)"
+        )
+        if not path:
+            return
+        try:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("datetime,"
+                        + ",".join("P%s" % n for n in self._point_names)
+                        + "\n")
+                for i, ts in enumerate(self._datetime_axis):
+                    row = [ts.isoformat()] + [
+                        "" if np.isnan(v) else "%.4g" % v
+                        for v in self._data[i, :]
+                    ]
+                    f.write(",".join(row) + "\n")
+            QtWidgets.QMessageBox.information(
+                self, "Export OK", "CSV written to:\n%s" % path,
+            )
+        except Exception as e:
+            QtWidgets.QMessageBox.warning(self, "Export failed", str(e))
+
+
+# ---------------------------------------------------------------------------
+# Output module class (called by DispersionAnalysis.runOutputModule)
+# ---------------------------------------------------------------------------
+
+class TimeSeriesDispersionModule(OutputModule):
+    """Plot AUSTAL TalMon time-series at monitor points."""
+
+    settings_schema = {}
 
     @staticmethod
     def getModuleName():
@@ -46,537 +356,118 @@ class TimeSeriesDispersionModule(OutputModule):
         if values_dict is None:
             values_dict = {}
         OutputModule.__init__(self, values_dict)
-
-        # Widget configuration
         self._parent = values_dict.get("parent")
-        self._widget = None
-
-        # Plot configuration
-        self._title = values_dict.get("title", "")
-        self._xtitle = values_dict.get("x_axis_title", "")
-        self._ytitle = values_dict.get("ytitle", "")
-        self._options = values_dict.get("options", "")
-
-        self._max_values = values_dict.get("is_daily_maximum_enabled", False)
-
-        # Results analysis
-        self._time_start = values_dict["start_dt_inclusive"]
-        self._time_end = values_dict["end_dt_inclusive"]
-
-        self._averaging_period = values_dict.get("averaging_period", "annual mean")
-        self._pollutant = values_dict.get("pollutant")
-        self._check_uncertainty = values_dict.get("check_uncertainty", False)
-        self._timeseries = values_dict.get("timeseries")
-        self._concentration_database = values_dict.get("concentration_path", None)
-        # self._total_concentration = 0.
-
-    def assure_time_interval(self, output_data):
-        try:  # convert t1, t2 to dates and check timedelta
-            t1, t2, t0 = (
-                output_data["t1"][0],
-                output_data["t2"][0],
-                output_data["rdat"][0],
-            )
-            # reconstruct actual date
-            start_date = datetime.strptime(t0, "%Y-%m-%d.%H:%M:%S")
-
-            start_time = (
-                datetime.strptime(t1, "%d.%H:%M:%S").replace(year=start_date.year)
-                if ("." in t1)
-                else datetime.strptime(t1, "%H:%M:%S").replace(year=start_date.year)
-            )
-            start_time = (
-                start_time + timedelta(days=0)
-                if ("." not in t1)
-                else start_time.replace(
-                    day=conversion.convertToInt(t1.split(".")[0]) + 1
-                )
-            )
-
-            end_time = (
-                datetime.strptime(t2, "%d.%H:%M:%S").replace(year=start_date.year)
-                if ("." in t2)
-                else datetime.strptime(t2, "%H:%M:%S").replace(year=start_date.year)
-            )
-            end_time = (
-                end_time + timedelta(days=0)
-                if ("." not in t2)
-                else end_time.replace(day=conversion.convertToInt(t2.split(".")[0]) + 1)
-            )
-
-            # timedelta
-            tdelta = end_time - start_time
-
-            if self._averaging_period == "daily mean" and (
-                tdelta.total_seconds() == 86400.0
-            ):
-                return True
-            # if self._averaging_period == "1-h, 8-h, or else": timedelta should be 1h
-            elif self._averaging_period != "daily mean" and (
-                tdelta.total_seconds() == 3600.0
-            ):
-                return True
-            else:
-                QtWidgets.QMessageBox.warning(
-                    None,
-                    "Time interval error",
-                    "Error in timedelta: (start: %s, end:%s)" % (t1, t2),
-                )
-                # logger.debug("Error in timedelta: (start: %s, end:%s)"%(t1, t2))
-                # logger.debug("\t (SD: %s, ED:%s, TD:%s)"%(start_time, end_time, tdelta.total_seconds()))
-                return False
-        except Exception:
-            return False
-
-    def assert_validity(self, avg_period="annual mean"):
-        required_proportion = 0.90 if avg_period == "annual mean" else 0.75
-        if np.count_nonzero(self._data_y) < required_proportion * len(self._data_y):
-            logger.error("Required proportion of valid data is not enough!")
-
-    def readA2Koutput(self, datapath):
-        if not os.path.isfile(datapath):
-            QtWidgets.QMessageBox.warning(
-                None,
-                "File not found",
-                "File '%s' not found. Choose another pollutant ? " % (datapath),
-            )
-        try:
-            with open(datapath, encoding="utf8", errors="ignore") as f:
-                raw_output_data = [
-                    x.rstrip("\n").lstrip().replace('"', "") for x in f.readlines()
-                ]
-
-            output_data = OrderedDict()
-            cnt = 0
-            for content in raw_output_data:
-                cnt += +1
-                if content.split() and "*" not in content.split()[0]:
-                    output_data[content.split()[0]] = content.split()[1:]
-                elif content.split() and "*" in content.split()[0]:
-                    break
-
-            index_ = raw_output_data.index("*")
-            # concentration_matrix = np.loadtxt(datapath, comments="*", skiprows=index_)
-            concentration_matrix = np.loadtxt(
-                raw_output_data, comments="*", skiprows=index_
-            )
-
-            return output_data, index_, concentration_matrix
-
-        except Exception as exc_:
-            logger.error(exc_)
-            return OrderedDict(), None, None
-
-    def CalculateMovingAverage(self, conc, n=3):
-        ret = np.cumsum(conc, dtype=float)
-        ret[n:] = ret[n:] - ret[:-n]
-        return ret[n - 1 :] / n
+        # Plugin pollutant name (e.g. "PM10"); we keep both this and the
+        # AUSTAL substance code (e.g. "pm") because AUSTAL output filenames
+        # use the substance code, not the plugin name.
+        plugin_poll = (values_dict.get("pollutant") or "").strip()
+        self._pollutant = plugin_poll.lower()  # used for display labels
+        self._austal_substance = _austal_substance_for_results(plugin_poll)
+        self._concentration_database = values_dict.get("concentration_path")
+        self._time_start = values_dict.get("start_dt_inclusive")
+        self._time_end = values_dict.get("end_dt_inclusive")
+        self._parsed = None
 
     def beginJob(self):
-
-        if self._pollutant.startswith("PM"):
-            logger.debug(
-                "Pollutant '%s', will be written simply as 'PM'" % self._pollutant
+        if not self._pollutant:
+            raise Exception(
+                "No pollutant selected. Please pick a pollutant in the "
+                "result visualisation panel before plotting."
             )
-            self._pollutant = "PM"
+        if not self._concentration_database:
+            raise Exception(
+                "No work directory available. Run AUSTAL or load existing "
+                "results first."
+            )
+        wd = str(self._concentration_database)
+        if not os.path.isdir(wd):
+            raise Exception("Work directory does not exist: %s" % wd)
 
-        self._data_x = []
-        self._data_y = []
-        self._data_y_std = []
-        self._data_y_max = []
-        self._8h_runnning_average = []
-        self._8h_runnning_average_max = []
-
-    def process(self):
-        try:
-            self._header = [(self._pollutant, "double")]
-
-            if self._averaging_period == "annual mean":
-                QtWidgets.QMessageBox.information(
-                    None, "Error", "Cannot create time-series plot for annual mean"
+        tmpa_path = os.path.join(
+            wd, "%s-tmpa.dmna" % self._austal_substance
+        )
+        if not os.path.isfile(tmpa_path):
+            # Distinguish the two failure modes with a list of what IS
+            # available in this work directory:
+            #   - "no tmpa files at all" -> NOTALUFT/receptors missing,
+            #     re-run AUSTAL
+            #   - "tmpa files exist for other pollutants" -> the user
+            #     picked a pollutant that wasn't in the AUSTAL run,
+            #     point them at what is available
+            import glob as _glob
+            existing = sorted(_glob.glob(os.path.join(wd, "*-tmpa.dmna")))
+            if not existing:
+                raise FileNotFoundError(
+                    "No TalMon time-series files in this work directory:\n"
+                    "  %s\n\n"
+                    "Plot Time Series requires the AUSTAL run to have:\n"
+                    "  1. Output Mode set to 'Per-hour series (NOTALUFT)' "
+                    "(checkbox in the Generate tab), AND\n"
+                    "  2. Monitor points (xp / yp lines) defined in "
+                    "austal.txt (provide a Receptors CSV in the Generate "
+                    "tab, or populate shapes_receptor_points in the "
+                    ".alaqs file).\n\n"
+                    "Re-run AUSTAL with both conditions met to produce "
+                    "<pollutant>-tmpa.dmna files." % wd
                 )
+            available = sorted({
+                os.path.basename(p).split("-")[0] for p in existing
+            })
+            # Map AUSTAL substance back to plugin pollutant name
+            sub_to_plugin = {
+                "pm": "PM10", "pm25": "PM2.5",
+                "nox": "NOx", "sox": "SOx",
+                "co": "CO", "co2": "CO2", "hc": "HC",
+                "no2": "NO2", "so2": "SO2",
+            }
+            available_plugin_names = [
+                sub_to_plugin.get(s, s.upper()) for s in available
+            ]
+            requested_plugin = self._pollutant.upper() if self._pollutant else "?"
+            raise FileNotFoundError(
+                "Time-series file not found for the selected pollutant: %s\n"
+                "  expected: %s\n\n"
+                "This pollutant is not in the current AUSTAL run output. "
+                "Available pollutants in this work directory:\n"
+                "  %s\n\n"
+                "Either pick one of the available pollutants in the result "
+                "panel, or re-run AUSTAL with %s included in the pollutant "
+                "selection (Generate tab)."
+                % (
+                    requested_plugin,
+                    tmpa_path,
+                    ", ".join(available_plugin_names),
+                    requested_plugin,
+                )
+            )
 
-            else:
-                OrderedDict()
-                time_counter = 1
-
-                if self._averaging_period == "daily mean":
-                    logger.debug("Averaging based on %s" % self._averaging_period)
-                    self._data_x = [
-                        day_
-                        for day_ in rrule.rrule(
-                            rrule.DAILY,
-                            dtstart=self._time_start,
-                            until=self._time_end + timedelta(days=-1),
-                        )
-                    ]
-                    while time_counter <= (self._time_end - self._time_start).days:
-                        output_file = (
-                            os.path.join(
-                                self._concentration_database,
-                                "%s-%sa.dmna"
-                                % (self._pollutant.lower(), str(time_counter).zfill(3)),
-                            )
-                            if not self._check_uncertainty
-                            else os.path.join(
-                                self._concentration_database,
-                                "%s-%ss.dmna"
-                                % (self._pollutant.lower(), str(time_counter).zfill(3)),
-                            )
-                        )
-
-                        output_data, index_, concentration_matrix = self.readA2Koutput(
-                            output_file
-                        )
-                        if not self.assure_time_interval(output_data):
-                            QtWidgets.QMessageBox.warning(
-                                None,
-                                "Timedelta Error",
-                                "Make sure files do exist for averaging method: '%s'"
-                                % self._averaging_period,
-                            )
-                            logger.warning(
-                                "Error in timedelta when reading dispersion model outputs. Choose another averaging period."
-                            )
-                            return False
-
-                        # self._sk = output_data['sk'] if ('sk' in output_data and len(output_data['sk']) > 0) else None
-                        # self._units = output_data['unit'][0].decode('latin-1') if ('unit' in output_data and len(output_data['unit']) > 0) else None
-                        self._units = (
-                            output_data["unit"][0]
-                            if ("unit" in output_data and len(output_data["unit"]) > 0)
-                            else None
-                        )
-
-                        index_i = (
-                            conversion.convertToInt(output_data["hghb"][0])
-                            if ("hghb" in output_data and len(output_data["hghb"]) > 0)
-                            else None
-                        )  # columns
-                        index_j = (
-                            conversion.convertToInt(output_data["hghb"][1])
-                            if ("hghb" in output_data and len(output_data["hghb"]) > 0)
-                            else None
-                        )  # rows
-                        index_k = (
-                            conversion.convertToInt(output_data["hghb"][2])
-                            if ("hghb" in output_data and len(output_data["hghb"]) > 0)
-                            else None
-                        )  # z
-
-                        if not (index_k and index_i and index_j):
-                            logger.error(
-                                "Error in reshaping concentration matrix: (%s, %s, %s)"
-                                % (index_k, index_i, index_j)
-                            )
-                            return False
-
-                        concentration_matrix_reshaped = np.reshape(
-                            concentration_matrix, (index_k, index_j, index_i)
-                        )
-                        # The result files contain the horizontal layers k=1...Kmax
-                        if (
-                            self._check_uncertainty
-                        ):  # take only first level for uncertainty: 0m to 3m
-                            self._data_y.append(
-                                np.mean(
-                                    concentration_matrix_reshaped[0, :, :].squeeze()
-                                )
-                            )
-                        else:
-                            # take the concentration up tp Kmax: <c> = c1*H1/(H1+H2+H3+...) + c2*H2/(H1+H2+H3+...) + c3*H3/(H1+H2+H3+...) + ...
-                            total_column_concentration = np.zeros(
-                                shape=(index_j, index_i)
-                            )
-                            for z_ in range(1, index_k + 1):
-                                total_column_concentration += (
-                                    conversion.convertToFloat(output_data["sk"][z_])
-                                    * concentration_matrix_reshaped[
-                                        z_ - 1, :, :
-                                    ].squeeze()
-                                ) / conversion.convertToFloat(
-                                    output_data["sk"][index_k]
-                                )
-                            self._data_y.append(np.mean(total_column_concentration))
-                            self._data_y_max.append(np.max(total_column_concentration))
-                            self._data_y_std.append(np.std(total_column_concentration))
-
-                        time_counter += +1
-
-                else:  # hourly means (1h, 8h, whatever ..)
-                    self._data_x = [
-                        hour_
-                        for hour_ in rrule.rrule(
-                            rrule.HOURLY,
-                            dtstart=self._time_start,
-                            until=self._time_end + timedelta(hours=-1),
-                        )
-                    ]
-                    # assert len(self._data_x) > 8
-
-                    for timeval in self._timeseries:
-
-                        while time_counter <= len(self._data_x):
-                            output_file = (
-                                os.path.join(
-                                    self._concentration_database,
-                                    "%s-%sa.dmna"
-                                    % (
-                                        self._pollutant.lower(),
-                                        str(time_counter).zfill(3),
-                                    ),
-                                )
-                                if not self._check_uncertainty
-                                else os.path.join(
-                                    self._concentration_database,
-                                    "%s-%ss.dmna"
-                                    % (
-                                        self._pollutant.lower(),
-                                        str(time_counter).zfill(3),
-                                    ),
-                                )
-                            )
-
-                            (
-                                output_data,
-                                index_,
-                                concentration_matrix,
-                            ) = self.readA2Koutput(output_file)
-                            if not self.assure_time_interval(output_data):
-                                QtWidgets.QMessageBox.warning(
-                                    None,
-                                    "Timedelta Error",
-                                    "Make sure files do exist for averaging method: '%s'"
-                                    % self._averaging_period,
-                                )
-                                logger.warning(
-                                    "Error in timedelta when reading dispersion model outputs. Choose another averaging period."
-                                )
-                                return False
-                                # raise Exception("Error in timedelta. Choose another averaging period for time interval (%s, %s)"%(output_data['t1'], output_data['t2']))
-
-                            # self._sk = output_data['sk'] if ('sk' in output_data and len(output_data['sk']) > 0) else None
-                            # self._units = output_data['unit'][0].decode('latin-1') if ('unit' in output_data and len(output_data['unit']) > 0) else None
-                            self._units = (
-                                output_data["unit"][0]
-                                if (
-                                    "unit" in output_data
-                                    and len(output_data["unit"]) > 0
-                                )
-                                else None
-                            )
-
-                            index_i = (
-                                conversion.convertToInt(output_data["hghb"][0])
-                                if (
-                                    "hghb" in output_data
-                                    and len(output_data["hghb"]) > 0
-                                )
-                                else None
-                            )  # columns
-                            index_j = (
-                                conversion.convertToInt(output_data["hghb"][1])
-                                if (
-                                    "hghb" in output_data
-                                    and len(output_data["hghb"]) > 0
-                                )
-                                else None
-                            )  # rows
-                            index_k = (
-                                conversion.convertToInt(output_data["hghb"][2])
-                                if (
-                                    "hghb" in output_data
-                                    and len(output_data["hghb"]) > 0
-                                )
-                                else None
-                            )  # z
-
-                            concentration_matrix_reshaped = np.reshape(
-                                concentration_matrix, (index_k, index_j, index_i)
-                            )
-
-                            # The result files contain the horizontal layers k=1...Kmax
-                            if (
-                                self._check_uncertainty
-                            ):  # take only first level for uncertainty: 0m to 3m
-                                self._data_y.append(
-                                    np.mean(
-                                        concentration_matrix_reshaped[0, :, :].squeeze()
-                                    )
-                                )
-                            else:
-                                # take the concentration up tp Kmax: <c> = c1*H1/(H1+H2+H3+...) + c2*H2/(H1+H2+H3+...) + c3*H3/(H1+H2+H3+...) + ...
-                                total_column_concentration = np.zeros(
-                                    shape=(index_j, index_i)
-                                )
-                                for z_ in range(1, index_k + 1):
-                                    total_column_concentration += (
-                                        conversion.convertToFloat(output_data["sk"][z_])
-                                        * concentration_matrix_reshaped[
-                                            z_ - 1, :, :
-                                        ].squeeze()
-                                    ) / conversion.convertToFloat(
-                                        output_data["sk"][index_k]
-                                    )
-
-                                self._data_y.append(np.mean(total_column_concentration))
-                                self._data_y_max.append(
-                                    np.max(total_column_concentration)
-                                )
-                                self._data_y_std.append(
-                                    np.std(total_column_concentration)
-                                )
-
-                            time_counter += +1
-
-                    if self._averaging_period == "8-hours mean":
-                        if len(self._data_x) <= 8:
-                            logger.warning(
-                                "Not enough data to calculate 8h running mean"
-                            )
-                            return False
-                        else:
-                            # calculate 8h-moving mean
-                            self._8h_runnning_average = self.CalculateMovingAverage(
-                                self._data_y, n=8
-                            )
-                            self._8h_runnning_average_max = self.CalculateMovingAverage(
-                                self._data_y_max, n=8
-                            )
-
+        try:
+            self._parsed = _parse_tmpa_file(tmpa_path)
         except Exception as e:
-            logger.error("TimeSeriesDispersionModule: Cannot fetch data: %s" % e)
+            raise Exception(
+                "Failed to parse TalMon file '%s': %s" % (tmpa_path, e)
+            )
 
-        # satisfy validity criteria check
-        self.assert_validity(avg_period=self._averaging_period)
+        file_pollutant = (self._parsed.get("pollutant") or "").lower()
+        if file_pollutant and file_pollutant != self._austal_substance:
+            logger.warning(
+                "tmpa file pollutant tag '%s' differs from expected "
+                "AUSTAL substance '%s' (plugin pollutant: %s)",
+                file_pollutant, self._austal_substance, self._pollutant,
+            )
+        return True
 
+    def process(self, **_kwargs):
         return True
 
     def endJob(self):
-        # show widget
-
-        # create a new instance of a QtDialog for matplotlib plotting with parent of current QtDialog (focusing)
-        if (
-            self._data_x
-            and self._data_y
-            and self._data_y_std
-            and len(self._data_x) == len(self._data_y)
-        ):
-
-            # at least one element must be nonzero ...
-            if all(e is None for e in self._data_y):
-                # self._data_y = [0.] * len(self._data_y)
-                self._data_y[0] = 0.0
-
-            self._widget = MatplotlibQtDialog(self._parent)  # self
-
-            # axis formatting
-            axis = self._widget.getAxes()
-
-            if not self._max_values:
-
-                if self._averaging_period == "8-hours mean" and np.all(
-                    0 <= self._8h_runnning_average
-                ):
-                    self._widget.plot(
-                        self._data_x, self._data_y, self._options, lw=2, color="k"
-                    )
-                    leg = ["Daily mean"]
-                    no = 8
-                    self._widget.plot(
-                        self._data_x[no - 1 :],
-                        self._8h_runnning_average,
-                        self._options,
-                        lw=2,
-                        color="b",
-                        alpha=0.5,
-                    )
-                    leg.append("8h moving avg")
-
-                else:
-                    self._widget.plot(
-                        self._data_x, self._data_y, self._options, lw=2, color="k"
-                    )
-                    leg = (
-                        ["Daily mean"]
-                        if self._averaging_period == "daily mean"
-                        else ["Hourly mean"]
-                    )
-                    y_plus_std = [
-                        self._data_y[i] + self._data_y_std[i]
-                        for i, j in enumerate(self._data_y)
-                    ]
-                    y_minus_std = [
-                        self._data_y[i] - self._data_y_std[i]
-                        for i, j in enumerate(self._data_y)
-                    ]
-                    axis.fill_between(
-                        self._data_x,
-                        y_plus_std,
-                        y_minus_std,
-                        lw=2,
-                        facecolor="k",
-                        alpha=0.5,
-                    )
-
-            else:
-                self._widget.plot(
-                    self._data_x, self._data_y_max, self._options, lw=2, color="k"
-                )
-                leg = (
-                    ["Daily max"]
-                    if self._averaging_period == "daily mean"
-                    else ["Hourly max."]
-                )
-                self._title = (" ").join(
-                    [leg[0], "concentration of %s" % self._pollutant]
-                )
-
-                if self._averaging_period == "8-hours mean" and np.all(
-                    0 <= self._8h_runnning_average_max
-                ):
-                    no = 8
-                    self._widget.plot(
-                        self._data_x[no - 1 :],
-                        self._8h_runnning_average_max,
-                        self._options,
-                        lw=2,
-                        color="b",
-                        alpha=0.5,
-                    )
-                    leg.append("8h moving avg (max)")
-
-                    # if self._moving_average:
-                    #     no = 5
-                    #     ma = self.CalculateMovingAverage(self._data_y_max, n=no)
-                    #     plot_ma = self._widget.plot(self._data_x[no-1:], ma, self._options, lw=2, color='b', alpha=0.5)
-                    #     leg.append('Moving avg')
-
-            legend = self._widget.getPlt().legend(
-                leg, shadow=True, fancybox=True, loc="best"
-            )
-            self._widget.getPlt().setp(
-                legend.get_texts(), fontsize="medium"
-            )  # sizes = ['xx-small', 'x-small', 'small', 'medium', 'large', 'x-large'
-
-            # Titles
-            self._widget.getFigure().suptitle(self._title)
-            axis.set_xlabel(self._xtitle)
-            self._ytitle = (" ").join([self._ytitle, "(", self._units, ")"])
-            axis.set_ylabel(self._ytitle)
-
-            # Set Xlim, Ylim
-            # axis.set_ylim([min(self._widget.getPlt().ylim()[0],0), self._widget.getPlt().ylim()[1]*1.1])
-
-            # use time as axis units
-            # formatter = DateFormatter('%Y-%m-%d %H:%M:%S')
-            formatter = DateFormatter("%Y-%m-%d %H:%M")
-            axis.xaxis.set_major_formatter(formatter)
-
-            # optimize the ticks of the axes
-            self._widget.getFigure().autofmt_xdate()
-
-            self._widget.getPlt().subplots_adjust(bottom=0.25, left=0.25)
-            self._widget.getPlt().xticks(rotation=35)
-
-        return self._widget
+        if self._parsed is None:
+            return None
+        dialog = TimeSeriesPlotDialog(
+            parent=self._parent,
+            parsed=self._parsed,
+            pollutant_label=self._pollutant,
+            time_start=self._time_start,
+            time_end=self._time_end,
+        )
+        return dialog

--- a/open_alaqs/core/modules/TimeSeriesDispersionOutputModule.py
+++ b/open_alaqs/core/modules/TimeSeriesDispersionOutputModule.py
@@ -65,6 +65,7 @@ def _austal_substance_for_results(plugin_pollutant):
 # DMNA tmpa parser
 # ---------------------------------------------------------------------------
 
+
 def _parse_tmpa_file(path):
     """Parse a TalMon ``<pollutant>-tmpa.dmna`` file.
 
@@ -119,7 +120,9 @@ def _parse_tmpa_file(path):
         logger.warning(
             "tmpa file '%s': mntn count (%d) doesn't match hghb point "
             "count (%d). Adjusting to hghb count.",
-            path, len(point_names), n_points,
+            path,
+            len(point_names),
+            n_points,
         )
         if len(point_names) < n_points:
             point_names = point_names + [
@@ -128,9 +131,9 @@ def _parse_tmpa_file(path):
         else:
             point_names = point_names[:n_points]
         if len(point_coords) < n_points:
-            point_coords = point_coords + [
-                (0.0, 0.0, 0.0)
-            ] * (n_points - len(point_coords))
+            point_coords = point_coords + [(0.0, 0.0, 0.0)] * (
+                n_points - len(point_coords)
+            )
         else:
             point_coords = point_coords[:n_points]
 
@@ -139,7 +142,8 @@ def _parse_tmpa_file(path):
         t0 = datetime.fromisoformat(rdat_str).replace(tzinfo=None)
     except Exception:
         logger.warning(
-            "Could not parse rdat='%s'; defaulting to 2025-01-01", rdat_str,
+            "Could not parse rdat='%s'; defaulting to 2025-01-01",
+            rdat_str,
         )
         t0 = datetime(2025, 1, 1)
 
@@ -181,16 +185,17 @@ def _parse_tmpa_file(path):
         "point_names": point_names,
         "point_coords": point_coords,
         "units": header["unit"][0] if header["unit"] else "",
-        "project_name": (header.get("idnt", [""])[0]
-                         if header.get("idnt") else ""),
-        "pollutant": (header.get("name", [""])[0].lower()
-                      if header.get("name") else ""),
+        "project_name": (header.get("idnt", [""])[0] if header.get("idnt") else ""),
+        "pollutant": (
+            header.get("name", [""])[0].lower() if header.get("name") else ""
+        ),
     }
 
 
 # ---------------------------------------------------------------------------
 # Plot dialog
 # ---------------------------------------------------------------------------
+
 
 class TimeSeriesPlotDialog(QtWidgets.QDialog):
     """Plot dialog: one line per monitor point, with a smoothing combo."""
@@ -202,8 +207,7 @@ class TimeSeriesPlotDialog(QtWidgets.QDialog):
         ("Monthly mean", "monthly"),
     ]
 
-    def __init__(self, parent, parsed, pollutant_label,
-                 time_start=None, time_end=None):
+    def __init__(self, parent, parsed, pollutant_label, time_start=None, time_end=None):
         super().__init__(parent)
         self.setWindowTitle("Time Series - %s" % pollutant_label.upper())
         self.resize(950, 620)
@@ -219,16 +223,18 @@ class TimeSeriesPlotDialog(QtWidgets.QDialog):
         if time_start is not None or time_end is not None:
             mask = np.ones(len(self._datetime_axis), dtype=bool)
             if time_start is not None:
-                mask &= (self._datetime_axis >= time_start)
+                mask &= self._datetime_axis >= time_start
             if time_end is not None:
-                mask &= (self._datetime_axis <= time_end)
+                mask &= self._datetime_axis <= time_end
             if mask.any():
                 self._datetime_axis = self._datetime_axis[mask]
                 self._data = self._data[mask, :]
             else:
                 logger.warning(
                     "Time-window [%s, %s] excludes all tmpa data; "
-                    "showing full year.", time_start, time_end,
+                    "showing full year.",
+                    time_start,
+                    time_end,
                 )
 
         plt.ioff()
@@ -298,8 +304,7 @@ class TimeSeriesPlotDialog(QtWidgets.QDialog):
         self._axes.set_title(title)
         self._axes.set_ylabel("Concentration [%s]" % self._units)
         self._axes.set_xlabel("Time")
-        self._axes.legend(loc="best", fontsize=8,
-                          ncol=min(4, len(self._point_names)))
+        self._axes.legend(loc="best", fontsize=8, ncol=min(4, len(self._point_names)))
         self._axes.grid(True, alpha=0.3)
 
         if key == "monthly":
@@ -319,17 +324,18 @@ class TimeSeriesPlotDialog(QtWidgets.QDialog):
             return
         try:
             with open(path, "w", encoding="utf-8") as f:
-                f.write("datetime,"
-                        + ",".join("P%s" % n for n in self._point_names)
-                        + "\n")
+                f.write(
+                    "datetime," + ",".join("P%s" % n for n in self._point_names) + "\n"
+                )
                 for i, ts in enumerate(self._datetime_axis):
                     row = [ts.isoformat()] + [
-                        "" if np.isnan(v) else "%.4g" % v
-                        for v in self._data[i, :]
+                        "" if np.isnan(v) else "%.4g" % v for v in self._data[i, :]
                     ]
                     f.write(",".join(row) + "\n")
             QtWidgets.QMessageBox.information(
-                self, "Export OK", "CSV written to:\n%s" % path,
+                self,
+                "Export OK",
+                "CSV written to:\n%s" % path,
             )
         except Exception as e:
             QtWidgets.QMessageBox.warning(self, "Export failed", str(e))
@@ -338,6 +344,7 @@ class TimeSeriesPlotDialog(QtWidgets.QDialog):
 # ---------------------------------------------------------------------------
 # Output module class (called by DispersionAnalysis.runOutputModule)
 # ---------------------------------------------------------------------------
+
 
 class TimeSeriesDispersionModule(OutputModule):
     """Plot AUSTAL TalMon time-series at monitor points."""
@@ -383,9 +390,7 @@ class TimeSeriesDispersionModule(OutputModule):
         if not os.path.isdir(wd):
             raise Exception("Work directory does not exist: %s" % wd)
 
-        tmpa_path = os.path.join(
-            wd, "%s-tmpa.dmna" % self._austal_substance
-        )
+        tmpa_path = os.path.join(wd, "%s-tmpa.dmna" % self._austal_substance)
         if not os.path.isfile(tmpa_path):
             # Distinguish the two failure modes with a list of what IS
             # available in this work directory:
@@ -395,6 +400,7 @@ class TimeSeriesDispersionModule(OutputModule):
             #     picked a pollutant that wasn't in the AUSTAL run,
             #     point them at what is available
             import glob as _glob
+
             existing = sorted(_glob.glob(os.path.join(wd, "*-tmpa.dmna")))
             if not existing:
                 raise FileNotFoundError(
@@ -410,15 +416,18 @@ class TimeSeriesDispersionModule(OutputModule):
                     "Re-run AUSTAL with both conditions met to produce "
                     "<pollutant>-tmpa.dmna files." % wd
                 )
-            available = sorted({
-                os.path.basename(p).split("-")[0] for p in existing
-            })
+            available = sorted({os.path.basename(p).split("-")[0] for p in existing})
             # Map AUSTAL substance back to plugin pollutant name
             sub_to_plugin = {
-                "pm": "PM10", "pm25": "PM2.5",
-                "nox": "NOx", "sox": "SOx",
-                "co": "CO", "co2": "CO2", "hc": "HC",
-                "no2": "NO2", "so2": "SO2",
+                "pm": "PM10",
+                "pm25": "PM2.5",
+                "nox": "NOx",
+                "sox": "SOx",
+                "co": "CO",
+                "co2": "CO2",
+                "hc": "HC",
+                "no2": "NO2",
+                "so2": "SO2",
             }
             available_plugin_names = [
                 sub_to_plugin.get(s, s.upper()) for s in available
@@ -444,16 +453,16 @@ class TimeSeriesDispersionModule(OutputModule):
         try:
             self._parsed = _parse_tmpa_file(tmpa_path)
         except Exception as e:
-            raise Exception(
-                "Failed to parse TalMon file '%s': %s" % (tmpa_path, e)
-            )
+            raise Exception("Failed to parse TalMon file '%s': %s" % (tmpa_path, e))
 
         file_pollutant = (self._parsed.get("pollutant") or "").lower()
         if file_pollutant and file_pollutant != self._austal_substance:
             logger.warning(
                 "tmpa file pollutant tag '%s' differs from expected "
                 "AUSTAL substance '%s' (plugin pollutant: %s)",
-                file_pollutant, self._austal_substance, self._pollutant,
+                file_pollutant,
+                self._austal_substance,
+                self._pollutant,
             )
         return True
 

--- a/open_alaqs/core/tools/austal_csv_generation.py
+++ b/open_alaqs/core/tools/austal_csv_generation.py
@@ -354,6 +354,7 @@ def generate_austal_from_csv(
     selected_pollutants: List[str],
     start_dt: datetime = None,
     end_dt: datetime = None,
+    receptors=None,
 ) -> None:
     """Generate AUSTAL input files from pre-calculated emissions and meteo CSVs.
 
@@ -377,6 +378,10 @@ def generate_austal_from_csv(
             first timestamp in the CSV.
         end_dt: Only process timesteps <= this datetime. Defaults to the
             last timestamp in the CSV.
+        receptors: Optional GeoDataFrame with receptor points. Same schema
+            as the ALAQS-mode receptor loader: 'longitude', 'latitude',
+            'height', 'EPSG' columns. If None or empty, AUSTAL runs
+            without xp/yp lines and TalMon will not write -tmpa.dmna.
 
     Raises:
         FileNotFoundError: If either CSV path does not exist.
@@ -388,6 +393,10 @@ def generate_austal_from_csv(
     logger.info("Meteo File=%s", meteo_csv_path)
     logger.info("Output Directory=%s", output_dir)
     logger.info("Selected Pollutants=%s", selected_pollutants)
+    if receptors is not None and len(receptors) > 0:
+        logger.info("Receptors=%d points", len(receptors))
+    else:
+        logger.info("Receptors=none (no -tmpa.dmna will be produced)")
 
     # Parse both inputs up front so format errors are caught before AUSTAL initialises
     rows_by_ts = parse_emissions_csv(emissions_csv_path)
@@ -432,7 +441,11 @@ def generate_austal_from_csv(
                 "pollutants_list": selected_pollutants,
                 "title": "OpenALAQS CSV AUSTAL generation",
                 "grid": grid,
-                "receptors": gpd.GeoDataFrame(),  # no receptor points in CSV mode
+                "receptors": (
+                    receptors
+                    if receptors is not None
+                    else gpd.GeoDataFrame()
+                ),
             }
         )
 

--- a/open_alaqs/core/tools/austal_csv_generation.py
+++ b/open_alaqs/core/tools/austal_csv_generation.py
@@ -442,9 +442,7 @@ def generate_austal_from_csv(
                 "title": "OpenALAQS CSV AUSTAL generation",
                 "grid": grid,
                 "receptors": (
-                    receptors
-                    if receptors is not None
-                    else gpd.GeoDataFrame()
+                    receptors if receptors is not None else gpd.GeoDataFrame()
                 ),
             }
         )

--- a/open_alaqs/gui/DispersionAnalysis.py
+++ b/open_alaqs/gui/DispersionAnalysis.py
@@ -1,4 +1,5 @@
 import csv
+import glob
 import os
 import re
 import shutil
@@ -295,7 +296,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             self._on_grid_source_file_changed(last_grid_file_path)
 
         self.ui.ResultsTable.clicked.connect(
-            lambda: self.runOutputModule("TableViewDispersionModule")
+            lambda: self.runOutputModule("ComplianceReportDispersionModule")
         )
         self.ui.VisualiseResults.clicked.connect(
             lambda: self.runOutputModule("QGISVectorLayerDispersionModule")
@@ -438,17 +439,18 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
 
         # CSV feedback visibility depends on CSV mode being selected
         self.ui.external_files_feedback.setVisible(
-            self.ui.generateFromCsvRadio.isChecked()
+            self._input_mode() == "csv"
         )
 
         # Connect CSV mode toggle for feedback visibility
-        def toggle_csv_feedback_visibility():
+        def toggle_csv_feedback_visibility(*_args):
             self.ui.external_files_feedback.setVisible(
-                self.ui.generateFromCsvRadio.isChecked()
+                self._input_mode() == "csv"
             )
 
-        self.ui.generateFromCsvRadio.toggled.connect(toggle_csv_feedback_visibility)
         self.ui.useExistingFilesRadio.toggled.connect(toggle_csv_feedback_visibility)
+        self.ui.generateFromAlaqsRadio.toggled.connect(toggle_csv_feedback_visibility)
+        self.ui.generateFromCsvRadio.toggled.connect(toggle_csv_feedback_visibility)
 
         # Connect OpenALAQS feedback visibility
         def toggle_alaqs_feedback_visibility(checked):
@@ -539,16 +541,108 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             (austal_completed and has_grid_config)
             or (has_output_files and has_grid_config)
         )
+        self.ui.VisualiseResults.setEnabled(can_visualize_vector)
+        if not can_visualize_vector:
+            self.ui.VisualiseResults.setToolTip(
+                "Disabled: Plot Vector Layer needs both an AUSTAL grid output "
+                "(.dmna files) and a configured grid (cells > 0, or grid from "
+                "an OpenALAQS file). Run AUSTAL or load existing output files, "
+                "and ensure the grid is set."
+            )
+        else:
+            self.ui.VisualiseResults.setToolTip(
+                "Click to plot the AUSTAL grid output as a QGIS vector layer."
+            )
 
-        # Enable/disable buttons accordingly
-        # self.ui.ResultsTable.setEnabled(bool(can_show_table_and_timeseries))
-        # self.ui.PlotTimeSeries.setEnabled(bool(can_show_table_and_timeseries))
+        # PlotTimeSeries + ResultsTable (Receptor Compliance Report) both
+        # need <substance>-tmpa.dmna files in the work directory. TalMon
+        # produces those only when AUSTAL runs with (a) receptors defined
+        # (xp/yp/hp lines in austal.txt) AND (b) NOTALUFT enabled. If
+        # neither was true, both modules have nothing to read.
+        work_dir_for_tmpa = None
+        try:
+            wd = self._get_austal_work_directory()
+            if wd is not None:
+                work_dir_for_tmpa = str(wd)
+        except Exception:
+            work_dir_for_tmpa = None
+        tmpa_files = []
+        if work_dir_for_tmpa and os.path.isdir(work_dir_for_tmpa):
+            tmpa_files = glob.glob(
+                os.path.join(work_dir_for_tmpa, "*-tmpa.dmna")
+            )
+        has_tmpa = bool(tmpa_files)
 
-        # TODO: ResultsTable and PlotTimeSeries buttons are currently disabled as they dont work with annual mean and they should be reactivated in future development
-        self.ui.ResultsTable.setEnabled(False)
-        self.ui.PlotTimeSeries.setEnabled(False)
+        self.ui.PlotTimeSeries.setEnabled(has_tmpa)
+        self.ui.ResultsTable.setEnabled(has_tmpa)
 
-        self.ui.VisualiseResults.setEnabled(bool(can_visualize_vector))
+        # User feedback on the buttons themselves so the disabled state is
+        # self-explanatory.
+        if has_tmpa:
+            substances = sorted({
+                os.path.basename(p).split("-")[0] for p in tmpa_files
+            })
+            tt_enabled = (
+                "Receptor results available for: %s." % ", ".join(substances)
+            )
+            self.ui.PlotTimeSeries.setToolTip(
+                tt_enabled + " Click to plot time series at receptors."
+            )
+            self.ui.ResultsTable.setToolTip(
+                tt_enabled
+                + " Click to compute per-receptor TA Luft compliance."
+            )
+        else:
+            tt_disabled = (
+                "Disabled: no <substance>-tmpa.dmna files in the AUSTAL "
+                "work directory.\n\nTo enable:\n"
+                "  1. Add receptor points (CSV picker in OpenALAQS "
+                "Generate tab, or shapes_receptor_points in .alaqs)\n"
+                "  2. Tick 'Per-hour series (NOTALUFT)' in Output Mode\n"
+                "  3. Re-generate AUSTAL inputs and re-run AUSTAL"
+            )
+            self.ui.PlotTimeSeries.setToolTip(tt_disabled)
+            self.ui.ResultsTable.setToolTip(tt_disabled)
+
+        # Status label below the result buttons (if the UI exposes one).
+        self._update_receptor_results_status(has_tmpa, tmpa_files)
+
+    def _update_receptor_results_status(self, has_tmpa, tmpa_files):
+        """Update the small status label below the result buttons.
+
+        Tells the user, in plain language, whether receptor-based results
+        (Plot Time Series, Compliance Report) are available, and what to
+        do if not. Silently no-ops if the UI doesn't expose the label
+        (older .ui versions without the receptorResultsStatusLabel).
+        """
+        label = getattr(self.ui, "receptorResultsStatusLabel", None)
+        if label is None:
+            return
+        if has_tmpa:
+            substances = sorted({
+                os.path.basename(p).split("-")[0] for p in tmpa_files
+            })
+            text = (
+                "Receptor results available for: %s. "
+                "Plot Time Series and Compliance Report are enabled."
+                % ", ".join(substances)
+            )
+            label.setStyleSheet(
+                "color: #1a6e1a; font-size: 10pt; padding: 2px 6px;"
+            )
+        else:
+            text = (
+                "No receptor results in this work directory. "
+                "To enable Plot Time Series and Compliance Report: add "
+                "receptors (CSV in OpenALAQS Generate tab, or "
+                "shapes_receptor_points in .alaqs), tick "
+                "'Per-hour series (NOTALUFT)', then re-generate AUSTAL "
+                "inputs and re-run AUSTAL."
+            )
+            label.setStyleSheet(
+                "color: #8a4a00; font-size: 10pt; padding: 2px 6px;"
+            )
+        label.setText(text)
 
     def updateMinMaxGUI(self, db_path_=""):
         time_start_calc_, time_end_calc_ = get_min_max_timestamps(db_path_)
@@ -770,6 +864,14 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             if dirname:  # Only clear settings if a path was explicitly cleared
                 s.setValue("OpenALAQS/last_work_directory_path", "")
 
+        # Refresh Run button state. _on_input_mode_changed only fires on
+        # radio-button toggles, so without this hook a directory change
+        # while already in "Use Existing" mode would leave the button in
+        # its previous (possibly stale) enabled/disabled state. The user
+        # would then have to toggle radios off and back to refresh.
+        if self._input_mode() == "existing":
+            self.ui.RunA2K.setEnabled(bool(dirname and os.path.isdir(dirname)))
+
     def _on_results_directory_changed(self, results_dir: str) -> None:
         """Auto-load AUSTAL results when a valid work directory is selected."""
         if not results_dir or not os.path.isdir(results_dir):
@@ -867,7 +969,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
                 elif self._austal_ran:
                     # Priority 2: AUSTAL ran from OpenALAQS generation (Option B)
                     if (
-                        self.ui.generateFromAlaqsRadio.isChecked()
+                        self._input_mode() == "alaqs"
                         and self._austal_grid_config
                     ):
                         alaqs_file = self.ui.alaqs_output_file_path.filePath()
@@ -876,14 +978,14 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
 
                     # Priority 3: AUSTAL ran from CSV generation (Option C)
                     elif (
-                        self.ui.generateFromCsvRadio.isChecked()
+                        self._input_mode() == "csv"
                         and self._austal_grid_config
                     ):
                         text = f"Using Grid from CSV Generation\n{_fmt(self._austal_grid_config)}"
                         bg_color = STATUS_STYLE_SUCCESS
 
                     # Priority 4: AUSTAL ran from existing files (Option A) - default grid
-                    elif self.ui.useExistingFilesRadio.isChecked():
+                    elif self._input_mode() == "existing":
                         if self._austal_grid_config:
                             text = f"Using Default Grid\n{_fmt(self._austal_grid_config)}\n\nRecommendation: Load a Grid from Result Visualisation section for accurate visualisation."
                         else:
@@ -1268,19 +1370,205 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
         if mode == "alaqs":
             quality_level = int(self.ui.alaqs_quality_level_spinbox.value())
             mixing_height = self.ui.alaqs_mixing_height_checkbox.isChecked()
+            notaluft = self.ui.alaqs_notaluft_checkbox.isChecked()
+            try:
+                pm10_fine_fraction = float(
+                    self.ui.alaqs_pm10_fine_fraction_spinbox.value()
+                )
+            except Exception:
+                pm10_fine_fraction = 0.9
         else:  # csv mode
             quality_level = int(self.ui.csv_quality_level_spinbox.value())
             mixing_height = self.ui.csv_mixing_height_checkbox.isChecked()
+            notaluft = self.ui.csv_notaluft_checkbox.isChecked()
+            # CSV path doesn't have a PM10 split control yet; use default.
+            pm10_fine_fraction = 0.9
+
+        # Build os= options string. NOTALUFT switches AUSTAL from
+        # TA Luft mode (annual mean post-process only) to per-hour
+        # series output. The latter is required for the result viewer
+        # to produce hourly / 8-hour / daily means.
+        if notaluft:
+            options_string = "NOSTANDARD;NOTALUFT;Kmax=1"
+        else:
+            options_string = "NOSTANDARD;SCINOTAT;Kmax=1"
 
         return {
             "is_enabled": True,
             "quality_level": quality_level,
-            "options_string": "NOSTANDARD;SCINOTAT;Kmax=1",
+            "options_string": options_string,
             "roughness_length_m": 0.2,
             "displacement_height_m": 1.2,
             "anemometer_height_m": 11.2,
             "mixing_height_enabled": mixing_height,
+            "pm10_fine_fraction": pm10_fine_fraction,
         }
+
+    def _read_receptor_csv(self, csv_path):
+        """Read a receptor CSV into a GeoDataFrame.
+
+        Returns None on any failure (caller decides fallback). Required
+        columns: longitude, latitude (case-insensitive, lon/lat aliases
+        accepted). Optional: height (default 1.5m), EPSG (default 4326),
+        id (label only).
+        """
+        try:
+            import geopandas as gpd
+            import pandas as pd
+        except Exception as e:
+            logger.warning(
+                "Receptor CSV read skipped (geopandas/pandas import failed): %s", e,
+            )
+            return None
+        if not csv_path or not os.path.isfile(csv_path):
+            return None
+        try:
+            df = pd.read_csv(csv_path)
+            df.columns = [c.strip().lower() for c in df.columns]
+            if "longitude" not in df.columns and "lon" in df.columns:
+                df = df.rename(columns={"lon": "longitude"})
+            if "latitude" not in df.columns and "lat" in df.columns:
+                df = df.rename(columns={"lat": "latitude"})
+            if "longitude" not in df.columns or "latitude" not in df.columns:
+                raise ValueError(
+                    "Receptor CSV must contain 'longitude' and 'latitude' "
+                    "columns (case-insensitive). Got: %s" % list(df.columns)
+                )
+            if "height" not in df.columns:
+                df["height"] = 1.5
+            if "epsg" in df.columns and "EPSG" not in df.columns:
+                df = df.rename(columns={"epsg": "EPSG"})
+            if "EPSG" not in df.columns:
+                df["EPSG"] = 4326
+            logger.info(
+                "Loaded %d receptor point(s) from CSV: %s", len(df), csv_path,
+            )
+            return gpd.GeoDataFrame(df)
+        except Exception as e:
+            logger.warning("Failed to load receptor CSV '%s': %s", csv_path, e)
+            return None
+
+    def _read_receptors_from_alaqs_db(self, alaqs_file):
+        """Read shapes_receptor_points table into a GeoDataFrame.
+
+        Returns None if the file isn't a readable SQLite DB or has no
+        rows. Filters to instudy != 'N' (Y, blank, NULL all kept).
+        """
+        try:
+            import geopandas as gpd
+            import pandas as pd
+        except Exception as e:
+            logger.warning(
+                "Receptor DB read skipped (geopandas/pandas import failed): %s", e,
+            )
+            return None
+        if not alaqs_file or not os.path.isfile(alaqs_file):
+            return None
+        try:
+            conn = sqlite3.connect(alaqs_file)
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT oid, source_id, xcoord, ycoord, height, instudy, "
+                "AsText(geometry) FROM shapes_receptor_points"
+            )
+            rows = cur.fetchall()
+            conn.close()
+        except Exception as e:
+            logger.warning(
+                "Could not read shapes_receptor_points from '%s': %s",
+                alaqs_file, e,
+            )
+            return None
+        if not rows:
+            return None
+        accepted = []
+        for oid, source_id, xc, yc, h, instudy, _wkt in rows:
+            if instudy and str(instudy).strip().upper() == "N":
+                continue
+            accepted.append({
+                "id": source_id or ("R%d" % oid),
+                "longitude": float(xc) if xc is not None else None,
+                "latitude": float(yc) if yc is not None else None,
+                "height": float(h) if h is not None else 1.5,
+                "EPSG": 3857,
+            })
+        if not accepted:
+            return None
+        df = pd.DataFrame(accepted).dropna(subset=["longitude", "latitude"])
+        if df.empty:
+            return None
+        logger.info(
+            "Loaded %d receptor point(s) from %s (shapes_receptor_points).",
+            len(df), alaqs_file,
+        )
+        return gpd.GeoDataFrame(df)
+
+    def _empty_receptors_gdf(self):
+        """Return an empty GeoDataFrame matching the receptor schema."""
+        try:
+            import geopandas as gpd
+        except Exception:
+            return None
+        return gpd.GeoDataFrame()
+
+    def _load_receptors(self, mode, alaqs_file=None):
+        """Mode-aware receptor loader.
+
+        mode='alaqs': read alaqs_receptors_csv_path → fall back to
+            shapes_receptor_points in alaqs_file → empty.
+        mode='csv': read csv_receptors_csv_path only (no .alaqs fallback,
+            since CSV mode has no .alaqs file) → empty.
+        mode='existing' or unknown: empty (no generation happening).
+
+        Returns a GeoDataFrame (possibly empty). Empty means AUSTAL will
+        run without xp/yp lines and TalMon will not write -tmpa.dmna,
+        so the receptor-based result buttons will stay disabled.
+        """
+        if mode == "alaqs":
+            csv_path = ""
+            try:
+                csv_path = self.ui.alaqs_receptors_csv_path.filePath().strip()
+            except Exception:
+                pass
+            gdf = self._read_receptor_csv(csv_path)
+            if gdf is not None and not gdf.empty:
+                return gdf
+            gdf = self._read_receptors_from_alaqs_db(alaqs_file)
+            if gdf is not None and not gdf.empty:
+                return gdf
+            logger.info(
+                "No receptor points (alaqs mode: CSV empty and .alaqs db "
+                "has none). AUSTAL will run without xp/yp lines; "
+                "Compliance Report and Plot Time Series will be disabled."
+            )
+            return self._empty_receptors_gdf()
+
+        if mode == "csv":
+            csv_path = ""
+            try:
+                csv_path = self.ui.csv_receptors_csv_path.filePath().strip()
+            except Exception:
+                pass
+            gdf = self._read_receptor_csv(csv_path)
+            if gdf is not None and not gdf.empty:
+                return gdf
+            logger.info(
+                "No receptor points (CSV mode: receptor CSV empty or not "
+                "provided). AUSTAL will run without xp/yp lines; "
+                "Compliance Report and Plot Time Series will be disabled."
+            )
+            return self._empty_receptors_gdf()
+
+        # 'existing' or unknown
+        return self._empty_receptors_gdf()
+
+    def _load_receptors_for_alaqs_path(self, alaqs_file):
+        """Backward-compatible wrapper around _load_receptors('alaqs').
+
+        Kept for any external callers that may still reach this name;
+        new code should call _load_receptors(mode, alaqs_file) directly.
+        """
+        return self._load_receptors("alaqs", alaqs_file)
 
     def _generate_austal_input_files(self):
         """Generate AUSTAL input files from CSV files or OpenALAQS output file.
@@ -1293,8 +1581,8 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
         5. Marks files as generated and stores the work directory
         6. Enables the Run AUSTAL button
         """
-        use_alaqs = self.ui.generateFromAlaqsRadio.isChecked()
-        use_csv = self.ui.generateFromCsvRadio.isChecked()
+        use_alaqs = self._input_mode() == "alaqs"
+        use_csv = self._input_mode() == "csv"
 
         # Determine the base output directory
         if use_alaqs:
@@ -1458,6 +1746,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
                 logger.info(f"Grid config: {grid_config}")
 
                 austal_cfg = self._get_austal_config_from_ui(mode="csv")
+                receptors_gdf = self._load_receptors("csv")
                 generate_austal_from_csv(
                     emissions_csv_path=emissions_csv,
                     meteo_csv_path=meteo_csv,
@@ -1467,6 +1756,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
                     selected_pollutants=selected_pollutants,
                     start_dt=sel_start,
                     end_dt=sel_end,
+                    receptors=receptors_gdf,
                 )
         except Exception as e:
             error_msg = f"Error generating AUSTAL input files: {e}"
@@ -1611,6 +1901,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
 
         # Add AUSTAL dispersion module for the selected pollutants
         austal_config = self._get_austal_config_from_ui()
+        receptors_gdf = self._load_receptors("alaqs", alaqs_file)
         austal_config.update(
             {
                 "output_path": output_dir,
@@ -1618,7 +1909,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
                 "pollutants_list": selected_pollutants,
                 "title": "OpenALAQS AUSTAL generation",
                 "grid": emission_calc.get3DGrid(),
-                "receptors": gpd.GeoDataFrame(),
+                "receptors": receptors_gdf,
             }
         )
 
@@ -1642,11 +1933,27 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             f"AUSTAL input files generated for pollutants: {', '.join(selected_pollutants)}"
         )
 
-    def _on_input_mode_changed(self) -> None:
-        """Handle switching between existing files, generate from OpenALAQS, and generate from CSV modes."""
-        use_existing = self.ui.useExistingFilesRadio.isChecked()
-        use_alaqs = self.ui.generateFromAlaqsRadio.isChecked()
-        use_csv = self.ui.generateFromCsvRadio.isChecked()
+    def _input_mode(self) -> str:
+        """Return current input strategy: 'existing', 'alaqs', or 'csv'."""
+        if self.ui.useExistingFilesRadio.isChecked():
+            return "existing"
+        if self.ui.generateFromAlaqsRadio.isChecked():
+            return "alaqs"
+        if self.ui.generateFromCsvRadio.isChecked():
+            return "csv"
+        return "existing"
+
+    def _on_input_mode_changed(self, *_args) -> None:
+        """Handle switching between input strategies.
+
+        Called both on radio toggle and directly during init. Manages
+        frame visibility, the generate button, generation flag reset,
+        and Run AUSTAL button state for the active mode.
+        """
+        mode = self._input_mode()
+        use_existing = mode == "existing"
+        use_alaqs = mode == "alaqs"
+        use_csv = mode == "csv"
 
         # Show/hide and enable/disable the frames based on selection
         self.ui.existingFilesFrame.setVisible(use_existing)
@@ -1656,7 +1963,8 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
         self.ui.generateFromCsvFrame.setVisible(use_csv)
         self.ui.generateFromCsvFrame.setEnabled(use_csv)
 
-        # Show/hide the generate button - only visible when generating from OpenALAQS output or CSV
+        # Show/hide the generate button - only visible when generating
+        # from OpenALAQS output or CSV
         self.ui.generateFromCsvBtn.setVisible(use_alaqs or use_csv)
 
         # Reset generation state when mode changes - need to regenerate files
@@ -1721,6 +2029,12 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
 
     def _validate_alaqs_generation_files(self) -> None:
         """Validate the selected OpenALAQS output file and working directory."""
+        # Only this validator owns the RunA2K state when the OpenALAQS
+        # generation radio is active. If the user is in "Use Existing"
+        # or "Generate from CSV" mode, leave RunA2K alone — that mode's
+        # own handler is the source of truth.
+        owns_run_button = self._input_mode() == "alaqs"
+
         alaqs_file = self.ui.alaqs_output_file_path.filePath()
         output_dir = self.ui.alaqs_output_work_dir_path.filePath()
         pollutants = self._get_selected_alaqs_pollutants()
@@ -1745,7 +2059,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             self.ui.alaqsGenerationStatusLabel.setStyleSheet(STATUS_STYLE_WARNING)
             self.ui.generateFromCsvBtn.setEnabled(False)
             # Keep Run AUSTAL enabled if files have already been generated (user may have deselected pollutant by mistake)
-            if not self._austal_input_files_generated:
+            if owns_run_button and not self._austal_input_files_generated:
                 self.ui.RunA2K.setEnabled(False)
             return
 
@@ -1756,7 +2070,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             self.ui.alaqsGenerationStatusLabel.setStyleSheet(STATUS_STYLE_ERROR)
             self.ui.generateFromCsvBtn.setEnabled(False)
             # Keep Run AUSTAL enabled if files have already been generated
-            if not self._austal_input_files_generated:
+            if owns_run_button and not self._austal_input_files_generated:
                 self.ui.RunA2K.setEnabled(False)
             return
 
@@ -1778,7 +2092,8 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
         self.ui.alaqsGenerationStatusLabel.setStyleSheet(STATUS_STYLE_SUCCESS)
         self.ui.generateFromCsvBtn.setEnabled(True)
         # Only enable Run AUSTAL if files have been generated
-        self.ui.RunA2K.setEnabled(self._austal_input_files_generated)
+        if owns_run_button:
+            self.ui.RunA2K.setEnabled(self._austal_input_files_generated)
 
     def _on_output_directory_changed(self, dirname: str) -> None:
         """Handle output directory selection for CSV generation."""
@@ -1847,6 +2162,10 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
 
     def _validate_external_csv_files(self) -> None:
         """Validate the selected external CSV files, output directory, and grid configuration."""
+        # Only this validator owns RunA2K when the CSV generation radio
+        # is active. Otherwise leave the button alone.
+        owns_run_button = self._input_mode() == "csv"
+
         output_dir = self.ui.output_directory_path.filePath()
         emissions_path = self.ui.emissions_csv_path.filePath()
         meteo_path = self.ui.meteo_csv_path.filePath()
@@ -1873,7 +2192,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             self.ui.external_files_feedback.setStyleSheet(STATUS_STYLE_WARNING)
             self.ui.generateFromCsvBtn.setEnabled(False)
             # Keep Run AUSTAL enabled if files have already been generated (user may have deselected pollutant by mistake)
-            if not self._austal_input_files_generated:
+            if owns_run_button and not self._austal_input_files_generated:
                 self.ui.RunA2K.setEnabled(False)
             return
 
@@ -1894,7 +2213,8 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
         self.ui.external_files_feedback.setStyleSheet(STATUS_STYLE_SUCCESS)
         self.ui.generateFromCsvBtn.setEnabled(True)
         # Only enable Run AUSTAL if files have been generated
-        self.ui.RunA2K.setEnabled(self._austal_input_files_generated)
+        if owns_run_button:
+            self.ui.RunA2K.setEnabled(self._austal_input_files_generated)
 
     # Display the text when the user presses the AUSTAL HELP buttton
     def show_austal_help(self):
@@ -1947,10 +2267,10 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             return self._generated_austal_work_dir
 
         # Otherwise, determine based on selected mode
-        if self.ui.generateFromAlaqsRadio.isChecked():
+        if self._input_mode() == "alaqs":
             # Use the output directory from OpenALAQS generation
             return str(self.ui.alaqs_output_work_dir_path.filePath())
-        elif self.ui.generateFromCsvRadio.isChecked():
+        elif self._input_mode() == "csv":
             # Use the output directory from CSV generation
             return str(self.ui.output_directory_path.filePath())
         else:
@@ -2004,7 +2324,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             return False, "Please select a valid AUSTAL executable file (Section 1)"
 
         # Check mode-specific requirements
-        if self.ui.useExistingFilesRadio.isChecked():
+        if self._input_mode() == "existing":
             work_dir = self.ui.work_directory_path.filePath()
             if not work_dir or not os.path.isdir(work_dir):
                 return (
@@ -2012,7 +2332,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
                     "Please select a valid work directory with AUSTAL input files",
                 )
 
-        elif self.ui.generateFromAlaqsRadio.isChecked():
+        elif self._input_mode() == "alaqs":
             alaqs_file = self.ui.alaqs_output_file_path.filePath()
             output_dir = self.ui.alaqs_output_work_dir_path.filePath()
             pollutants = self._get_selected_alaqs_pollutants()
@@ -2031,7 +2351,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
                     "Selected OpenALAQS file does not have a valid grid_3d_definition",
                 )
 
-        elif self.ui.generateFromCsvRadio.isChecked():
+        elif self._input_mode() == "csv":
             output_dir = self.ui.output_directory_path.filePath()
             emissions_csv = self.ui.emissions_csv_path.filePath()
             meteo_csv = self.ui.meteo_csv_path.filePath()
@@ -2050,7 +2370,8 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
 
     @catch_errors
     def run_austal(self, *args, **kwargs):
-        from subprocess import PIPE, Popen
+        import subprocess as _sp
+        from subprocess import Popen
 
         try:
             # Validate all inputs before running
@@ -2099,21 +2420,38 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             else:
                 cmd = [austal_, work_dir]
 
-            p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-            output, err = p.communicate()
+            # Don't redirect stdout/stderr. On Windows the OS allocates a
+            # console window for AUSTAL automatically; with redirection the
+            # window stays blank for the entire (potentially hour-long) run.
+            # Letting output flow through gives the user live progress.
+            # CREATE_NEW_CONSOLE forces a fresh console even when QGIS was
+            # itself launched from one (otherwise AUSTAL's output would
+            # interleave with QGIS console output).
+            creationflags = 0
+            if hasattr(_sp, "CREATE_NEW_CONSOLE"):
+                creationflags = _sp.CREATE_NEW_CONSOLE
+
+            p = Popen(cmd, creationflags=creationflags)
+            p.wait()
 
             if p.returncode != 0:
-                output_text = (
-                    output.decode("utf-8", errors="replace")
-                    if isinstance(output, bytes)
-                    else str(output)
-                )
-                err_text = (
-                    err.decode("utf-8", errors="replace")
-                    if isinstance(err, bytes)
-                    else str(err)
-                )
-                raise Austal2000RunError(f"{output_text}\nSTDERR: {err_text}".strip())
+                # Output was written to AUSTAL's own console; pull error
+                # detail from austal.log in the work dir if it exists.
+                err_msg = f"AUSTAL exited with code {p.returncode}."
+                log_path = os.path.join(work_dir, "austal.log")
+                if os.path.isfile(log_path):
+                    try:
+                        with open(log_path, "r", encoding="utf-8",
+                                  errors="replace") as fh:
+                            tail = fh.readlines()[-40:]
+                        err_msg += "\n\nLast 40 lines of austal.log:\n" + (
+                            "".join(tail)
+                        )
+                    except OSError as exc_:
+                        err_msg += f"\n(Could not read austal.log: {exc_})"
+                else:
+                    err_msg += "\nSee the AUSTAL console window for details."
+                raise Austal2000RunError(err_msg)
 
             # Update status to completed
             self.ui.executionStatusLabel.setText("Status: Completed successfully")
@@ -2124,7 +2462,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             self._austal_ran = True
 
             # Snapshot grid based on which input mode was used
-            if self.ui.generateFromAlaqsRadio.isChecked():
+            if self._input_mode() == "alaqs":
                 # Option B: Use grid from the ALAQS file
                 alaqs_file = self.ui.alaqs_output_file_path.filePath()
                 try:
@@ -2164,7 +2502,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
                         if self.get_current_grid_config()
                         else None
                     )
-            elif self.ui.generateFromCsvRadio.isChecked():
+            elif self._input_mode() == "csv":
                 # Option C: Use G1 grid from spinboxes
                 self._austal_grid_config = (
                     self.get_current_grid_config().copy()
@@ -2723,43 +3061,58 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
                 "Error",
                 "Could not execute runOutputModule: %s (error: %s)" % (name, e),
             )
-            raise e
+            # Don't re-raise: that triggers QGIS's own Python traceback
+            # popup, giving the user two error windows for the same
+            # condition. The single dialog above is enough; the full
+            # traceback is written to the QGIS message log (View > Panels
+            # > Log Messages > "open_alaqs") for developer debugging.
+            logger.error(
+                "runOutputModule(%s) failed: %s", name, e, exc_info=True,
+            )
 
     def _setup_averaging_options(self):
-        """Disable all averaging options except 'annual mean' to indicate future functionality."""
+        """Configure the averaging combo box.
+
+        All four options (annual / daily / hourly / 8-hours) are
+        selectable. The reading path (`getA2KData` in
+        ConcentrationsQGISVectorLayerOutputModule and
+        TableViewDispersionOutputModule) handles each by reading the
+        appropriate AUSTAL output file:
+            - annual mean → <pol>-y00a.dmna
+            - daily / hourly / 8-hours → consecutive <pol>-NNNa.dmna
+              files, aggregated client-side over the selected period.
+
+        For non-annual options to actually have files to read, AUSTAL
+        must have been run with the NOTALUFT option (Section 2 →
+        "Output Mode: Per-hour series" checkbox). Without NOTALUFT,
+        only the annual mean file exists; selecting another averaging
+        will hit "File X doesn't exist" warnings.
+        """
         try:
-            # Get the averaging combo from the UI directly
             averaging_combo = (
                 self.ui.averagingCombo if hasattr(self.ui, "averagingCombo") else None
             )
 
             if averaging_combo and isinstance(averaging_combo, QtWidgets.QComboBox):
                 model = averaging_combo.model()
-
+                # Re-enable every item (clear any prior disable from older builds)
                 for i in range(averaging_combo.count()):
-                    item_text = averaging_combo.itemText(i)
-                    if item_text != "annual mean":
-                        item = model.item(i)
-                        if item:
-                            # Disable the item
-                            item.setFlags(
-                                item.flags() & ~QtCore.Qt.ItemFlag.ItemIsEnabled
-                            )
-                            # Set gray color to make it visually clear it's disabled
-                            item.setForeground(QtGui.QColor(150, 150, 150))
-                            # Optional: Add a tooltip explaining why it's disabled
-                            item.setToolTip(
-                                "This averaging option is not yet available. Coming soon!"
-                            )
+                    item = model.item(i)
+                    if item:
+                        item.setFlags(
+                            item.flags() | QtCore.Qt.ItemFlag.ItemIsEnabled
+                        )
+                        item.setForeground(QtGui.QColor(0, 0, 0))
+                        item.setToolTip("")
 
-                # Ensure "annual mean" is selected
+                # Default to annual mean as the initial pick (still the
+                # most reliable option until os=Hourly/Daily are wired
+                # into the AUSTAL run-time config).
                 annual_mean_index = averaging_combo.findText("annual mean")
-                if annual_mean_index >= 0:
+                if annual_mean_index >= 0 and averaging_combo.currentIndex() < 0:
                     averaging_combo.setCurrentIndex(annual_mean_index)
 
-                logger.debug(
-                    "Successfully disabled averaging options except 'annual mean'"
-                )
+                logger.debug("Averaging options enabled (all four selectable).")
             else:
                 logger.warning("Could not find averagingCombo in UI")
 

--- a/open_alaqs/gui/DispersionAnalysis.py
+++ b/open_alaqs/gui/DispersionAnalysis.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-import geopandas as gpd
 from qgis.core import QgsMapLayer, QgsProject, QgsSettings, QgsTextAnnotation
 from qgis.gui import QgsFileWidget
 from qgis.PyQt import QtCore, QtGui, QtWidgets
@@ -438,15 +437,11 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
         self.ui.alaqsGridStatusLabel.setVisible(self.ui.alaqsGridGroupBox.isChecked())
 
         # CSV feedback visibility depends on CSV mode being selected
-        self.ui.external_files_feedback.setVisible(
-            self._input_mode() == "csv"
-        )
+        self.ui.external_files_feedback.setVisible(self._input_mode() == "csv")
 
         # Connect CSV mode toggle for feedback visibility
         def toggle_csv_feedback_visibility(*_args):
-            self.ui.external_files_feedback.setVisible(
-                self._input_mode() == "csv"
-            )
+            self.ui.external_files_feedback.setVisible(self._input_mode() == "csv")
 
         self.ui.useExistingFilesRadio.toggled.connect(toggle_csv_feedback_visibility)
         self.ui.generateFromAlaqsRadio.toggled.connect(toggle_csv_feedback_visibility)
@@ -568,9 +563,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             work_dir_for_tmpa = None
         tmpa_files = []
         if work_dir_for_tmpa and os.path.isdir(work_dir_for_tmpa):
-            tmpa_files = glob.glob(
-                os.path.join(work_dir_for_tmpa, "*-tmpa.dmna")
-            )
+            tmpa_files = glob.glob(os.path.join(work_dir_for_tmpa, "*-tmpa.dmna"))
         has_tmpa = bool(tmpa_files)
 
         self.ui.PlotTimeSeries.setEnabled(has_tmpa)
@@ -579,18 +572,13 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
         # User feedback on the buttons themselves so the disabled state is
         # self-explanatory.
         if has_tmpa:
-            substances = sorted({
-                os.path.basename(p).split("-")[0] for p in tmpa_files
-            })
-            tt_enabled = (
-                "Receptor results available for: %s." % ", ".join(substances)
-            )
+            substances = sorted({os.path.basename(p).split("-")[0] for p in tmpa_files})
+            tt_enabled = "Receptor results available for: %s." % ", ".join(substances)
             self.ui.PlotTimeSeries.setToolTip(
                 tt_enabled + " Click to plot time series at receptors."
             )
             self.ui.ResultsTable.setToolTip(
-                tt_enabled
-                + " Click to compute per-receptor TA Luft compliance."
+                tt_enabled + " Click to compute per-receptor TA Luft compliance."
             )
         else:
             tt_disabled = (
@@ -619,17 +607,13 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
         if label is None:
             return
         if has_tmpa:
-            substances = sorted({
-                os.path.basename(p).split("-")[0] for p in tmpa_files
-            })
+            substances = sorted({os.path.basename(p).split("-")[0] for p in tmpa_files})
             text = (
                 "Receptor results available for: %s. "
                 "Plot Time Series and Compliance Report are enabled."
                 % ", ".join(substances)
             )
-            label.setStyleSheet(
-                "color: #1a6e1a; font-size: 10pt; padding: 2px 6px;"
-            )
+            label.setStyleSheet("color: #1a6e1a; font-size: 10pt; padding: 2px 6px;")
         else:
             text = (
                 "No receptor results in this work directory. "
@@ -639,9 +623,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
                 "'Per-hour series (NOTALUFT)', then re-generate AUSTAL "
                 "inputs and re-run AUSTAL."
             )
-            label.setStyleSheet(
-                "color: #8a4a00; font-size: 10pt; padding: 2px 6px;"
-            )
+            label.setStyleSheet("color: #8a4a00; font-size: 10pt; padding: 2px 6px;")
         label.setText(text)
 
     def updateMinMaxGUI(self, db_path_=""):
@@ -968,19 +950,13 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
                 # Priority 2-4: AUSTAL ran - determine which grid was used
                 elif self._austal_ran:
                     # Priority 2: AUSTAL ran from OpenALAQS generation (Option B)
-                    if (
-                        self._input_mode() == "alaqs"
-                        and self._austal_grid_config
-                    ):
+                    if self._input_mode() == "alaqs" and self._austal_grid_config:
                         alaqs_file = self.ui.alaqs_output_file_path.filePath()
                         text = f"Using Grid from OpenALAQS file: {os.path.basename(alaqs_file)}\n{_fmt(self._austal_grid_config)}"
                         bg_color = STATUS_STYLE_SUCCESS
 
                     # Priority 3: AUSTAL ran from CSV generation (Option C)
-                    elif (
-                        self._input_mode() == "csv"
-                        and self._austal_grid_config
-                    ):
+                    elif self._input_mode() == "csv" and self._austal_grid_config:
                         text = f"Using Grid from CSV Generation\n{_fmt(self._austal_grid_config)}"
                         bg_color = STATUS_STYLE_SUCCESS
 
@@ -1417,7 +1393,8 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             import pandas as pd
         except Exception as e:
             logger.warning(
-                "Receptor CSV read skipped (geopandas/pandas import failed): %s", e,
+                "Receptor CSV read skipped (geopandas/pandas import failed): %s",
+                e,
             )
             return None
         if not csv_path or not os.path.isfile(csv_path):
@@ -1441,7 +1418,9 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             if "EPSG" not in df.columns:
                 df["EPSG"] = 4326
             logger.info(
-                "Loaded %d receptor point(s) from CSV: %s", len(df), csv_path,
+                "Loaded %d receptor point(s) from CSV: %s",
+                len(df),
+                csv_path,
             )
             return gpd.GeoDataFrame(df)
         except Exception as e:
@@ -1459,7 +1438,8 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             import pandas as pd
         except Exception as e:
             logger.warning(
-                "Receptor DB read skipped (geopandas/pandas import failed): %s", e,
+                "Receptor DB read skipped (geopandas/pandas import failed): %s",
+                e,
             )
             return None
         if not alaqs_file or not os.path.isfile(alaqs_file):
@@ -1476,7 +1456,8 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
         except Exception as e:
             logger.warning(
                 "Could not read shapes_receptor_points from '%s': %s",
-                alaqs_file, e,
+                alaqs_file,
+                e,
             )
             return None
         if not rows:
@@ -1485,13 +1466,15 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
         for oid, source_id, xc, yc, h, instudy, _wkt in rows:
             if instudy and str(instudy).strip().upper() == "N":
                 continue
-            accepted.append({
-                "id": source_id or ("R%d" % oid),
-                "longitude": float(xc) if xc is not None else None,
-                "latitude": float(yc) if yc is not None else None,
-                "height": float(h) if h is not None else 1.5,
-                "EPSG": 3857,
-            })
+            accepted.append(
+                {
+                    "id": source_id or ("R%d" % oid),
+                    "longitude": float(xc) if xc is not None else None,
+                    "latitude": float(yc) if yc is not None else None,
+                    "height": float(h) if h is not None else 1.5,
+                    "EPSG": 3857,
+                }
+            )
         if not accepted:
             return None
         df = pd.DataFrame(accepted).dropna(subset=["longitude", "latitude"])
@@ -1499,7 +1482,8 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             return None
         logger.info(
             "Loaded %d receptor point(s) from %s (shapes_receptor_points).",
-            len(df), alaqs_file,
+            len(df),
+            alaqs_file,
         )
         return gpd.GeoDataFrame(df)
 
@@ -2441,8 +2425,9 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
                 log_path = os.path.join(work_dir, "austal.log")
                 if os.path.isfile(log_path):
                     try:
-                        with open(log_path, "r", encoding="utf-8",
-                                  errors="replace") as fh:
+                        with open(
+                            log_path, "r", encoding="utf-8", errors="replace"
+                        ) as fh:
                             tail = fh.readlines()[-40:]
                         err_msg += "\n\nLast 40 lines of austal.log:\n" + (
                             "".join(tail)
@@ -3067,7 +3052,10 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
             # traceback is written to the QGIS message log (View > Panels
             # > Log Messages > "open_alaqs") for developer debugging.
             logger.error(
-                "runOutputModule(%s) failed: %s", name, e, exc_info=True,
+                "runOutputModule(%s) failed: %s",
+                name,
+                e,
+                exc_info=True,
             )
 
     def _setup_averaging_options(self):
@@ -3099,9 +3087,7 @@ class OpenAlaqsDispersionAnalysis(QtWidgets.QDialog):
                 for i in range(averaging_combo.count()):
                     item = model.item(i)
                     if item:
-                        item.setFlags(
-                            item.flags() | QtCore.Qt.ItemFlag.ItemIsEnabled
-                        )
+                        item.setFlags(item.flags() | QtCore.Qt.ItemFlag.ItemIsEnabled)
                         item.setForeground(QtGui.QColor(0, 0, 0))
                         item.setToolTip("")
 

--- a/open_alaqs/metadata.txt
+++ b/open_alaqs/metadata.txt
@@ -9,7 +9,7 @@ qgisMaximumVersion=4.99
 supportsQt6=True
 description=An open-source local air quality model
 
-version=5.1.0
+version=5.1.1
 author=Eurocontrol
 email=open-alaqs@eurocontrol.int
 

--- a/open_alaqs/ui/ui_run_austal.ui
+++ b/open_alaqs/ui/ui_run_austal.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>800</width>
-    <height>1050</height>
+    <height>800</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -340,13 +340,54 @@
           </widget>
          </item>
          <item row="6" column="0">
+          <widget class="QLabel" name="alaqsReceptorsLabel">
+           <property name="text">
+            <string>Receptors CSV (optional):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QgsFileWidget" name="alaqs_receptors_csv_path">
+           <property name="dialogTitle">
+            <string>Select receptor points CSV</string>
+           </property>
+           <property name="filter">
+            <string>CSV files (*.csv);;All files (*)</string>
+           </property>
+           <property name="toolTip">
+            <string>Optional. CSV with columns: id, longitude, latitude, height (optional), EPSG (optional).
+If empty, receptors are auto-loaded from the .alaqs file's shapes_receptor_points table.
+If both empty, AUSTAL runs without xp/yp lines and TalMon writes no -tmpa.dmna file.
+AUSTAL accepts up to 20 monitor points; extras are silently dropped.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="alaqsNotaluftLabel">
+           <property name="text">
+            <string>Output Mode:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="QCheckBox" name="alaqs_notaluft_checkbox">
+           <property name="text">
+            <string>Per-hour series (NOTALUFT) — required for hourly/daily/8h analysis</string>
+           </property>
+           <property name="toolTip">
+            <string>Unchecked: AUSTAL writes only the annual mean (TA Luft compliant).
+Checked: AUSTAL writes per-hour concentration files; the result viewer can then aggregate them as hourly, 8-hour, or daily means. Disables the auto annual-mean post-processing.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
           <widget class="QLabel" name="alaqsStartDtLabel">
            <property name="text">
             <string>Start (incl.):</string>
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
+         <item row="8" column="1">
           <widget class="QDateTimeEdit" name="alaqs_start_dt_edit">
            <property name="displayFormat">
             <string>dd-MM-yyyy HH:mm</string>
@@ -356,14 +397,14 @@
            </property>
           </widget>
          </item>
-         <item row="7" column="0">
+         <item row="9" column="0">
           <widget class="QLabel" name="alaqsEndDtLabel">
            <property name="text">
             <string>End (incl.):</string>
            </property>
           </widget>
          </item>
-         <item row="7" column="1">
+         <item row="9" column="1">
           <widget class="QDateTimeEdit" name="alaqs_end_dt_edit">
            <property name="displayFormat">
             <string>dd-MM-yyyy HH:mm</string>
@@ -373,7 +414,43 @@
            </property>
           </widget>
          </item>
-         <item row="8" column="0" colspan="2">
+         <item row="10" column="0">
+          <widget class="QLabel" name="alaqsPm10FineFractionLabel">
+           <property name="text">
+            <string>PM10 fine fraction (0–1):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="1">
+          <widget class="QDoubleSpinBox" name="alaqs_pm10_fine_fraction_spinbox">
+           <property name="minimum">
+            <double>0.0</double>
+           </property>
+           <property name="maximum">
+            <double>1.0</double>
+           </property>
+           <property name="singleStep">
+            <double>0.05</double>
+           </property>
+           <property name="decimals">
+            <number>2</number>
+           </property>
+           <property name="value">
+            <double>0.9</double>
+           </property>
+           <property name="toolTip">
+            <string>Share of PM10 mass treated as the fine fraction (pm-1, &lt; 2.5 µm in AUSTAL).
+The remainder goes to pm-2 (2.5–10 µm). AUSTAL writes both as separate emission lines and sums them in pm-y00a.dmna for the PM10 result.
+
+Recommended values:
+ • 0.95 — pure aircraft/jet engine exhaust (nvPM is overwhelmingly &lt; 100 nm).
+ • 0.90 — typical airport mix (aircraft + GSE + airport vehicle exhaust).
+ • 0.70 — general road traffic including non-exhaust contributions (tyre/brake/road wear).
+ • 0.40–0.50 — non-exhaust dominated (tyre/brake wear) or fugitive dust sources.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="0" colspan="2">
           <widget class="QLabel" name="alaqsGenerationStatusLabel">
            <property name="text">
             <string>Status: Missing OpenALAQS *_out file</string>
@@ -468,14 +545,37 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="0" colspan="2">
+         <item row="3" column="0">
+          <widget class="QLabel" name="csvReceptorsLabel">
+           <property name="text">
+            <string>Receptors CSV (optional):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QgsFileWidget" name="csv_receptors_csv_path">
+           <property name="dialogTitle">
+            <string>Select receptor points CSV</string>
+           </property>
+           <property name="filter">
+            <string>CSV files (*.csv);;All files (*)</string>
+           </property>
+           <property name="toolTip">
+            <string>Optional. CSV with columns: longitude, latitude, height (optional), EPSG (optional), id (optional).
+If empty, AUSTAL runs without xp/yp lines and TalMon writes no -tmpa.dmna file.
+Without -tmpa.dmna, the Compliance Report and Plot Time Series buttons stay disabled.
+AUSTAL accepts up to 20 monitor points; extras are silently dropped.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0" colspan="2">
           <widget class="QLabel" name="pollutantLabel">
            <property name="text">
             <string>Pollutants:</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="0" colspan="2">
+         <item row="5" column="0" colspan="2">
           <layout class="QHBoxLayout" name="pollutantCheckboxLayout">
           <item>
             <widget class="QCheckBox" name="pollutant_co2">
@@ -534,14 +634,14 @@
            </item>
           </layout>
          </item>
-         <item row="5" column="0">
+         <item row="6" column="0">
           <widget class="QLabel" name="csvQualityLevelLabel">
            <property name="text">
             <string>Quality Level (1-3):</string>
            </property>
           </widget>
          </item>
-         <item row="5" column="1">
+         <item row="6" column="1">
           <widget class="QSpinBox" name="csv_quality_level_spinbox">
            <property name="minimum">
             <number>1</number>
@@ -554,28 +654,46 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="0">
+         <item row="7" column="0">
           <widget class="QLabel" name="csvMixingHeightLabel">
            <property name="text">
             <string>Include Mixing Height:</string>
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
+         <item row="7" column="1">
           <widget class="QCheckBox" name="csv_mixing_height_checkbox">
            <property name="text">
             <string>Enable Mixing Height In Output</string>
            </property>
           </widget>
          </item>
-         <item row="7" column="0">
+         <item row="8" column="0">
+          <widget class="QLabel" name="csvNotaluftLabel">
+           <property name="text">
+            <string>Output Mode:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="QCheckBox" name="csv_notaluft_checkbox">
+           <property name="text">
+            <string>Per-hour series (NOTALUFT) — required for hourly/daily/8h analysis</string>
+           </property>
+           <property name="toolTip">
+            <string>Unchecked: AUSTAL writes only the annual mean (TA Luft compliant).
+Checked: AUSTAL writes per-hour concentration files; the result viewer can then aggregate them as hourly, 8-hour, or daily means. Disables the auto annual-mean post-processing.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0">
           <widget class="QLabel" name="csvStartDtLabel">
            <property name="text">
             <string>Start (incl.):</string>
            </property>
           </widget>
          </item>
-         <item row="7" column="1">
+         <item row="9" column="1">
           <widget class="QDateTimeEdit" name="csv_start_dt_edit">
            <property name="displayFormat">
             <string>dd-MM-yyyy HH:mm</string>
@@ -585,14 +703,14 @@
            </property>
           </widget>
          </item>
-         <item row="8" column="0">
+         <item row="10" column="0">
           <widget class="QLabel" name="csvEndDtLabel">
            <property name="text">
             <string>End (incl.):</string>
            </property>
           </widget>
          </item>
-         <item row="8" column="1">
+         <item row="10" column="1">
           <widget class="QDateTimeEdit" name="csv_end_dt_edit">
            <property name="displayFormat">
             <string>dd-MM-yyyy HH:mm</string>
@@ -602,7 +720,7 @@
            </property>
           </widget>
          </item>
-         <item row="9" column="0" colspan="2">
+         <item row="11" column="0" colspan="2">
           <widget class="QLabel" name="external_files_feedback">
            <property name="text">
             <string>Status: Missing output directory, emissions CSV, and meteo CSV</string>
@@ -613,7 +731,7 @@
           </widget>
          </item>
          <!-- Grid Configuration (Nested in CSV Generation) -->
-         <item row="10" column="0" colspan="2">
+         <item row="12" column="0" colspan="2">
           <widget class="QGroupBox" name="gridManagementGroupBox">
            <property name="title">
             <string>Grid Configuration</string>
@@ -1216,6 +1334,24 @@
         </layout>
        </widget>
       </item>
+      <!-- Section separator before View Results -->
+      <item>
+       <widget class="Line" name="resultsSectionSeparator">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="resultsSectionHeaderLabel">
+        <property name="text">
+         <string>View Results</string>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">font-weight: bold; font-size: 11pt; padding: 4px 0px 2px 0px;</string>
+        </property>
+       </widget>
+      </item>
       <!-- Result Visualisation Buttons -->
       <item>
        <layout class="QHBoxLayout" name="visualisationButtonsLayout">
@@ -1234,7 +1370,7 @@
            <number>35</number>
           </property>
           <property name="text">
-           <string>Results Table</string>
+           <string>Compliance Report</string>
           </property>
          </widget>
         </item>
@@ -1278,22 +1414,22 @@
         </item>
        </layout>
       </item>
+      <!-- Status text for the receptor-dependent buttons -->
+      <item>
+       <widget class="QLabel" name="receptorResultsStatusLabel">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">color: #666; font-size: 10pt; padding: 2px 6px;</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
-   </item>
-   <!-- Stretch at bottom -->
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
       </layout>
      </widget>


### PR DESCRIPTION
## Summary

Hotfix bundle from EHRD (Rotterdam) integration testing. Five themes:

1. **AUSTAL writer** — PM10 splits into pm-1 + pm-2 (configurable fine fraction, default 0.9); PM2.5 substance code corrected; stationary writer fixed.
2. **AUSTAL reader** — pm vs pm10 filename mismatch fixed; parse errors no longer swallowed by `getA2KData`; clearer messages for missing/malformed dmna files.
3. **Receptors** — CSV picker added to both ALAQS and CSV input modes; mode-aware loader; auto-load from `shapes_receptor_points` table in ALAQS mode.
4. **Compliance Report (new)** — per-receptor PASS/FAIL evaluation against EU Directive 2024/2881 limits applicable from 1 January 2030. Threshold values verified against the official directive (Annex I, Section 1) and the EEA Air Quality Status Report 2025.
5. **UX cleanup** — button gating with explanatory tooltips, section separator, single error dialog (no more dual traceback popup), pre-action narration popups demoted to log lines.

## Commits on this branch

1. `v5.1.1: receptor handling, EU 2024/2881 compliance, AUSTAL writer/reader fixes` — the 9-file change set
2. `CHANGELOG: add v5.1.1 entry`
3. `metadata.txt: bump version to 5.1.1`

## Verification

End-to-end smoke test against EHRD .alaqs file (3588 roadways, 10 gates, 7 parking, 6 taxiways, 1 runway, 8 receptors):

- Generate AUSTAL Input Files ✓
- Run AUSTAL ✓ (~14 min runtime)
- Plot Vector Layer (annual mean) ✓
- Plot Time Series (per receptor) ✓
- Compliance Report (8 receptors × {PM10, NOx, CO}) ✓

All Python files pass AST parse; UI XML validates.

## Compliance threshold sources

- Directive (EU) 2024/2881 Annex I, Section 1: http://data.europa.eu/eli/dir/2024/2881/oj
- EEA Air Quality Status Report 2025, "Benchmark analysis against the standards in the revised directive (EU) 2024/2881"

## Reportable substances

PM10, PM2.5, NO2, NOx (ecosystem), SO2. CO/HC/CO2 explicitly excluded with an explanatory note in the dialog header — `austal.settings` `ry` values for those are AUSTAL internal scaling references, not regulatory ambient limits. CO has a 10 mg/m³ 8-hour mean limit which is not modelled by this report.

## Known limitations (worth tracking as follow-up issues)

- SO2 daily exceedance count under 2024/2881 not yet verified against the consolidated text; treated conservatively as absolute (any exceedance fails) until verified.
- Plot Vector Layer "daily mean" aggregation from per-hour files not implemented; the new error message points users to Compliance Report for daily exceedance analysis at receptors.
- CO 8-hour rolling mean not yet implemented in Compliance Report (would require a new metric type beyond annual/daily/hourly).