### PR TITLE
docs: Tier 1 audit fixes for BFFM2, USER_GUIDE, TEST_CASE_STUDY

### DIFF
--- a/documents/BFFM2_validation/BFFM2.md
+++ b/documents/BFFM2_validation/BFFM2.md
@@ -66,42 +66,32 @@ The BFFM2 calculation for a single profile segment proceeds in six steps. Steps 
 
 The power setting `P` (a dimensionless fraction from 0 to 1, where 1 = maximum takeoff thrust) is converted to a reference fuel flow `Wf_ref` at ICAO SLS conditions (T = 288.15 K, p = 101 325 Pa, M = 0) using one of the two interpolation methods described in [Fuel flow interpolation methods](#fuel-flow-interpolation-methods).
 
-Both methods are bounded from below by the idle (TX) fuel flow:
+The twin-quadratic method applies an idle floor clamp only at very low power settings:
 
 ```
-Wf_ref = max(interpolated_value, Wf_TX)
+if P < 0.07:
+    Wf_ref = max(parabola_value, Wf_TX)
 ```
 
-This prevents physically impossible sub-idle values from the quadratic fit at very low power settings.
+For P ≥ 0.07 the twin-quadratic value is used directly; the parabola passes through `(0.07, Wf_TX)` by construction, so the unclamped value rarely goes sub-idle in practice. The anchor method has no idle clamp.
 
 ---
 
-##### Step 2 — Convert to ambient fuel flow
+##### Step 2 — Convert to BFFM2 reference fuel flow
 
-The reference fuel flow is corrected for actual ambient conditions using the ICAO correction factors θ (temperature ratio) and δ (pressure ratio):
+The per-engine ambient fuel flow `Wf_amb` (from Step 1, or supplied directly via ADS-B's `fuel_flow_kgm` column) is projected to BFFM2 reference fuel flow using the CAEP14 universal correction:
 
 ```
 θ = T_amb / 288.15
 δ = p_amb / 101 325
+M = TAS / SOS
 
-Wf_amb = Wf_ref × δ / √θ
-```
-
-`Wf_amb` is the per-engine ambient fuel flow in kg/s. This is the value used both for the log–log interpolation in Step 3 and for computing fuel burned in Step 6.
-
-The Mach number correction to the reference fuel flow is applied *inside* the BFFM2 interpolation (Step 3) rather than here, consistent with SAE AIR-5715:
-
-```
 Wf_ref_BFFM2 = (Wf_amb / δ) × θ^3.8 × exp(0.2 × M²)
 ```
 
-where M is the True Mach number at the start of the segment:
+where `SOS = 331.3 + 0.606 × (T_amb − 273.15) m/s` is the speed of sound at ambient temperature, and M is the true Mach number at the start of the segment.
 
-```
-M = (TAS / SOS) × √(288.15 / T_amb)
-```
-
-and SOS = 331.3 + 0.606 × (T_amb − 273.15) m/s.
+`Wf_ref_BFFM2` is the value used for the log–log interpolation in Step 3. CAEP14 prescribes this universal form for all flight phases; the older ICAO Doc 9889 Appendix 2 decomposition (separate `δ/√θ` ambient correction at LTO only, followed by a Mach correction at high altitude) is not used. See the inline comment at `bffm2.py:79-81` for the rationale.
 
 ---
 
@@ -116,7 +106,7 @@ log10(EI) = log10(EI_i) + [log10(EI_{i+1}) - log10(EI_i)] ×
              [log10(Wf) - log10(Wf_i)] / [log10(Wf_{i+1}) - log10(Wf_i)]
 ```
 
-**CO special handling.** The CO log–log curve is non-monotonic: CO EI is high at idle, drops steeply to a minimum (the "Lean Azeotropic Value", LAV) near the Approach–Climbout boundary, and then remains approximately flat through Climbout and Takeoff. OpenALAQS detects whether the CO curve has this standard shape and, if so, applies a horizontal segment at the LAV once the fuel flow exceeds the AP–CL intersection point. For engines where this standard shape is not detected, a simple linear interpolation is used throughout.
+**CO / HC special handling.** The CO and HC log–log curves are non-monotonic: EI is high at idle, drops steeply through Approach, and remains approximately flat through Climbout and Takeoff. OpenALAQS applies the CAEP14 v14 "HC_CO Slope To Mean Value" rule: for any fuel flow above the Approach anchor, the EI is snapped to `lin_av`, the linear average of the Climbout and Takeoff anchor EIs. This produces a step discontinuity at the Approach boundary. For engines where the standard shape is not detected (non-monotonic decrease from idle to approach), a simple linear interpolation is used throughout.
 
 **Extrapolation capping.** If `Wf_ref_BFFM2` falls below the idle breakpoint, the idle EI is used. If it exceeds the takeoff breakpoint, the takeoff EI is used. No extrapolation beyond the EEDB range is performed.
 
@@ -130,10 +120,10 @@ The raw interpolated EI is corrected for ambient conditions:
 
 ```
 h = −19 × (ω − 0.00634)           # humidity coefficient; ω in kg H₂O / kg dry air
-EI_NOx_corr = EI_NOx × exp(h) × (δ^x / θ^3.3)^0.5
+EI_NOx_corr = EI_NOx × exp(h) × (δ^1.02 / θ^3.3)^0.5
 ```
 
-where `x = 1.0` (default P₃T₃ exponent) and `ω` is the specific humidity, computed from relative humidity `RH`, ambient temperature and pressure if not provided directly:
+where `ω` is the specific humidity, computed from relative humidity `RH`, ambient temperature and pressure if not provided directly:
 
 ```
 p_sat = 6.107 × 10^(7.5 × T_C / (237.3 + T_C))   [mbar; T_C in °C]
@@ -145,8 +135,8 @@ At the ICAO reference humidity (ω = 0.00634 kg/kg), `exp(h) = 1` and the humidi
 **CO and HC** (temperature and pressure correction only):
 
 ```
-EI_CO_corr  = EI_CO  × (θ^3.3 / δ^1.0)
-EI_HC_corr  = EI_HC  × (θ^3.3 / δ^1.0)
+EI_CO_corr  = EI_CO  × (θ^3.3 / δ^1.02)
+EI_HC_corr  = EI_HC  × (θ^3.3 / δ^1.02)
 ```
 
 ---
@@ -157,7 +147,7 @@ BFFM2 does not interpolate PM or SOx on a gas-phase log-log curve. Instead, afte
 
 - **`pm10_g_kg`** = `pm10_ei` (total combustion PM10: nonvol + sulphate + organic)
 - **`pm10_nonvol_g_kg`** = `pm10_nonvol`, subject to MEEM V1 ambient correction (see [MEEM V1](#meem-v1--nvpm-ambient-correction))
-- **`pm10_sul_g_kg`** = `pm10_sul` (36.75 mg/kg constant)
+- **`pm10_sul_g_kg`** = `pm10_sul` (~0.04896 g/kg stored value; back-calculates to FSC ≈ 667 ppm with ε = 0.024)
 - **`pm10_organic_g_kg`** = `pm10_organic`
 - **`nvpm_number_kg`** = `nvpm_number_ei`, subject to MEEM V1 number correction
 - **`sox_g_kg`** = `sox_ei` (1.0 g/kg for jet fuel)
@@ -214,7 +204,7 @@ The four EEDB breakpoints are connected by three straight line segments in P–W
 
 This is the interpolation assumed in the ICAO CAEP14 BFFM2 reference calculator and produces results that are generally within 1–2% of the twin-quadratic values for standard EHRD movements.
 
-> **Note.** For power settings below 7% (P < 0.07), both methods return the TX idle fuel flow (idle floor clamp). For P > 1.0, the TO fuel flow is returned.
+> **Note.** For P < 0.07 the twin-quadratic method applies `max(parabola_value, Wf_TX)`. For 1.0 < P ≤ 1.05 the power setting is clamped to 1.0 (with a logged warning) and the high-range parabola is evaluated, effectively returning the TO fuel flow. For P > 1.05 a `ValueError` is raised — the method does **not** silently return TO.
 
 ---
 
@@ -222,7 +212,7 @@ This is the interpolation assumed in the ICAO CAEP14 BFFM2 reference calculator 
 
 Engine installation in the airframe causes small losses in net thrust and slight changes in fuel flow relative to the bare-engine values measured on the EEDB test stand. BFFM2 accounts for this by multiplying the EEDB reference fuel flow breakpoints by mode-specific installation correction factors *before* the log–log interpolation. This shifts the interpolation x-axis breakpoints without changing the EI y-axis values.
 
-OpenALAQS applies the following default correction factors from SAE AIR-5715:
+OpenALAQS applies the following default correction factors (CAEP14 default; originally from SAE AIR-5715):
 
 | LTO mode | Installation correction factor |
 |----------|-------------------------------|
@@ -304,7 +294,7 @@ For the EHRD test case:
 
 **CO: BFFM2 is higher for arrivals, similar for departures**
 
-The EEDB CO curve is U-shaped: high at idle (~20–24 g/kg), dropping to a minimum (LAV ~0.2–0.6 g/kg) near Climbout/Takeoff power. Near-idle approach segments get CO EI ≈ idle level in BFFM2, whereas bymode uses the lower AP value (~2–4 g/kg). For departures, both methods give similar CO because most departure segments are at or near TO/CL power where CO EI is at the LAV floor. HC follows the same qualitative pattern.
+The EEDB CO curve is U-shaped: high at idle (~20–24 g/kg), dropping to a minimum (`lin_av` ~0.2–0.6 g/kg) near Climbout/Takeoff power. Near-idle approach segments get CO EI ≈ idle level in BFFM2, whereas bymode uses the lower AP value (~2–4 g/kg). For departures, both methods give similar CO because most departure segments are at or near TO/CL power where CO EI is at the `lin_av` floor. HC follows the same qualitative pattern.
 
 | Movement type | Typical CO: BFFM2 vs Bymode |
 |---------------|------------------------------|
@@ -346,7 +336,7 @@ The BFFM2 implementation is spread across the following files:
 
 | File | Role |
 |------|------|
-| `core/tools/bffm2.py` | Core formula: ambient corrections, log–log interpolation, CO LAV logic, installation corrections |
+| `core/tools/bffm2.py` | Core formula: ambient corrections, log–log interpolation, CO/HC slope-to-mean-value logic, installation corrections |
 | `core/tools/twin_quadratic_fit_method.py` | Power setting → reference fuel flow via twin-quadratic polynomial (Step 1, ALAQS default) |
 | `core/tools/meem_v1.py` | MEEM V1 nvPM ambient correction: ISA/ambient P3 computation, F_GR conversion, 5-point interpolation |
 | `core/interfaces/Engine.py` (`EngineEmissionIndex` class) | Orchestrates Steps 1–5: twin-quad call, ambient correction, cache, call to `bffm2.py`; `getEmissionIndexByModeWithMEEM()` applies MEEM V1 |
@@ -380,7 +370,7 @@ MovementSourceModule.calculate_emissions()
             ▼
             for each (start_point_, end_point_) in trajectory.getPointPairs():
                 │
-                ├── Mach = TAS / SOS × √(288.15 / T_amb)
+                ├── Mach = TAS / SOS
                 ├── method['config'].update({'mach_number': Mach})
                 │
                 ├── engine_thrust = start_point_.getEngineThrust()
@@ -427,7 +417,7 @@ MovementSourceModule.calculate_emissions()
 | `default_aircraft_engine_ei` | `fuel_kg_sec` | EEDB reference fuel flow (kg/s per engine, SLS) |
 | `default_aircraft_engine_ei` | `nox_ei`, `co_ei`, `hc_ei` | EEDB emission indices (g/kg) |
 | `default_aircraft_engine_ei` | `pm10_nonvol` | nvPM mass EI (g/kg) |
-| `default_aircraft_engine_ei` | `pm10_sul` | Sulphate vPM EI (g/kg); 36.75 mg/kg constant |
+| `default_aircraft_engine_ei` | `pm10_sul` | Sulphate vPM EI (g/kg); ~0.04896 g/kg stored constant (FSC ≈ 667 ppm, ε = 0.024) |
 | `default_aircraft_engine_ei` | `pm10_organic` | Organic vPM EI (g/kg) |
 | `default_aircraft_engine_ei` | `pm10_ei` | Total PM10 EI = nonvol + sul + organic (g/kg) |
 | `default_aircraft_engine_ei` | `p1_ei`, `p2_ei` | PM1.0 / PM2.5 placeholders; currently = `pm10_ei` |

--- a/documents/TEST_CASE_STUDY.md
+++ b/documents/TEST_CASE_STUDY.md
@@ -45,12 +45,12 @@ This guide walks through a complete OpenALAQS study using **Rotterdam The Hague 
 
 | File | Description |
 |---|---|
-| `training_movements.csv` | Aircraft movements table (12 movements across 3 days) |
-| `training_meteo.csv` | Hourly meteorological data (3 days × 25 hourly records) |
+| `training_movements.csv` | Aircraft movements table (13 movements across 3 days) |
+| `training_meteo.csv` | Hourly meteorological data (75 hourly records, covering 2025-12-01 00:00 through 2025-12-04 00:00) |
 | `training.alaqs` | Pre-built study database (starting point) |
 | `training_out.alaqs` | Completed output file (reference result) |
 
-The study covers three days of operations at EHRD: 12 aircraft movements across three gates and two runway directions, combined with representative stationary sources (parking lot, roadway, power plant, terminal building). All movements use standard ANP profiles from the internal database.
+The study covers three days of operations at EHRD: 13 aircraft movements across three gates and two runway directions, combined with representative stationary sources (parking lot, roadway, power plant, terminal building). Twelve movements use standard ANP profiles from the internal database; one movement uses a CUSTOM ADS-B-derived profile (`1677686160_DIETB`) to illustrate the trajectory override mechanism.
 
 ---
 
@@ -73,7 +73,7 @@ The **ALAQS Project Properties** window opens automatically. Fill in the followi
 | Country | NL |
 | Latitude | 51.96 |
 | Longitude | 4.44 |
-| Elevation (m) | 0 |
+| Elevation (m) | -15 |
 
 Once you enter the ICAO code `EHRD`, the remaining airport fields are populated automatically from the internal database. You can adjust them if needed.
 
@@ -179,7 +179,7 @@ Draw each taxiway segment as a linestring along the taxiway centreline. Use snap
 
 ##### Tracks
 
-For all six EHRD movements, standard ANP profiles from `default_aircraft_profiles` are used — no custom tracks are required. The profile IDs are referenced directly in the movements table via `profile_id`. The Tracks layer in OpenALAQS is only needed when using custom ADS-B-derived trajectories with `course = CUSTOM`; it is not used in this study.
+Twelve of the thirteen EHRD movements use standard ANP profiles from `default_aircraft_profiles`. One movement (row 11, A20N departure on day 3) uses the CUSTOM ADS-B-derived profile `1677686160_DIETB` to illustrate the trajectory override mechanism. Profile IDs are referenced directly in the movements table via `profile_id`; the Tracks layer is not used in this study since CUSTOM profiles are read from `default_aircraft_profiles`, not from the Tracks layer.
 
 ---
 
@@ -334,7 +334,7 @@ Taxi routes define the sequence of taxiway segments an aircraft follows between 
 
 For each route, select the **Gate**, **Runway direction**, and **Operation type** (Arrival or Departure), then choose the ordered sequence of taxiway segment names. Finally, select the **aircraft groups** that use this route (for EHRD all groups share the same routes).
 
-Create the following three taxi routes for this study:
+Create six taxi routes for this study — one arrival and one departure variant for each of the three gates G2, G4, G7. Three are detailed below as representative examples; create the other three (G2 arrival, G4 departure, G7 departure) by analogous taxiway-segment selection. The `training_movements.csv` file references all six route names.
 
 **Route G4/24/A/1** — Arrivals from runway 24 to gate G4
 
@@ -369,7 +369,7 @@ Create the following three taxi routes for this study:
 | Taxiway sequence | K → R → T → F → D → U → P |
 | Aircraft groups | All |
 
-> **Note:** Departure movements to runway 06 at EHRD follow the same physical route as departures to runway 24 on the ground (EHRD has a single runway). The runway direction `06` or `24` only affects the LTO flight profile — the taxiway route is the same. Reference `G2/24/D/1` in the movements table for all departures regardless of runway direction.
+> **Note:** EHRD has a single physical runway with directions 06 and 24. Departures to runway 06 follow the same ground path as departures to runway 24; the runway designator affects only the LTO flight profile, not the taxiway route. Each gate still gets its own arrival and departure routes because aircraft enter and exit the gate area along different segments.
 
 #### Create output file
 
@@ -414,61 +414,60 @@ Click **Generate** to create `training_out.alaqs`. This file copies all source d
 
 #### Movements table
 
-The file `training_movements.csv` (semicolon-delimited) defines the 12 aircraft movements in this study. Movements span 2025-12-01 to 2025-12-03.
+The file `training_movements.csv` (semicolon-delimited) defines the 13 aircraft movements in this study, spanning 2025-12-01 06:05 through 2025-12-03 08:05. The table below shows five representative rows; consult the file directly for the complete set.
 
-| OID | Aircraft | Engine | D/A | Gate | Runway | Runway time | Block time | Profile | Taxi route |
-|---|---|---|---|---|---|---|---|---|---|
-| 1 | A20N | LEAP-1A26 | A | G4 | 24 | 06:05 | 06:10 | JET-SMALL-A-1 | G4/24/A/1 |
-| 2 | A20N | LEAP-1A26 | A | G7 | 24 | 06:15 | 06:20 | JET-SMALL-A-1 | G7/24/A/1 |
-| 3 | A21N | PW1133G | D | G2 | 06 | 06:40 | 06:35 | JET-SMALL-D-2 | G2/24/D/1 |
-| 11 | A21N | PW1133G | D | G2 | 06 | 06:41 | 06:36 | JET-SMALL-D-6 | G2/24/D/1 |
-| 12 | E75L | CF34-8E5 | D | G2 | 06 | 06:45 | 06:40 | JET-MEDIUM-D-2 | G2/24/D/1 |
-| 14 | E75L | CF34-8E5 | D | G2 | 06 | 06:50 | 06:45 | JET-MEDIUM-D-2 | G2/24/D/1 |
+| # | runway_time | aircraft | gate | op | runway | engine | profile_id | taxi route |
+|---|---|---|---|---|---|---|---|---|
+| 1 | 2025-12-01 06:05 | A20N | G4 | A | 24 | 01P20CM128 (LEAP-1A26) | JET-SMALL-A-1 | G4/24/A/1 |
+| 2 | 2025-12-01 06:15 | A20N | G4 | D | 24 | 01P20CM128 (LEAP-1A26) | JET-SMALL-D-1 | G4/24/D/1 |
+| 3 | 2025-12-01 06:40 | E190 | G7 | A | 24 | 11GE144 (CF34-10E) | JET-REGIONAL-A-1 | G7/24/A/1 |
+| 8 | 2025-12-02 07:30 | E190 | G4 | D | 06 | 11GE144 (CF34-10E) | JET-REGIONAL-D-1 | G4/24/D/1 |
+| 11 | 2025-12-03 07:00 | A20N | G2 | D | 24 | 01P20CM128 (LEAP-1A26) | **1677686160_DIETB** (CUSTOM) | G2/24/D/1 |
 
 Key observations:
 
-- **OIDs 1–2** are A320neo (A20N) arrivals via runway 24 with a 5-minute taxi-in time each.
-- **OIDs 3 and 11** are A321neo (A21N / PW1133G) departures using two different ANP departure profiles: JET-SMALL-D-2 and JET-SMALL-D-6. These profiles have different runway distance schedules (D-2 is a shorter-field profile, D-6 represents a longer takeoff roll), resulting in measurable differences in NOx and CO when calculated with BFFM2.
-- **OIDs 12 and 14** are E175 (E75L / CF34-8E5) departures, both using JET-MEDIUM-D-2.
-- **All departures** have taxi time = 5 minutes (block_time to runway_time difference).
-- `apu_code = 0` for all movements — APU emissions are excluded from this study.
+- **Aircraft mix.** Two ICAO types: A20N (Airbus A320neo, JET SMALL, 8 movements) and E190 (Embraer ERJ-190, JET REGIONAL, 5 movements). Each is paired with its default engine: `01P20CM128` (CFM LEAP-1A26) and `11GE144` (CF34-10E) respectively.
+- **Profile mix.** Twelve movements use standard ANP profiles (`JET-SMALL-A-1`, `JET-SMALL-D-1`, `JET-REGIONAL-A-1`, `JET-REGIONAL-D-1`). Row 11 uses the CUSTOM ADS-B profile `1677686160_DIETB` — same A20N aircraft, but the trajectory is overridden by the CUSTOM points from `default_aircraft_profiles`.
+- **Operation split.** 7 arrivals, 6 departures, distributed across the three days. Each day's activity is clustered in the early-morning hours.
+- **Runway direction.** Most movements use runway 24; three rows (6, 8, 13) use runway 06.
+- **APU and gate emissions suppressed.** All 13 rows have `apu_code = 0` and `gate_emissions_code = 0`, so APU and gate (GSE/GPU/MES) emissions are excluded in this study. This isolates the aircraft trajectory contribution for comparison against the bymode/BFFM2 methodology output.
 
-**Exercise — ANP profile variant comparison:** Compare NOx emissions for OID 3 (JET-SMALL-D-2) against OID 11 (JET-SMALL-D-6) for the same A21N/PW1133G aircraft and engine. With the BFFM2 method, the two profiles will show different NOx and CO totals because they have different power schedule distributions across the LTO altitude range. JET-SMALL-D-6 has a longer climbout section at elevated thrust, typically resulting in higher BFFM2 NOx compared to D-2.
+The movements table supports many optional fields. For this study all optional fields (other than `apu_code` and `gate_emissions_code`, which are explicitly 0) are left empty, which causes the calculator to apply defaults:
 
-The movements table supports many optional fields. For this study all optional fields are left empty, which causes the calculator to apply defaults:
-
-| Optional field | Default applied |
+| Optional field | Default applied when empty |
 |---|---|
 | `engine_name` | Most representative engine for the aircraft type |
 | `engine_thrust_level_for_taxiing` | 0.07 (7% thrust, ICAO idle) |
 | `taxi_engine_count` | All engines operating |
-| `apu_code` | 0 (no APU) |
-| `gate_emissions_code` | 1 (GSE, GPU and MES included) |
+| `tow_ratio` | 1.0 |
+| `number_of_stop_and_gos` | 0 |
+
+Note that the *system* default for `gate_emissions_code` when the field is empty is **1** (gate emissions enabled), but this study explicitly overrides it to **0** for every row.
 
 #### Meteorology
 
-The file `training_meteo.csv` provides 75 hourly records (3 days × 25 records each) covering 2025-12-01 through 2025-12-03. The format uses semicolons as delimiters and the following columns:
+The file `training_meteo.csv` provides 75 hourly records covering 2025-12-01 00:00 through 2025-12-04 00:00. The format is comma-delimited with the following columns:
 
 ```
-Scenario ; DateTime(YYYY-mm-dd hh:mm:ss) ; Temperature(K) ; Humidity(kg_water/kg_dry_air) ;
-RelativeHumidity(%) ; SeaLevelPressure(mb) ; WindSpeed(m/s) ; WindDirection(degrees) ;
-ObukhovLength(m) ; MixingHeight(m)
+Scenario, DateTime(YYYY-mm-dd hh:mm:ss), Temperature(K), Humidity(kg_water/kg_dry_air),
+RelativeHumidity(0-1), SeaLevelPressure(Pa), WindSpeed(m/s), WindDirection(degrees),
+ObukhovLength(m), MixingHeight(m)
 ```
 
-Representative values for the 06:00 hour used in this study:
+Representative values for the 06:00 hour on 2025-12-01:
 
 | Parameter | Value |
 |---|---|
 | Temperature | 280.5 K (7.35 °C) |
-| Specific humidity | 0.00634 kg/kg |
-| Relative humidity | 0.68 (68%) |
+| Specific humidity | 0.00446 kg/kg |
+| Relative humidity | 0.68 |
 | Pressure | 97 600 Pa |
 | Wind speed | 5 m/s |
 | Wind direction | 225° (SW) |
 | Obukhov length | 99 999 m (neutral stability) |
 | Mixing height | 914.4 m |
 
-The `Humidity` column (specific humidity) takes priority over `RelativeHumidity` when both are provided. For the BFFM2 ambient corrections, the specific humidity of 0.00634 kg/kg equals the ISA reference day humidity, so the NOx humidity correction factor is 1.0 for this dataset.
+The `Humidity` column (specific humidity) takes priority over `RelativeHumidity` when both are provided. The specific humidity of 0.00446 kg/kg is **below** the ISA reference day humidity (0.00634 kg/kg), so the BFFM2 NOx humidity correction factor is **less than 1.0** for this dataset — drier air shifts NOx emission indices downward.
 
 If the meteorology file is omitted, OpenALAQS falls back to ISA default conditions (T = 288.15 K, P = 101 325 Pa, H = 0.00634 kg/kg).
 
@@ -502,7 +501,7 @@ Click **Visualize Emission Calculation** in the toolbar and browse to `training_
    - BFFM2 gives 20–50% lower NOx for arrivals (actual approach power is far below the 30% AP mode assumption).
    - BFFM2 gives 15–30% higher CO for arrivals (near-idle approach power has high CO EI).
 
-3. **ANP profile variant comparison** — select *MovementSource*, filter to OID 3 vs OID 11 (both A321neo/PW1133G departures with different ANP profiles). With BFFM2 enabled, OID 11 (JET-SMALL-D-6) will show different NOx and CO compared to OID 3 (JET-SMALL-D-2) because the two profiles have different thrust schedules and altitude distributions. This illustrates the sensitivity of BFFM2 results to the choice of departure profile.
+3. **Per-aircraft method drift** — extend exercise 2 by splitting the per-movement CSV by aircraft type. Compare the BFFM2-minus-ByMode NOx delta for the eight A20N movements versus the five E190 movements. Because the two aircraft have different engine power schedules and different default ANP profiles, the BFFM2 correction shifts them differently. Expect larger relative drift on the regional jet (E190) approach segments, where actual approach thrust is further below the 30% AP-mode default than on the narrowbody. This illustrates that BFFM2 vs ByMode differences are aircraft-type dependent, not just mode dependent.
 
 4. **PM10 sub-components** — select *MovementSource*, examine the `pm10_nonvol_kg`, `pm10_sul_kg`, and `pm10_organic_kg` output columns alongside `pm10_kg`. For departures, `pm10_kg = pm10_nonvol_kg + pm10_sul_kg + pm10_organic_kg` exactly. For arrivals, `pm10_kg` also includes the FOA3 brake-wear contribution (`MTOW × 0.000476 − 8.74` grams per movement), visible as a surplus in `pm10_kg` relative to the sub-component sum. Verify that `p1_kg = p2_kg = pm10_kg` for all movements.
 
@@ -576,9 +575,9 @@ AUSTAL writes concentration output files in `.dmna` format, one file per polluta
 | `co-y00a.dmna` | CO period mean concentration |
 | `nox-y00s.dmna` | Statistical uncertainty for NOx |
 
-The values represent the **mean concentration over the simulated period** (2025-12-01 06:00–07:00), not an annual mean. Each file is a plain-text matrix of concentration values on the model grid. The grid is north-oriented; the first value in the matrix corresponds to the south-west corner of the domain.
+The values represent the **mean concentration over the simulated period** (2025-12-01 06:00 through 2025-12-03 08:00, ≈50 hours), not an annual mean. Each file is a plain-text matrix of concentration values on the model grid. The grid is north-oriented; the first value in the matrix corresponds to the south-west corner of the domain.
 
-Key interpretation note: this study simulates only 2 hours of a single day. Concentrations from this run are illustrative only and cannot be compared directly to air quality limit values, which require full annual averaging.
+Key interpretation note: this study spans a 50-hour window across three days, but actual aircraft activity is clustered in early-morning hours (~06:00–08:00 daily, ~6 hours of operations total). Concentrations from this run are illustrative only and cannot be compared directly to air quality limit values, which require full annual averaging.
 
 #### Visualize results
 
@@ -596,4 +595,4 @@ To inspect specific grid cells, use the **Results Table** option to export conce
 ---
 
 *Test case prepared using EHRD operational data for the OpenALAQS Training Course, March 2026.*
-*Airport: Rotterdam The Hague (EHRD) | Movements period: 2025-12-01 06:00–07:00 | Six movements, four source types.*
+*Airport: Rotterdam The Hague (EHRD) | Movements period: 2025-12-01 06:05 to 2025-12-03 08:05 | Thirteen movements, four source types.*

--- a/documents/USER_GUIDE.md
+++ b/documents/USER_GUIDE.md
@@ -273,7 +273,7 @@ When adding a point source, the following information is required:
   + **Height**: Height at which emissions are released (in metres). `Not yet fully implemented`.
   + **Activity per year**: How much the source operates in one inventory year. The numeric value of throughput, fuel consumed, or hours run.
   + **Activity unit** (read-only): Unit paired with *Activity per year*. Inherited from the selected emission factor row (`default_stationary_ef.activity_unit`). Examples: `1000_m3` (natural gas throughput), `1000_L` (liquid-fuel throughput), `hr` (engine operating hours), `1000_kg` (solid waste / coating).
-+ **Profiles**: Each point source carries one *hour*, one *day*, and one *month* profile. The profiles split the *Activity per year* total into a per-hour timeline across the inventory year. Three named profiles ship with the templates: `heating_season` (winter-weighted month profile), `cooling_season` (summer-weighted month profile), and `business_hours` (8 AM to 6 PM weekday hour profile). Pick the named profile that matches the source, or define a custom profile via the OpenALAQS Toolbar → *Activity Profiles* panel.
++ **Profiles**: Each point source carries one *hour*, one *day*, and one *month* profile. The profiles split the *Activity per year* total into a per-hour timeline across the inventory year. The `default_stationary_ef` table recommends profile names per source type (e.g. `business_hours` for stationary IC engines, `heating_season` for power/heat plants); these names refer to profiles you must define yourself via the OpenALAQS Toolbar → *Activity Profiles* panel, since the user profile tables in the project template ship empty. Until you create them, sources fall back to the default uniform profile.
 
 ![points-layer.png](./../open_alaqs/assets/points-layer.png)
 
@@ -300,7 +300,7 @@ where the three profile factors are dimensionless and average to 1.0 across the 
 
 **Schema migration note**: studies produced by older plugin versions used a single `units_per_year` field (hours per year only) without an explicit activity unit. The `scripts/migrate_alaqs.py` tool upgrades legacy `.alaqs` files in place, renames `units_per_year` to `annual_activity`, adds the `activity_unit` column to `shapes_point_sources`, and reports any source pinned to an emission-factor row that has since been deprecated. See `documents/AUXILIARY_MATERIAL.md` for the v2 schema reference.
 
-**Stationary IC Engine sources** are a v2 addition (category 6) and use `hr` as the activity unit (engine operating hours per year). Available types include diesel and natural-gas reciprocating engines at three power tiers (<50 kW, 50 to 500 kW, >500 kW); pick the type that matches the rated power of the engine on site.
+**Stationary IC Engine sources** are a v2 addition (category 6) and use `hr` as the activity unit (engine operating hours per year). Available types are diesel reciprocating engines at two power tiers: `>600 hp` (split further into *Prechamber* and *Open-Chamber* combustion types, per AP-42 §3.4) and `<600 hp`. Pick the type that matches the rated power and combustion chamber of the engine on site.
 
 #### [Area sources](#area-sources)
 
@@ -455,7 +455,7 @@ The following optional parameters can be left empty. They will only be used if t
 | `set_time_of_main_engine_off_after_runway_exit_in_s` | Duration in seconds after runway exit during which full-engine taxi applies before engines are cut (arrival). | Active |
 | `engine_thrust_level_for_taxiing` | Taxi thrust level as a fraction (ICAO default: 0.07 = 7%). Only affects the BFFM2 emission index for the moving taxi phase; queuing always uses true idle (7%) regardless of this setting. | Active |
 | `taxi_fuel_ratio` | Ratio between actual fuel flow and idle fuel flow during taxi. Acts as a direct multiplier on taxi segment emissions. Default: 1.0. | Active |
-| `number_of_stop_and_gos` | Number of stop-and-go events during taxiing. Each event is modelled as two phases: 21 s at idle (deceleration + hold, per ECAC Doc 29 Vol. 2 Appendix B) plus 11 s at ~15% thrust (acceleration). | Active |
+| `number_of_stop_and_gos` | Number of stop-and-go events during taxiing. Each event adds `AVERAGE_DURATION_OF_STOP_AND_GOS_IN_S = 9.0` seconds at idle thrust per engine (`MovementEmissionCalculator.py:159, 403`). Added to the queuing segment only (last taxi segment). | Active |
 
 ### [Helicopters (FOCA 2015)](#helicopters-foca-2015)
 
@@ -494,7 +494,7 @@ The 3400 kg threshold is defined in FOCA 2015 section 2.4. The category drives b
 
 To add a helicopter type that is not in the default catalog, insert a row into `default_helicopter` referencing an existing engine in `default_helicopter_engines` (or insert a new engine row first). The minimum fields are `icao`, `variant_label`, `mtow_kg`, `engine_count`, `engine`, `engine_name`, `max_shp_per_engine`, `is_default`. Once the row is in place, any movement whose `aircraft` field matches that ICAO will be routed through the FOCA path automatically.
 
-**What is suppressed for helicopters.** APU emissions and gate emissions are skipped at the dispatch level regardless of the movement table's `apu_code` and `gate_emissions_code` values. The FOCA 2015 LTO cycle covers all of ground idle, takeoff, climb-out, approach, and landing on its own, so APU and GSE / GPU / MES emissions are not double-counted. Taxi emissions are handled by the fixed-wing taxi route logic; helicopters typically taxi minimally (ground idle on the spot or air-taxi).
+**What is suppressed for helicopters.** APU emissions are skipped because the helicopter taxi branch (`_apply_taxiing_emissions_for_helicopters` in `MovementEmissionCalculator.py`) does not call the APU code path — `apu_code` is not consulted on this branch. For gate emissions, `gate_emissions_code` is still respected (the gate function returns early if it is 0); when gate emissions are enabled, GSE and GPU sub-components are explicitly skipped for helicopters but MES (Main Engine Start) is computed normally. The FOCA 2015 LTO cycle covers ground idle, takeoff, climb-out, approach, and landing on its own, avoiding double-counting against the suppressed sub-components. Taxi emissions themselves are handled by the helicopter taxi function; helicopters typically taxi minimally (ground idle on the spot or air-taxi).
 
 **Limitations.** The 3000 ft AGL LTO ceiling is per the ICAO LTO definition; emissions above that altitude are not modelled. Two known FOCA 2015 PDF inconsistencies were resolved during implementation (piston fuel-flow leading coefficient and twin-heavy Appendix C power settings) and are recorded in the docstring of `open_alaqs/core/tools/foca_heli.py`.
 
@@ -510,7 +510,7 @@ The required meteorological parameters are:
 | `DateTime` | YYYY-MM-DD HH:MM:SS | |
 | `Temperature` | K | |
 | `Humidity` | kg water / kg dry air | Used directly if non-zero; takes priority over `RelativeHumidity` |
-| `RelativeHumidity` | % | Used to derive specific humidity if `Humidity` is zero or empty |
+| `RelativeHumidity` | fraction (0–1) | Used to derive specific humidity if `Humidity` is zero or empty |
 | `SeaLevelPressure` | Pa | |
 | `WindSpeed` | m/s | |
 | `WindDirection` | degrees | |
@@ -556,7 +556,7 @@ The emission output CSV contains the following PM-related columns for aircraft m
 |---|---|
 | `pm10_kg` | Total PM10 = combustion PM10 + brake wear (arrivals only) |
 | `pm10_nonvol_kg` | Non-volatile PM (nvPM mass), MEEM V1 ambient-corrected where 5-point EEDB data are available |
-| `pm10_sul_kg` | Sulphate vPM = 36.75 mg/kg × fuel burned (FSC 500 ppm, ε = 0.024, CAEP14 default) |
+| `pm10_sul_kg` | Sulphate vPM = ~48.96 mg/kg × fuel burned (FSC ≈ 667 ppm, ε = 0.024; stored as a constant in the `pm10_sul` column) |
 | `pm10_organic_kg` | Organic vPM = δ_k × HC_EI × fuel burned |
 | `p1_kg` | PM1.0 placeholder; currently equal to `pm10_kg` |
 | `p2_kg` | PM2.5 placeholder; currently equal to `pm10_kg` |
@@ -589,7 +589,7 @@ The dispersion module will only be activated if the `Is Enabled` checkbox is che
 The following parameters need to be defined:
 + **Roughness Length**: Height above ground where wind speed theoretically becomes zero. Depends on terrain type (e.g., forests, urban areas, flat fields).
 + **Displacement Height**: Height at which the wind profile starts to be affected by obstacles on the ground, such as buildings or trees.
-+ **Anemometer Height**: Height at which wind speed measurements are taken. Default: 10 m.
++ **Anemometer Height**: Height at which wind speed measurements are taken. Default: `10 + 6·z0` m, where `z0` is the roughness length (≈ 11.2 m at the typical airport value `z0 = 0.2`).
 + **Quality Level**: Determines the number of simulation particles (range: −4 to +4). Higher values increase accuracy but also computation time.
 + **NOTALUFT** (per-hour series): when enabled, AUSTAL writes per-hour grid output (`<substance>-NNNa.dmna`) and, when receptor points are configured, per-receptor time-series files (`<substance>-tmpa.dmna`). Required for **Plot Time Series** and **Compliance Report**; optional for **Plot Vector Layer** with `annual mean`.
 + **PM10 fine fraction**: how PM10 emissions are split between AUSTAL's `pm-1` and `pm-2` substances (default 0.9, suitable for an airport mix dominated by aircraft non-volatile PM and combustion exhaust).


### PR DESCRIPTION
29 patches across three files, all sourced from a code-against-doc audit:

BFFM2.md (10 patches):
- delta exponent 1.0 -> 1.02 in NOx, CO, HC ambient corrections (matches bffm2.py:406, 416, 423 and CAEP14 BFFM2 sheet)
- Mach formula: drop extraneous sqrt(288.15/T_amb) factor (the SOS formula already accounts for ambient T)
- Step 2 rewrite: drop the ICAO Doc 9889 delta/sqrt(theta) decomposition; present the CAEP14 universal form the code actually applies
- PM10 sulphate value: ~48.96 mg/kg stored (was claimed 36.75); FSC back-calculates to ~667 ppm not 500 ppm
- CO/HC interpolation: replace 'Lean Azeotropic Value (LAV)' terminology with the actual code variable 'lin_av'; correct the threshold from 'AP-CL intersection' to 'Approach anchor'
- Idle floor clamp: clarify it only applies for P < 0.07; correct the P > 1.0 behaviour description (clamp 1.0-1.05 with warning, ValueError above 1.05)
- Installation corrections attribution: 'CAEP14 default; originally from SAE AIR-5715' (was attributed to SAE AIR-5715 alone)
- Three downstream cleanups: 'LAV' references in the CO discussion paragraph and code-file table, and the Mach formula in the ASCII flow diagram

USER_GUIDE.md (7 patches):
- Stop-and-go: replace fictional 2-phase model (21s idle + 11s thrust, citing ECAC Doc 29) with the actual 9s at idle thrust per engine
- Anemometer Height default: '10 + 6*z0' m (was simply '10 m')
- Stationary IC Engine tiers: '>600 hp Prechamber/Open-Chamber and <600 hp, all diesel' (was 'diesel and natural-gas at three kW tiers')
- Named profiles: clarify they're recommended names; users must define them via the Activity Profiles Editor (the user_*_profile tables in project.alaqs ship empty)
- PM10 sulphate: same numeric correction as BFFM2.md
- RelativeHumidity unit: fraction (0-1), not %
- Helicopter APU/gate suppression: describe the actual mechanism (code-path divergence for APU; gate_emissions_code respected, only GSE/GPU sub-components skipped for helicopters)

TEST_CASE_STUDY.md (12 patches):
- Aircraft/engines/profile IDs rebuilt against the actual training_movements.csv: A20N + E190 (was A21N + E75L); engines 01P20CM128 + 11GE144 (was PW1133G + CF34-8E5)
- Movement count corrected: 13 (was claimed 12 and 'Six movements')
- Profile IDs: JET-SMALL-A-1/D-1 + JET-REGIONAL-A-1/D-1 + one CUSTOM ADS-B profile (was JET-SMALL-D-2/D-6 + JET-MEDIUM-D-2, none of which exist in the file)
- Taxi routes: 6 routes referenced in actual file (was claimed 3)
- Meteo delimiter: comma (was claimed semicolon)
- Meteo pressure unit: Pa (was claimed mb)
- Meteo RH unit: 0-1 fraction (was claimed %)
- Meteo specific humidity: 0.00446 kg/kg actual value (was 0.00634)
- EHRD elevation: -15 m (was 0)
- Exercise 3 rewrite: per-aircraft method drift (was JET-SMALL-D-2 vs D-6 comparison using profiles that do not exist)
- Time-range claims aligned: 'three days, ~6 hours of actual ops' (was 'only 2 hours of a single day')
- All apu_code and gate_emissions_code = 0 explicitly noted (file data has both explicit zeros for all 13 rows)

No code changes; pre-commit clean on all three files.