### PR TITLE
docs: refresh result-module and receptor handling for v5.1.1

### DIFF
--- a/documents/AUSTAL/AUSTAL_OPERATION.md
+++ b/documents/AUSTAL/AUSTAL_OPERATION.md
@@ -28,8 +28,8 @@ The second section, `inputStrategyGroupBox`. Picks where AUSTAL's input files co
 | Radio | When to use |
 |---|---|
 | **Use Existing AUSTAL Input Files** | You have a folder with hand-prepared `austal.txt` / `series.dmna` / `zeitreihe.dmna` etc. The plugin will only run AUSTAL against that folder; it will not generate anything. |
-| **Generate AUSTAL Input Files from OpenALAQS Emission Inventory File** | You have an OpenALAQS `*_out.alaqs` file from a prior emissions inventory run. The plugin generates the AUSTAL inputs from it (emissions + meteo + grid) and then runs AUSTAL. |
-| **Generate AUSTAL Input Files from CSV** | You have an emissions CSV and a meteo CSV from outside OpenALAQS. The plugin assembles AUSTAL inputs from those two files. |
+| **Generate AUSTAL Input Files from OpenALAQS Emission Inventory File** | You have an OpenALAQS `*_out.alaqs` file from a prior emissions inventory run. The plugin generates the AUSTAL inputs from it (emissions + meteo + grid) and then runs AUSTAL. Receptor points are auto-loaded from the `shapes_receptor_points` table in the `.alaqs` file, or you can override with a receptor CSV. |
+| **Generate AUSTAL Input Files from CSV** | You have an emissions CSV and a meteo CSV from outside OpenALAQS. The plugin assembles AUSTAL inputs from those two files. A receptor CSV picker is also exposed in this mode (no `.alaqs` file is involved, so receptors must come from the CSV if you want per-receptor results). |
 
 Each radio reveals its own input fields below. The status label (`existingFilesStatusLabel`, `alaqsGenerationStatusLabel`, or `external_files_feedback`) reports what's still missing - work through the gaps until it goes green.
 
@@ -61,6 +61,40 @@ There's also a **Save Grid as CSV** button (`saveGridCsvBtn`) that writes the cu
 
 ---
 
+## Receptor points, NOTALUFT, and PM10 split
+
+Three controls inside step 2 affect what AUSTAL produces and which result modules are usable afterwards.
+
+### Receptor points
+
+AUSTAL writes per-receptor time series files (`<substance>-tmpa.dmna`) only when receptor points are passed to it via `xp` / `yp` lines in `austal.txt`. The plugin builds those lines from a `GeoDataFrame` of receptors. The data comes from:
+
+- **ALAQS mode**: the **Receptors CSV** picker in the alaqs Generate sub-section first; if empty, the plugin auto-loads from the `shapes_receptor_points` table in the `.alaqs` file (filtered to `instudy != 'N'`); if that's also empty, AUSTAL runs without receptor lines.
+- **CSV mode**: the **Receptors CSV** picker in the CSV input sub-section; nothing else is checked. If the picker is empty, AUSTAL runs without receptor lines.
+
+Receptor CSV format (case-insensitive headers): `longitude`, `latitude`, optional `height` (defaults to 1.5 m), optional `EPSG` (defaults to 4326), optional `id` (label only). `lon` / `lat` are accepted as aliases.
+
+Without receptors AUSTAL still runs to completion; it produces only the grid output (`<substance>-y00a.dmna`) and Plot Vector Layer continues to work, but Plot Time Series and Compliance Report stay disabled.
+
+### NOTALUFT (per-hour series)
+
+The **NOTALUFT** checkbox on the Output Mode row tells the dispersion module to write per-hour series, producing `<substance>-NNNa.dmna` files (one per simulation hour) and the receptor time-series `<substance>-tmpa.dmna` files. Without NOTALUFT, only the annual aggregate (`-y00a.dmna`) is written.
+
+NOTALUFT is required for:
+- Plot Time Series (reads `tmpa.dmna`)
+- Compliance Report (reads `tmpa.dmna`)
+- Plot Vector Layer with `hourly` or `8-hours mean` averaging (reads `NNNa.dmna`)
+
+NOTALUFT is **not** required for Plot Vector Layer with `annual mean` averaging.
+
+### PM10 fine fraction
+
+The **PM10 fine fraction** spinbox (default 0.9) controls how PM10 emissions are split into AUSTAL's `pm-1` and `pm-2` substances when the writer expands a PM10 emission line. The default of 0.9 reflects an airport mix dominated by aircraft non-volatile PM and combustion exhaust (mostly fine particles); set lower (0.6–0.7) for studies dominated by re-suspended dust or brake wear.
+
+If PM10 is not in the selected pollutant list, the spinbox is ignored.
+
+---
+
 ## 3. Execution
 
 The third section, `runGroupBox`. One button: **Run AUSTAL** (`RunA2K`).
