### PR TITLE
docs: Tier 2 audit fixes + Activity Profiles worked example

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Open-ALAQS ships three aircraft emission methods selectable at run time:
 - **bymode** — multiplies anchor-mode fuel flow × anchor-mode EI × time × engine count. No ambient corrections. Use as a tautological baseline.
 - **BFFM2 (trajectory)** — default BFFM2 path. For each trajectory segment resolves fuel flow from the segment's sub-mode power setting via the twin-quadratic fit, applies SAE AIR-5715 atmospheric corrections for NOx, and snaps CO/HC to the horizontal mean(CL, TO) value above the APP anchor in the standard-intersection case (CAEP14 v14 rule).
 - **BFFM2 (mode_anchor)** — uses the mode anchor fuel flow (IDLE/APP/CL/TO EEDB values) as the BFFM2 input, still applying ambient corrections. Useful when trajectories lack per-segment sub-mode fidelity.
-- **Helicopters (FOCA 2015)** — separate dispatch for movements flagged as helicopters. Four FOCA categories (PISTON, SINGLE_TURBOSHAFT, TWIN_TURBOSHAFT_LIGHT/HEAVY) with per-category trajectories and emission indices. APU and gate emissions are suppressed; airborne emissions only. See [`documents/USER_GUIDE.md`](documents/USER_GUIDE.md) for category derivation and [`documents/TRAJECTORY_DATA_SOURCES.md`](documents/TRAJECTORY_DATA_SOURCES.md) for the data sources.
+- **Helicopters (FOCA 2015)** — separate dispatch for movements flagged as helicopters. Four FOCA categories (PISTON, SINGLE_TURBOSHAFT, TWIN_TURBOSHAFT_LIGHT/HEAVY) with per-category trajectories and emission indices. APU and gate emissions are suppressed; airborne emissions only. See [`documents/USER_GUIDE.md`](documents/USER_GUIDE.md) for category derivation and [`documents/HELICOPTER_TRAJECTORIES.md`](documents/HELICOPTER_TRAJECTORIES.md) for the data sources.
 
 PM is via MEEM V1 at LTO (EEDB nvPM anchors unchanged at LTO altitudes). The MEEM V2 base method (ICAO CAEP/13-WG3) is also implemented for non-LTO altitudes. The MDG4 / Staged Combustion update is not implemented.
 
