### PR TITLE
fix(austal): renumber legacy source slots to gap-free 01..N

### DIFF
--- a/open_alaqs/core/modules/AUSTALOutputModule.py
+++ b/open_alaqs/core/modules/AUSTALOutputModule.py
@@ -2159,6 +2159,110 @@ class AUSTALDispersionModule(DispersionModule):
                 slot_id,
             )
 
+    def _ti_compact_legacy_slots(self):
+        """Renumber surviving legacy slots to a contiguous 01..N range.
+
+        process() assigns each pollutant a slot id by its position in
+        _pollutants_list (NOx=01, CO=02, ... SOx=05, CO2=06), and
+        _ti_drop_empty_legacy_slots() removes slots that carried zero
+        emissions across the whole run. When a removed slot is not the
+        last one (e.g. zero-SOx slot 05 dropped while CO2 keeps 06), the
+        surviving ids have a hole: 01,02,03,04,06.
+
+        AUSTAL does not read directory names from austal.txt literally;
+        it counts the source columns and expects grid source directories
+        numbered sequentially 01..N. An interior hole makes it look for a
+        directory that was never created ("The grid source directory
+        '.../05' is missing!") and abort with "invalid input".
+
+        This method closes the holes: it builds an order-preserving map
+        old_id -> new_id over the surviving slots, renames the on-disk
+        directories, and applies the same map to every piece of
+        slot-keyed state (_total_sources, _results[*], _timeID_per_source,
+        _gridfile_written). It is a no-op when the ids are already
+        contiguous, so runs with no dropped slot are unaffected (and stay
+        bit-identical).
+        """
+        if not self._total_sources:
+            return
+
+        # Surviving ids in their current (sorted) order. Keys are
+        # zero-padded strings like "01".."NN", so lexical sort == numeric.
+        old_ids = sorted(self._total_sources.keys())
+        remap = {}
+        for new_idx, old_id in enumerate(old_ids, start=1):
+            new_id = str(new_idx).zfill(2)
+            if new_id != old_id:
+                remap[old_id] = new_id
+
+        if not remap:
+            # Already contiguous (01..N). Nothing to do; preserves the
+            # no-dropped-slot fast path byte-for-byte.
+            return
+
+        out_dir = self.getOutputPathAsPath()
+
+        # 1) Rename on-disk directories. Renaming into a gap (06 -> 05)
+        # is safe because the target id was removed; but to be robust
+        # against any ordering where a target name still exists, stage
+        # through a temporary suffix first, then move into place.
+        staged = {}
+        for old_id, new_id in remap.items():
+            src = out_dir / old_id
+            if src.is_dir():
+                tmp = out_dir / (old_id + "__compact_tmp")
+                try:
+                    src.rename(tmp)
+                    staged[new_id] = tmp
+                except OSError as exc:
+                    logger.error(
+                        "AUSTAL: could not stage slot dir '%s' for " "renumbering: %s",
+                        old_id,
+                        exc,
+                    )
+        for new_id, tmp in staged.items():
+            dst = out_dir / new_id
+            try:
+                tmp.rename(dst)
+            except OSError as exc:
+                logger.error(
+                    "AUSTAL: could not finalise slot dir rename to '%s': %s",
+                    new_id,
+                    exc,
+                )
+
+        # 2) Remap _total_sources, preserving insertion order.
+        new_total = OrderedDict()
+        for old_id in old_ids:
+            new_id = remap.get(old_id, old_id)
+            new_total[new_id] = self._total_sources[old_id]
+        self._total_sources = new_total
+
+        # 3) Remap per-hour _results[<dt>][<slot>].
+        for dt_str in self._results:
+            hour = self._results[dt_str]
+            moved = {}
+            for old_id, new_id in remap.items():
+                if old_id in hour:
+                    moved[new_id] = hour.pop(old_id)
+            hour.update(moved)
+
+        # 4) Remap _timeID_per_source and _gridfile_written.
+        for attr in ("_timeID_per_source", "_gridfile_written"):
+            state = getattr(self, attr, None)
+            if not state:
+                continue
+            moved = {}
+            for old_id, new_id in remap.items():
+                if old_id in state:
+                    moved[new_id] = state.pop(old_id)
+            state.update(moved)
+
+        logger.info(
+            "AUSTAL: compacted legacy slots to contiguous ids (remap %s)",
+            ", ".join(f"{o}->{n}" for o, n in remap.items()),
+        )
+
     def _ti_fill_legacy_zero_hours(self):
         """For each surviving non-stationary slot, write a zero-filled
         eXXXX.dmna for any hour skipped by process() (because that hour
@@ -2265,6 +2369,16 @@ class AUSTALDispersionModule(DispersionModule):
         # series.dmna and so their now-empty grid directories are removed.
         self._ti_drop_empty_legacy_slots()
         self._ti_fill_legacy_zero_hours()
+        # Renumber surviving legacy slots to a gap-free 01..N sequence.
+        # _ti_drop_empty_legacy_slots may leave holes (e.g. a zero-SOx
+        # slot 05 removed while CO2 keeps id 06). AUSTAL enumerates grid
+        # source directories sequentially from the source-column count in
+        # austal.txt, so an interior hole makes it look for a directory
+        # that does not exist ("grid source directory '.../05' is
+        # missing") and abort. Compaction renames the directories and
+        # remaps all slot-keyed state so directories, austal.txt and
+        # series.dmna stay mutually consistent and contiguous.
+        self._ti_compact_legacy_slots()
 
         group_ids, group_weights, group_rates = self._ti_aggregate_stationary()
         n_legacy = len(self._total_sources)

--- a/tests/test_austal_slot_compaction.py
+++ b/tests/test_austal_slot_compaction.py
@@ -1,0 +1,109 @@
+"""Unit tests for AUSTALDispersionModule._ti_compact_legacy_slots.
+
+Regression guard for the bug where a selected pollutant with zero total
+emissions, positioned BEFORE a non-zero pollutant, left an interior hole
+in the source-slot numbering (e.g. surviving slots 01,02,03,04,06 after a
+zero-SOx slot 05 was dropped). AUSTAL enumerates grid source directories
+sequentially from the source-column count in austal.txt, so the hole made
+it look for a directory that was never created and abort with:
+
+    The grid source directory '.../05' is missing!
+    AUSTAL terminated because of invalid input.
+
+These tests do not require QGIS. They build a bare module instance with
+object.__new__ and populate only the slot-keyed state the method touches,
+plus a temporary output directory for the directory-rename step.
+
+Run from the openalaqs repo root:
+    pytest tests/test_austal_slot_compaction.py -v
+"""
+
+from collections import OrderedDict
+from pathlib import Path
+
+from open_alaqs.core.modules.AUSTALOutputModule import AUSTALDispersionModule
+
+
+def _make_module(out_dir, survivor_ids):
+    """Build a bare module with the minimal slot-keyed state populated
+    for the given surviving slot ids, plus on-disk directories for each.
+    """
+    mod = object.__new__(AUSTALDispersionModule)
+    mod._total_sources = OrderedDict((sid, ["x"]) for sid in survivor_ids)
+    mod._timeID_per_source = OrderedDict((sid, 1) for sid in survivor_ids)
+    mod._gridfile_written = {sid: {1} for sid in survivor_ids}
+    mod._results = {
+        "2025-06-01:01": {sid: {"x": 1.0, "timeID": 1} for sid in survivor_ids}
+    }
+    # getOutputPathAsPath() is the only path accessor the method uses.
+    out = Path(out_dir)
+    mod.getOutputPathAsPath = lambda: out
+    for sid in survivor_ids:
+        (out / sid).mkdir(parents=True, exist_ok=True)
+    return mod
+
+
+def _dirs(out_dir):
+    return sorted(
+        p.name
+        for p in Path(out_dir).iterdir()
+        if p.is_dir() and not p.name.endswith("__compact_tmp")
+    )
+
+
+def test_interior_hole_is_closed(tmp_path):
+    """The user's exact case: SOx slot 05 dropped, survivors
+    01,02,03,04,06. CO2 (06) must be renamed to 05 so directories,
+    _total_sources and series/austal stay contiguous 01..05.
+    """
+    mod = _make_module(tmp_path, ["01", "02", "03", "04", "06"])
+    mod._ti_compact_legacy_slots()
+
+    assert list(mod._total_sources.keys()) == ["01", "02", "03", "04", "05"]
+    assert _dirs(tmp_path) == ["01", "02", "03", "04", "05"]
+    # All slot-keyed state moved in lockstep.
+    assert sorted(mod._timeID_per_source.keys()) == ["01", "02", "03", "04", "05"]
+    assert sorted(mod._gridfile_written.keys()) == ["01", "02", "03", "04", "05"]
+    res_slots = sorted(k for k in mod._results["2025-06-01:01"] if k != "timeID")
+    assert res_slots == ["01", "02", "03", "04", "05"]
+
+
+def test_two_holes_are_closed(tmp_path):
+    """Slots 03 and 05 dropped: survivors 01,02,04,06 -> 01,02,03,04."""
+    mod = _make_module(tmp_path, ["01", "02", "04", "06"])
+    mod._ti_compact_legacy_slots()
+
+    assert list(mod._total_sources.keys()) == ["01", "02", "03", "04"]
+    assert _dirs(tmp_path) == ["01", "02", "03", "04"]
+
+
+def test_contiguous_is_noop(tmp_path):
+    """Already contiguous survivors (no dropped slot, or last-slot
+    dropped) must be left untouched - preserves bit-identical output.
+    """
+    mod = _make_module(tmp_path, ["01", "02"])
+    # Snapshot identity of state objects to prove no rebuild happened.
+    ts_before = mod._total_sources
+    mod._ti_compact_legacy_slots()
+
+    assert list(mod._total_sources.keys()) == ["01", "02"]
+    assert _dirs(tmp_path) == ["01", "02"]
+    # No remap => the original dict object is retained (no rebuild).
+    assert mod._total_sources is ts_before
+
+
+def test_single_survivor_renumbered_to_01(tmp_path):
+    """A lone survivor at 04 (everything before it dropped) -> 01."""
+    mod = _make_module(tmp_path, ["04"])
+    mod._ti_compact_legacy_slots()
+
+    assert list(mod._total_sources.keys()) == ["01"]
+    assert _dirs(tmp_path) == ["01"]
+
+
+def test_empty_total_sources_is_safe(tmp_path):
+    """No legacy slots at all (all-stationary run) must not raise."""
+    mod = _make_module(tmp_path, [])
+    # Remove the directories created for an empty list (none) and call.
+    mod._ti_compact_legacy_slots()
+    assert list(mod._total_sources.keys()) == []


### PR DESCRIPTION
AUSTAL aborts with "The grid source directory '.../05' is missing! AUSTAL terminated because of invalid input." when generating input files from the AUSTAL Dispersion Analysis window for an inventory in which a selected pollutant has zero total emissions and is positioned before a non-zero pollutant (e.g. zero-SOx selected together with CO2).

Root cause
----------
The time-indexed writer assigns one source slot per pollutant by its position in _pollutants_list (NOx=01, CO=02, HC=03, PM10=04, SOx=05, CO2=06). The on-disk source directory is created lazily, only inside `if hashed_emissions > 0` in process(), so a zero-emission pollutant (SOx) never gets a directory while the pollutant after it (CO2=06) does. _ti_drop_empty_legacy_slots() then removes the dead SOx key from _total_sources but leaves a hole: 01,02,03,04,06.

austal.txt and series.dmna are written from the surviving keys (5 source columns), but the on-disk directories are 01,02,03,04,06. AUSTAL does not read directory names from austal.txt literally; it counts the source columns and expects grid source directories numbered sequentially 01..05. Directory 05 does not exist (CO2 is in 06), so it aborts.

The bug only triggers on an interior hole. A zero-emission pollutant in the last slot leaves the survivors contiguous, which is why earlier PM10-only runs (SOx last) succeeded.

Fix