@@ -77,21 +111,33 @@ AUSTAL is single-threaded and CPU-bound; even modest grids take several minutes 
 
 ## 4. Result Visualisation
 
-The fourth section, `visualisationGroupBox`. Three buttons that all read from the **Results Directory** field (`resultsWorkDirectoryPath`).
+The fourth section. Three buttons grouped under a **View Results** separator, all reading from the **Results Directory** field (`resultsWorkDirectoryPath`).
 
 The Results Directory is auto-set to the work directory after a successful run. You can also point it at any other AUSTAL output folder via the **Load Existing Results** sub-section, which is how you visualise a run that finished outside this session.
 
-| Button | What it does |
-|---|---|
-| **ResultsTable** | Opens a tabular view of the per-pollutant per-time-step grid totals. No grid required - reads the `.dmna` headers directly. |
-| **VisualiseResults** | Calls `QGISVectorLayerDispersionModule`. Builds a polygon vector layer (one feature per grid cell, attribute = concentration) and adds it to the QGIS canvas. **Requires the visualisation grid** (the second grid section) to be set. |
-| **PlotTimeSeries** | Calls `TimeSeriesDispersionModule`. Plots concentration-vs-time at a single point (or averaged over the grid) in a popup chart. |
+| Button | What it does | Preconditions |
+|---|---|---|
+| **Plot Vector Layer** | Calls `ConcentrationsQGISVectorLayerOutputModule`. Builds a polygon vector layer (one feature per grid cell, attribute = concentration) and adds it to the QGIS canvas. The averaging combo selects which file is read: `annual mean` reads `<substance>-y00a.dmna`; `hourly` and `8-hours mean` aggregate `<substance>-NNNa.dmna` files (NOTALUFT required). `daily mean` is not currently implemented for the grid output. | Visualisation grid set; the `.dmna` file matching the chosen averaging period exists. |
+| **Plot Time Series** | Calls `TimeSeriesDispersionOutputModule`. Reads `<substance>-tmpa.dmna` files directly and plots concentration vs time per receptor with a smoothing combo (raw / 1h / 8h / 24h / 7d), navigation toolbar, and CSV export. | At least one `*-tmpa.dmna` file in the work directory (i.e. AUSTAL run with receptors AND NOTALUFT). |
+| **Compliance Report** | Calls `ComplianceReportOutputModule`. Per-receptor PASS/FAIL evaluation against EU Directive 2024/2881 limit values applicable from 1 January 2030. Reportable substances: PM10, PM2.5, NO2, NOx (ecosystem), SO2. CO/HC/CO2 are excluded (no formal EU ambient limits comparable to those modelled here). Each row reports value, threshold, allowed exceedances, and PASS/FAIL with colour coding. CSV export available. | Same as Plot Time Series: `*-tmpa.dmna` files present. |
 
-The status label `visualisationStatusLabel` greys these buttons out until their preconditions are met (results directory exists, grid loaded for the polygon button, etc.). Hover the label for the specific reason.
+The status label `receptorResultsStatusLabel` (under the buttons) lists which substances have receptor data available, or explains why the receptor-based buttons are disabled. Each button's tooltip gives a 3-step recipe for enabling it (add receptors, tick NOTALUFT, regenerate inputs, re-run AUSTAL).
 
 ### About the vector layer plot
 