@@ -226,9 +226,9 @@ Most tests need QGIS available on the Python path. CI runs the suite in a QGIS D
 
 [(Back to top)](#table-of-contents)
 
-Open-ALAQS is validated against external CAEP14 reference values to floating-point precision across bymode, BFFM2 trajectory, and BFFM2 mode_anchor methods, with non-volatile PM matching EEDB anchors exactly via MEEM V1 at LTO.
+Open-ALAQS is validated against an external reference spreadsheet to floating-point precision across bymode, BFFM2 trajectory, and BFFM2 mode_anchor methods, with non-volatile PM matching EEDB anchors exactly via MEEM V1 at LTO.
 
-The full validation matrix, per-engine results, and cross-platform agreement evidence are in [`documents/VALIDATION_GUIDE.md`](documents/VALIDATION_GUIDE.md).
+The full validation matrix, per-engine results, and cross-platform agreement evidence are in [`documents/BFFM2_validation/BFFM2.md`](documents/BFFM2_validation/BFFM2.md).
 
 ## Recent changes
 

--- a/documents/AUXILIARY_MATERIAL.md
+++ b/documents/AUXILIARY_MATERIAL.md
@@ -69,15 +69,15 @@ Aircraft PM10 emissions are decomposed into three physical components, stored se
 **Sulphate PM (`pm10_sul`)** — volatile sulphate particles formed from sulphur in the fuel. Computed from the fuel sulphur content (FSC) and a conversion efficiency ε using ICAO Doc 9889 Appendix D:
 
 ```
-pm10_sul (g/kg) = FSC (kg/kg) × ε × 3 062 500
+pm10_sul (mg/kg) = FSC (kg/kg) × ε × 3 062 500
 ```
 
-The database uses **FSC = 500 ppm (0.0005 kg/kg)** and **ε = 0.024** (CAEP14 default), giving a constant value of **36.75 mg/kg** for all engines and all modes.
+The database uses **FSC ≈ 667 ppm (0.000667 kg/kg)** and **ε = 0.024** (CAEP14 default), giving a constant value of **~48.96 mg/kg** for all engines and all modes.
 
 **Organic vPM (`pm10_organic`)** — volatile organic particles from unburned hydrocarbons, calculated by the parameterised vPM method from ICAO Doc 9889 Appendix D:
 
 ```
-pm10_organic (g/kg) = δ_k × EI_HC (g/kg)
+pm10_organic (mg/kg) = δ_k (mg/g_HC) × EI_HC (g/kg)
 ```
 
 where δ_k is the mode-specific conversion factor:
@@ -227,7 +227,7 @@ COPERT contains emission factors for more than 450 individual vehicle types cons
 
 The implementation (see [`copert5.py`](./../open_alaqs/core/tools/copert5.py)) of the COPERT methodology in OpenALAQS preserves the core information from the original model, albeit with some simplification tailored to the scope of OpenALAQS. It generates typical emission factors for roadway segments or parking areas based on fleet year (as a proxy for Euro standard), country, fleet mix, number of vehicles, temperature, average speed, and roadway segment length.
 
-The vehicle categories examined are Passenger Cars (PCs), Light Commercial Vehicles (LCVs), Heavy Duty Trucks (HDTs), buses and motorcycles. Only petrol and diesel engines are included. Emission factors are provided for 37 countries: EU27 Member States, EU27 aggregated, UK, Iceland, Norway, Switzerland, Liechtenstein, North Macedonia, Turkey, Albania, Serbia and Montenegro.
+The vehicle categories examined are Passenger Cars (PCs), Light Commercial Vehicles (LCVs), Heavy Duty Trucks (HDTs), buses and motorcycles. Only petrol and diesel engines are included. Emission factors are provided for 38 entries: 26 EU Member States (Slovakia is not currently present in the dataset), the EU27 and EU28 aggregates, plus UK, Iceland, Norway, Switzerland, Liechtenstein, North Macedonia, Turkey, Albania, Serbia, and Montenegro.
 
 **Special remarks**:
 + HDTs petrol: only "Conventional" Euro standard option is available

--- a/documents/HELICOPTER_TRAJECTORIES.md
+++ b/documents/HELICOPTER_TRAJECTORIES.md
@@ -115,13 +115,14 @@ here are the post-2015 corrected values, as documented in the
 
 For all four categories the approach is modelled as two segments:
 
-1. `approach_start_nm` → 1500 ft AGL: initial descent at
+1. `approach_start_nm` → 500 ft AGL: initial descent at
    `approach_tas_initial_kt` and `approach_rod_initial_fpm`.
-2. 1500 ft AGL → hover (5 ft AGL): final descent at
+2. 500 ft AGL → hover (5 ft AGL): final descent at
    `approach_tas_final_kt` and `approach_rod_final_fpm`.
 
-The 1500-ft intermediate altitude is a FOCA Appendix A convention
-(start of the deceleration profile). Hover is held for
+The 500-ft intermediate altitude (`FINAL_BREAK_ALT_FT` in
+`foca_heli_trajectory.py`) represents a typical final-approach
+altitude for the deceleration profile. Hover is held for
 `HOVER_DURATION_S` (18 s) before touchdown.
 
 ## Departure geometry
@@ -141,13 +142,21 @@ elsewhere:
 - **Fuel flow and emission indices**. Computed live from the
   helicopter's engine type, max shaft horsepower, engine count, and
   category at each FOCA LTO mode (Ground Idle, Takeoff, Climb-out,
-  Approach). See `foca_heli.py` `compute_lto()`.
+  Approach). See `compute_lto()` in `foca_heli_utils.py`. The
+  per-pollutant fuel-flow and emission-index helpers
+  (`piston_fuel_flow_kg_s`, `turboshaft_ei_nox_g_kg`, etc.) live in
+  `foca_heli.py`.
 - **Mode time-in-mode allocation**. The trajectory generator emits
   per-segment timing (`t_s` field on each `TrajectoryPoint`); the
   emission calculator integrates fuel flow over these times.
-- **APU and gate emissions**. Suppressed for helicopters at the
-  dispatch level in `MovementEmissionCalculator` regardless of the
-  movement table's `apu_code` and `gate_emissions_code` values.
+- **APU and gate emissions**. APU is skipped because the helicopter
+  taxi branch (`_apply_taxiing_emissions_for_helicopters` in
+  `MovementEmissionCalculator.py`) does not call the APU code path
+  — `apu_code` is not consulted on this branch. For gate emissions,
+  `gate_emissions_code` is still respected (the gate function returns
+  early if it is 0); when gate emissions are enabled, GSE and GPU
+  sub-components are explicitly skipped for helicopters, but MES (Main
+  Engine Start) is computed normally.
 
 ## Adding a new category
 

--- a/documents/USER_GUIDE.md
+++ b/documents/USER_GUIDE.md
@@ -28,6 +28,7 @@
       - [Area sources](#area-sources)
       - [Buildings](#buildings)
   - [Activity Profiles](#activity-profiles)
+    - [Worked example — defining and using named profiles](#worked-example--defining-and-using-named-profiles)
   - [Generate Emissions Inventory](#generate-emissions-inventory)
     - [Taxi routes](#taxi-routes)
     - [Create output file](#create-output-file)
@@ -350,6 +351,39 @@ Each factor is a non-negative decimal number. Values are not capped at 1.0; what
 
 > **Note:** Profiles whose calendar-weighted mean is exactly 0 (every entry zero) are handled specially: the multiplier evaluates to 0 for every hour, so emissions remain 0 throughout the simulation. There is no normalisation in this case.
 
+### [Worked example — defining and using named profiles](#worked-example--defining-and-using-named-profiles)
+
+The names `heating_season`, `cooling_season`, and `business_hours` are recommended in `default_stationary_ef` but must be defined by the user in the Activity Profiles Editor (see [Point Sources](#point-sources)). Suggested factor values, intended as a starting point for a temperate European airport:
+
+**`heating_season` — month profile, winter-weighted** (peaks Jan/Feb/Dec):
+
+```
+Jan=2.5, Feb=2.2, Mar=1.5, Apr=0.8, May=0.3, Jun=0.1,
+Jul=0.1, Aug=0.1, Sep=0.4, Oct=1.0, Nov=1.8, Dec=2.4
+```
+
+**`cooling_season` — month profile, summer-weighted** (peaks Jun-Aug):
+
+```
+Jan=0.1, Feb=0.1, Mar=0.2, Apr=0.5, May=1.2, Jun=2.2,
+Jul=2.5, Aug=2.4, Sep=1.5, Oct=0.6, Nov=0.2, Dec=0.1
+```
+
+**`business_hours` — define in BOTH `user_hour_profile` and `user_day_profile`** (one row in each table, sharing the name; the lookup uses the appropriate row at each context):
+
+- Hour profile: zero for h01–h07 and h19–h24, ~1.0 for h08–h18 (peak ~1.2 around mid-morning).
+- Day profile: 1.0 for Mon–Fri, 0 for Sat/Sun.
+
+**Example combinations:**
+
+| Source type | Month profile | Day profile | Hour profile | Resulting timing |
+|---|---|---|---|---|
+| Heating plant | `heating_season` | `default` | `default` | Concentrated in winter; uniform within each day. |
+| Stationary IC engine | `default` | `business_hours` | `business_hours` | Year-round but Mon–Fri 08:00–18:00 only. |
+| Cooling tower | `cooling_season` | `default` | `business_hours` | Summer daytime, every day. |
+
+Values are relative — what matters is the ratio between entries. The `profile_mean` normalisation rescales them so the source's total annual emission is preserved across any choice of profile shape (see notes above).
+
 ## [Generate Emissions Inventory](#generate-emissions-inventory)
 [(Back to top)](#table-of-contents)
 
@@ -472,7 +506,7 @@ Helicopter movements share the Movements table format described above; the only 
 | `TWIN_TURBOSHAFT_LIGHT` | `engine_type = TURBOSHAFT`, `engine_count ≥ 2`, MTOM ≤ 3400 kg |
 | `TWIN_TURBOSHAFT_HEAVY` | `engine_type = TURBOSHAFT`, `engine_count ≥ 2`, MTOM > 3400 kg |
 
-The 3400 kg threshold is defined in FOCA 2015 section 2.4. The category drives both the emission formulas and the trajectory geometry; the per-category trajectory parameters and their citations are documented in [`TRAJECTORY_DATA_SOURCES.md`](TRAJECTORY_DATA_SOURCES.md).
+The 3400 kg threshold is defined in FOCA 2015 section 2.4. The category drives both the emission formulas and the trajectory geometry; the per-category trajectory parameters and their citations are documented in [`HELICOPTER_TRAJECTORIES.md`](HELICOPTER_TRAJECTORIES.md).
 
 **Default catalog.** 60 helicopter rows in `default_helicopter` covering common types (R22, A109, EC135, AS332, S76, S92, etc.). 86 engine rows in `default_helicopter_engines` covering the corresponding turboshaft and piston engines. The columns are:
 

--- a/open_alaqs/core/tools/foca_heli_trajectory.py
+++ b/open_alaqs/core/tools/foca_heli_trajectory.py
@@ -5,7 +5,7 @@ Builds 3D trajectories (x, y, z in meters) for the departure and arrival
 halves of an LTO, scaled per helicopter category.
 
 Source data for per-category parameters is documented in
-documents/TRAJECTORY_DATA_SOURCES.md. Core summary:
+documents/HELICOPTER_TRAJECTORIES.md. Core summary:
 
   - PISTON (R22):           500 ft/min climb at 60 kt,  75 kt cruise
   - SINGLE_TURBOSHAFT:     1000 ft/min climb at 60 kt, 120 kt cruise (FOCA Appx A)
@@ -53,7 +53,7 @@ HOVER_DURATION_S = 18.0  # From Appendix A — assumed universal
 class TrajectoryParams:
     """Category-specific flight parameters for trajectory building.
 
-    See documents/TRAJECTORY_DATA_SOURCES.md for per-field citations.
+    See documents/HELICOPTER_TRAJECTORIES.md for per-field citations.
     """
 
     climb_roc_fpm: float  # rate of climb during TO mode


### PR DESCRIPTION
Rename:
- documents/TRAJECTORY_DATA_SOURCES.md -> documents/HELICOPTER_TRAJECTORIES.md The file covers only helicopter (FOCA 2015) trajectories; fixed-wing ANP trajectories live elsewhere. The previous name was misleading.

References updated to the new filename:
- README.md:153
- documents/USER_GUIDE.md (helicopter category section)
- open_alaqs/core/tools/foca_heli_trajectory.py:8, :56

CHANGELOG.md:141 left as-is (historical 5.2.0 release record).

AUXILIARY_MATERIAL.md (3 patches):
- PM10 sulphate formula: LHS unit g/kg -> mg/kg (the constant 3,062,500 is dimensioned for mg/kg, not g/kg)
- PM10 sulphate stored value: ~48.96 mg/kg with FSC ~ 667 ppm (was claimed 36.75 mg/kg with FSC = 500 ppm; verified against every row of default_aircraft_engine_ei.csv where pm10_sul = 0.04896 g/kg)
- PM10 organic formula: LHS unit g/kg -> mg/kg with explicit 'delta_k (mg/g_HC)' annotation (the delta_k values 115/76/56.25/6.17 only balance dimensionally if expressed as mg/g_HC)
- COPERT countries: '38 entries: 26 EU Member States (Slovakia not currently in dataset), EU27 and EU28 aggregates, plus 10 non-EU' (was '37 countries: EU27 Member States ...', missing Slovakia, missing EU28 aggregate; arithmetic on the original wording added to 38 anyway)

HELICOPTER_TRAJECTORIES.md (3 patches):
- Approach intermediate altitude: 1500 ft -> 500 ft AGL (FINAL_BREAK_ALT_FT = 500.0 in foca_heli_trajectory.py:253, with inline comment 'typical final'; no 1500 ft constant exists; no FOCA Appendix A citation in the code)
- compute_lto() file path: 'foca_heli_utils.py' (was 'foca_heli.py'; the latter contains only per-pollutant primitives like piston_fuel_flow_kg_s and turboshaft_ei_nox_g_kg)
- APU/gate suppression mechanism: describe what the code actually does (APU skipped via code-path divergence; gate_emissions_code respected, only GSE and GPU sub-components explicitly skipped for helicopters, MES computed normally) — aligns with the same Tier 1 fix in USER_GUIDE.md

USER_GUIDE.md Activity Profiles section:
- New 'Worked example — defining and using named profiles' subsection with concrete factor values for heating_season, cooling_season, and business_hours profiles, plus three example source-type combinations showing how to compose month/day/hour profiles for typical airport stationary sources. Closes the loop on the Tier 1 B.4 fix which flagged these names as undefined in the project template.

No behavioural code changes; pre-commit clean.