-The polygon layer is rendered in EPSG:3857 (web mercator) so it stacks correctly with QGIS basemaps. Each cell's geometry comes from the grid you selected in the visualisation grid section; each cell's attribute value comes from the corresponding `.dmna` file. Default styling is a graduated colour ramp on the concentration field, but the layer is a normal `QgsVectorLayer` - you can edit its symbology, classify by different fields if multiple pollutants are loaded, or export it to GeoPackage from the QGIS layers panel.
+The polygon layer is rendered in the project UTM zone so cells display as true `dd × dd` m squares. Each cell's geometry comes from the grid you selected in the visualisation grid section; each cell's attribute value comes from the corresponding `.dmna` file. Default styling is a graduated colour ramp on the concentration field, but the layer is a normal `QgsVectorLayer` - you can edit its symbology, classify by different fields if multiple pollutants are loaded, or export it to GeoPackage from the QGIS layers panel.
+
+### About the compliance evaluation
+
+Threshold values are hardcoded against the official directive ([EU 2024/2881 Annex I, Section 1](http://data.europa.eu/eli/dir/2024/2881/oj)) and cross-checked with the EEA Air Quality Status Report 2025 benchmark analysis. The report header line states which directive version is in use and how many receptors / substances were evaluated. The current limit set (binding from 1 January 2030):
+
+| Substance | Annual mean (µg/m³) | Daily mean (µg/m³, max exceedances/year) | Hourly mean (µg/m³, max exceedances/year) |
+|---|---|---|---|
+| PM10 | 20 | 45 (≤18) | — |
+| PM2.5 | 10 | 25 (≤18) | — |
+| NO2 | 20 | — | 200 (≤3) |
+| NOx (ecosystem) | 30 | — | — |
+| SO2 | 20 | 50 (treated as absolute pending verification of exceedance count) | — |
 
 ---
 
@@ -101,9 +147,10 @@ The polygon layer is rendered in EPSG:3857 (web mercator) so it stacks correctly
 2. **§1**: file-pick the AUSTAL executable (one-time per machine; it persists).
 3. **§2**: pick a strategy. Most common: select **Generate from OpenALAQS Emission Inventory File**, browse to your `*_out.alaqs`, set the work directory and the time window.
 4. **§2 / Grid Configuration**: confirm the grid was inherited from the inventory file. If not, fill in the details manually.
-5. **§3**: click **Run AUSTAL**. Wait for green status.
-6. **§4 / Grid Management**: point at the same `*_out.alaqs` so the plot has a grid.
-7. **§4**: click **VisualiseResults**. The polygon layer appears on the QGIS canvas.
+5. **§2 / Receptors + NOTALUFT** *(only if you want per-receptor results)*: provide a Receptors CSV (or rely on the auto-load from `shapes_receptor_points`) and tick **NOTALUFT**.
+6. **§3**: click **Run AUSTAL**. Wait for green status.
+7. **§4 / Grid Management**: point at the same `*_out.alaqs` so the plot has a grid.
+8. **§4**: click **Plot Vector Layer** (annual mean concentration map), or, if you ran with NOTALUFT + receptors, **Plot Time Series** / **Compliance Report**.
 
 ---
 
@@ -111,7 +158,9 @@ The polygon layer is rendered in EPSG:3857 (web mercator) so it stacks correctly
 
 - **`No Executable Loaded` even after picking the file** - the file picker doesn't accept anything not named `austal.exe` or `austal`. If you have `austal_3.3.exe`, rename it.
 - **Run completes but the `.dmna` files are missing** - check that the AUSTAL installation has the `austal.settings` file from this OpenALAQS folder copied in. The default `austal.settings` shipped with AUSTAL writes to a different output schema and the plugin won't find the results.
-- **`VisualiseResults` button stays disabled** - the visualisation grid (`alaqsGridGroupBox`) is unset. The execution grid and the visualisation grid are independent fields; both must be filled, even when they point at the same file.
+- **`Plot Vector Layer` button stays disabled** - the visualisation grid (`alaqsGridGroupBox`) is unset. The execution grid and the visualisation grid are independent fields; both must be filled, even when they point at the same file.
+- **`Plot Time Series` and `Compliance Report` stay disabled** - no `*-tmpa.dmna` files in the work directory. Both modules need receptors AND NOTALUFT set before the AUSTAL run; if either was missing, only the grid output (`-y00a.dmna`) was produced. The status label below the buttons names the missing piece. Re-run with both controls set.
+- **Plot Vector Layer fails with "can't aggregate to '<period>'"** - you selected an averaging period (daily / hourly / 8-hours) that the file's time interval doesn't support. Switch the averaging combo to `annual mean` for grid plotting; for hourly/daily analysis use Plot Time Series or Compliance Report at receptor points.
 - **Polygons appear in the wrong place on the map** - the visualisation grid does not match the run's grid. AUSTAL output cells are indexed; if you give the plotter a different reference lat/lon or cell size, it will draw cells at the wrong coordinates. Re-select the same `*_out.alaqs` for both grid sections.
 - **Run takes hours and you're not sure it's progressing** - check the AUSTAL log file in the work directory. AUSTAL writes progress to `austal.log` (or similar) as it iterates over time steps; if the file is growing, the run is alive.
 
@@ -123,15 +172,18 @@ In the work directory after a green run:
 
 ```
 work/
-├── austal.txt              # input file the plugin generated (or yours, if "use existing")
-├── series.dmna             # time-resolved emission series
-├── zeitreihe.dmna          # meteo time series (only if generated by plugin)
-├── work/                   # AUSTAL's own output sub-folder
-│   ├── austal.log          # run log
-│   ├── pollutant-001.dmna  # per-pollutant per-period grid result
-│   ├── pollutant-002.dmna
+├── austal.txt                 # input file the plugin generated (or yours, if "use existing")
+├── series.dmna                # time-resolved emission series
+├── zeitreihe.dmna             # meteo time series (only if generated by plugin)
+├── work/                      # AUSTAL's own output sub-folder
+│   ├── austal.log             # run log
+│   ├── <substance>-y00a.dmna  # annual-mean grid (always produced)
+│   ├── <substance>-NNNa.dmna  # per-hour grid (NNN = hour index, NOTALUFT only)
+│   ├── <substance>-tmpa.dmna  # per-receptor time series (receptors + NOTALUFT only)
 │   └── ...
-└── meta.txt                # OpenALAQS-emitted run metadata
+└── meta.txt                   # OpenALAQS-emitted run metadata
 ```
+
+`<substance>` is the AUSTAL substance code (e.g. `co`, `nox`, `pm`, `pm25`, `so2`). The plugin writes `pm` for PM10 (split into `pm-1` + `pm-2` internally) and `pm25` for PM2.5; the readers map back automatically.
 
 The visualisation buttons read from `work/` (the inner one). If you move the folder, point the Results Directory at the new location and the same buttons will still work.

--- a/documents/USER_GUIDE.md
+++ b/documents/USER_GUIDE.md
@@ -519,13 +519,16 @@ The connection of OpenALAQS with AUSTAL was realized based on the existing archi
 
 ### [Input data](#input-data)
 
-The dispersion module will only be activated if the `Is Enabled` checkbox is checked. By default, this checkbox is unchecked. Once enabled, the user must select one of the output modules (`View Emissions Table`, `Plot Time Series`, or `Plot Vector Layer`).
+The dispersion module will only be activated if the `Is Enabled` checkbox is checked. By default, this checkbox is unchecked.
 
 The following parameters need to be defined:
 + **Roughness Length**: Height above ground where wind speed theoretically becomes zero. Depends on terrain type (e.g., forests, urban areas, flat fields).
 + **Displacement Height**: Height at which the wind profile starts to be affected by obstacles on the ground, such as buildings or trees.
 + **Anemometer Height**: Height at which wind speed measurements are taken. Default: 10 m.
 + **Quality Level**: Determines the number of simulation particles (range: −4 to +4). Higher values increase accuracy but also computation time.
++ **NOTALUFT** (per-hour series): when enabled, AUSTAL writes per-hour grid output (`<substance>-NNNa.dmna`) and, when receptor points are configured, per-receptor time-series files (`<substance>-tmpa.dmna`). Required for **Plot Time Series** and **Compliance Report**; optional for **Plot Vector Layer** with `annual mean`.
++ **PM10 fine fraction**: how PM10 emissions are split between AUSTAL's `pm-1` and `pm-2` substances (default 0.9, suitable for an airport mix dominated by aircraft non-volatile PM and combustion exhaust).
++ **Receptor Points**: Specify receptor points using a `.csv` file. In ALAQS mode the plugin will also auto-load any receptors defined in the `shapes_receptor_points` table of the `.alaqs` file if no CSV is given. Without receptors AUSTAL still produces grid output, but Plot Time Series and Compliance Report stay disabled.
 + **Options String**:
   + `NOSTANDARD`: Activates non-standard calculation configurations.
   + `SCINOTAT`: Forces output in scientific notation with four significant decimal places.
@@ -548,17 +551,29 @@ By default, a file named `austal.log` is generated at the end of the dispersion 
 
 ### [Output data](#output-data)
 
-AUSTAL calculates substance-specific annual means and possibly daily or hourly means with a given number of exceedances. The annual mean is the mean over the time period defined by the provided file `series.dmna`.
+AUSTAL calculates substance-specific annual means and, when run with NOTALUFT, also per-hour means (used by the plugin to derive daily / hourly / 8-hour aggregates and per-receptor time series).
 
-For example, the annual mean concentration file for HC is `hc-y00a.dmna` ('00' refers to the grid, 'a' refers to additional load). The statistical uncertainty is provided in the corresponding file `hc-y00s.dmna`. Concentrations are in micrograms per cubic metre.
+| File pattern | When written | Read by |
+|---|---|---|
+| `<substance>-y00a.dmna` | Always | Plot Vector Layer (annual mean) |
+| `<substance>-NNNa.dmna` | NOTALUFT enabled | Plot Vector Layer (hourly / 8-hour mean) |
+| `<substance>-tmpa.dmna` | NOTALUFT + receptors | Plot Time Series, Compliance Report |
+| `<substance>-y00s.dmna` | Always | Statistical uncertainty companion to `y00a` |
+
+For example, the annual-mean concentration for HC is `hc-y00a.dmna` ('00' refers to the grid; 'a' refers to additional load). The statistical uncertainty is in `hc-y00s.dmna`. Concentrations are in micrograms per cubic metre.
 
 By default, the concentration file only contains the ground layer (K=1). Using the `NOSTANDARD` option, more layers can be written out (e.g. `NOSTANDARD;Kmax=3` in `austal.txt`).
 
+The plugin's substance codes follow AUSTAL convention: `pm` for PM10 (which AUSTAL internally splits into `pm-1` and `pm-2`), `pm25` for PM2.5, lowercase enum value for the rest.
+
 ### [Visualize results](#visualize-results)
 
-To explore the results of a simulation, the user must select the OpenALAQS file used for the calculation (to ensure the exact grid and date are applied), and then choose one of the output modules:
-+ **Visualise Results** as a vector layer
-+ **Plot Time Series** to display results as a time series
-+ **Results Table** to view results in table format
+After a successful AUSTAL run, three result modules are available under the **View Results** section:
+
++ **Plot Vector Layer** — spatial concentration map on the AUSTAL grid. The averaging combo selects which `.dmna` file is read: `annual mean` always works; `hourly` and `8-hours mean` require NOTALUFT.
++ **Plot Time Series** — concentration vs time at a chosen receptor point, with smoothing combo (raw / 1h / 8h / 24h / 7d), navigation toolbar, and CSV export. Requires NOTALUFT + receptors.
++ **Compliance Report** — per-receptor PASS/FAIL evaluation against EU Directive 2024/2881 limit values applicable from 1 January 2030 (PM10, PM2.5, NO2, NOx ecosystem, SO2). Each row reports value, threshold, allowed exceedances, and PASS/FAIL with colour coding. CSV export available. Requires NOTALUFT + receptors.
+
+The status label below the buttons lists which substances have receptor data available, or names the missing piece (no receptors / no NOTALUFT / no AUSTAL output yet) when a button is disabled. Each button's tooltip gives the exact 3-step recipe.
 
 ![running-austal-2.png](./../open_alaqs/assets/running-austal-2.png)

--- a/scripts/austal_from_csv/README.md
+++ b/scripts/austal_from_csv/README.md
@@ -140,6 +140,10 @@ The CSV must have a header row with columns: `x_cells`, `y_cells`, `z_cells`, `x
 
 Boolean keys accept (case-insensitive): `True`, `1`, `yes` for true; anything else is treated as false.
 
+### Receptors (not supported by this script)
+
+The QGIS plugin (v5.1.1+) supports receptor points and writes per-receptor `<substance>-tmpa.dmna` files when AUSTAL is run with both receptors and NOTALUFT. **The standalone script does not currently expose this feature** and runs AUSTAL with grid-only output. As a result, the `Plot Time Series` and `Compliance Report` views in the plugin will not have data to read for runs produced by this script. Receptor support in the standalone script is planned for a future release. If you need per-receptor results for an external emissions CSV, drive the run from the QGIS plugin (the **Generate AUSTAL Input Files from CSV** input mode also exposes a Receptors CSV picker).
+
 ---
 
 ## Input CSV Formats


### PR DESCRIPTION
AUSTAL_OPERATION.md
- Receptor CSV note in 'Generate from CSV' input-mode row
- New section 'Receptor points, NOTALUFT, and PM10 split' covering the three new controls in step 2 and what they enable downstream
- Section 4 rewritten around the three current result buttons (Plot Vector Layer, Plot Time Series, Compliance Report) with explicit preconditions for each
- New 'About the compliance evaluation' subsection with the EU 2024/2881 threshold table
- Typical session flow adds the optional receptor + NOTALUFT step
- Failure modes refreshed for the current button set
- 'Files written by a successful run' lists -y00a / -NNNa / -tmpa patterns and the substance code mapping (PM10 -> pm, PM2.5 -> pm25)

USER_GUIDE.md
- AUSTAL Input data section: adds NOTALUFT, PM10 fine fraction, receptor points entries
- Output data section: rewritten with file-pattern table mapping each .dmna pattern to the read modules
- Visualize results section: rewritten around Plot Vector Layer, Plot Time Series, Compliance Report with their preconditions

scripts/austal_from_csv/README.md
- New 'Receptors (not supported by this script)' subsection documenting that receptor support is GUI-only in v5.1.1; the standalone script writes grid-only output. Points users at the plugin's CSV input mode for receptor-driven runs.