### PR TITLE
Phase 1a: extract get_vertical_envelope helper (refactor, no behaviour change)

### DIFF
--- a/open_alaqs/core/GeoTransformation.py
+++ b/open_alaqs/core/GeoTransformation.py
@@ -125,9 +125,7 @@ class GeoTransformation(abc.ABC):
         avoid recomputing the vertical values from a single dynamics
         lookup.
         """
-        params = GeoTransformation._get_dynamics_params(
-            aircraft, sas_method, lto_mode
-        )
+        params = GeoTransformation._get_dynamics_params(aircraft, sas_method, lto_mode)
         return GeoTransformation._compute_z_envelope(
             sas_method,
             params["vertical_shift"],
@@ -177,9 +175,7 @@ class GeoTransformation(abc.ABC):
 
         # ── Dynamics lookup — delegated to _get_dynamics_params (E1 FIX
         # preserved: fetched once, then used twice below).
-        params = GeoTransformation._get_dynamics_params(
-            aircraft, sas_method, lto_mode
-        )
+        params = GeoTransformation._get_dynamics_params(aircraft, sas_method, lto_mode)
         d_h = params["horizontal_extension"]
         s_v = params["vertical_shift"]
         d_v = params["vertical_extension"]

--- a/open_alaqs/core/GeoTransformation.py
+++ b/open_alaqs/core/GeoTransformation.py
@@ -44,6 +44,98 @@ class GeoTransformation(abc.ABC):
         raise NotImplementedError
 
     @staticmethod
+    def _get_dynamics_params(aircraft, sas_method, lto_mode):
+        """Resolve per-mode plume dynamics for (aircraft, lto_mode) under
+        ``sas_method``.
+
+        Returns a dict with keys ``horizontal_extension``, ``vertical_shift``,
+        ``vertical_extension``. Preserves the pre-existing behaviour of
+        ``create_polygon_3d``: emits the same missing-dynamics warning when
+        the mode is absent, and falls back from ``sas_method`` to
+        ``"default"`` when the requested method key is unavailable.
+
+        Extracted from ``create_polygon_3d`` for reuse by callers that need
+        only the vertical envelope (e.g. engine-test emissions), without
+        constructing a trajectory-segment polygon.
+        """
+        # B4 FIX (preserved): guard against KeyError if the aircraft group
+        # has no entry for this mode in the default_emission_dynamics table.
+        try:
+            mode_dynamics = aircraft.getEmissionDynamicsByMode()[lto_mode]
+        except (KeyError, TypeError):
+            logger.warning(
+                "No emission dynamics found for mode '%s' on aircraft '%s'. "
+                "Using zero-extension defaults.",
+                lto_mode,
+                aircraft.getICAOIdentifier() if aircraft else "unknown",
+            )
+            return {
+                "horizontal_extension": 0.0,
+                "vertical_shift": 0.0,
+                "vertical_extension": 0.0,
+            }
+
+        try:
+            return mode_dynamics.getEmissionDynamics(sas_method)
+        except (KeyError, TypeError):
+            return mode_dynamics.getEmissionDynamics("default")
+
+    @staticmethod
+    def _compute_z_envelope(sas_method, s_v, d_v, z_ground):
+        """Pure vertical-envelope formula.
+
+        Returns ``(z_lower, z_upper)`` for one endpoint (or one stationary
+        source) at ground z = ``z_ground``, under smooth-and-shift method
+        ``sas_method`` (``"default"`` or ``"sas"``; any other value takes
+        the no-shift fallback branch).
+
+        Expressions and evaluation order preserved verbatim from the
+        previous inline z-block of ``create_polygon_3d`` so the movement
+        inventory build is byte-identical before and after this extraction.
+        The ``ver_ext = d_v`` symbol identity from the original code is
+        preserved rather than algebraically simplified. z-floor clamping
+        (``max(0, z)``) is NOT applied here; the caller does it during
+        geometry-vertex construction, matching the prior behaviour.
+        """
+        ver_ext = d_v  # preserved: original had `ver_ext = d_v` after lookup
+        ver_shift = s_v  # preserved: original had `ver_shift = s_v`
+
+        if sas_method == "default":
+            z_lower = z_ground + ver_shift
+            z_upper = z_lower + ver_ext
+        elif sas_method == "sas":
+            z_lower = z_ground - (ver_ext + d_v) / 2
+            z_upper = z_ground + ver_ext
+        else:
+            z_lower = z_ground
+            z_upper = z_ground
+
+        return z_lower, z_upper
+
+    @staticmethod
+    def get_vertical_envelope(aircraft, sas_method, lto_mode, z_ground):
+        """Convenience wrapper: (aircraft, method, mode, z_ground) ->
+        (z_lower, z_upper).
+
+        Combines ``_get_dynamics_params`` and ``_compute_z_envelope`` for
+        callers that need only the vertical envelope of a stationary source
+        (e.g. engine-test emissions) rather than the full 3-D polygon
+        around a trajectory segment. ``create_polygon_3d`` itself does not
+        call this wrapper; it calls the two internal helpers directly to
+        avoid recomputing the vertical values from a single dynamics
+        lookup.
+        """
+        params = GeoTransformation._get_dynamics_params(
+            aircraft, sas_method, lto_mode
+        )
+        return GeoTransformation._compute_z_envelope(
+            sas_method,
+            params["vertical_shift"],
+            params["vertical_extension"],
+            z_ground,
+        )
+
+    @staticmethod
     def create_polygon_3d(
         aircraft, sas_method, lto_mode, point_1: QgsPoint, point_2: QgsPoint
     ):
@@ -83,66 +175,32 @@ class GeoTransformation(abc.ABC):
                 f"start={start_coords}, end={end_coords}"
             )
 
-        # ── Dynamics lookup — E1 FIX: fetch once, not five times ─────────────
-        # B4 FIX: guard against KeyError if the aircraft group has no entry for
-        # this mode in the default_emission_dynamics table.
-        try:
-            mode_dynamics = aircraft.getEmissionDynamicsByMode()[lto_mode]
-        except (KeyError, TypeError):
-            logger.warning(
-                "No emission dynamics found for mode '%s' on aircraft '%s'. "
-                "Using zero-extension defaults.",
-                lto_mode,
-                aircraft.getICAOIdentifier() if aircraft else "unknown",
-            )
-            mode_dynamics = None
-
-        if mode_dynamics is not None:
-            try:
-                sas_params = mode_dynamics.getEmissionDynamics(sas_method)
-            except (KeyError, TypeError):
-                sas_params = mode_dynamics.getEmissionDynamics("default")
-
-            d_h = sas_params["horizontal_extension"]
-            s_v = sas_params["vertical_shift"]
-            d_v = sas_params["vertical_extension"]
-
-            # ver_ext must come from the same method as d_v.
-            # The original code used "default" for airborne modes (CL/AP) and
-            # sas_method for TX/TO, which mixed "default" and "sas" columns in
-            # the sas z-shift formula: z - (ver_ext + d_v) / 2.
-            # Since d_v and ver_ext are both "vertical_extension" from the same
-            # EmissionDynamics object, they must use the same method lookup so
-            # the formula is consistent.  sas_method is already normalised to
-            # either "default" or "sas" in __init__, so this is always correct.
-            ver_ext = d_v
-        else:
-            d_h = d_v = s_v = ver_ext = 0.0
+        # ── Dynamics lookup — delegated to _get_dynamics_params (E1 FIX
+        # preserved: fetched once, then used twice below).
+        params = GeoTransformation._get_dynamics_params(
+            aircraft, sas_method, lto_mode
+        )
+        d_h = params["horizontal_extension"]
+        s_v = params["vertical_shift"]
+        d_v = params["vertical_extension"]
 
         # ── Polygon geometry ─────────────────────────────────────────────────
         hor_ext = d_h / 2  # half-width
-        ver_shift = s_v
 
         perp_x = -dy / length
         perp_y = dx / length
 
-        if sas_method == "default":
-            z_shifted_start = start_coords[2] + ver_shift
-            z_shifted_end = end_coords[2] + ver_shift
-            z_upper_start = z_shifted_start + ver_ext
-            z_upper_end = z_shifted_end + ver_ext
+        # z-envelope per endpoint, delegated to _compute_z_envelope.
+        z_shifted_start, z_upper_start = GeoTransformation._compute_z_envelope(
+            sas_method, s_v, d_v, start_coords[2]
+        )
+        z_shifted_end, z_upper_end = GeoTransformation._compute_z_envelope(
+            sas_method, s_v, d_v, end_coords[2]
+        )
 
-        elif sas_method == "sas":
-            z_shifted_start = start_coords[2] - (ver_ext + d_v) / 2
-            z_shifted_end = end_coords[2] - (ver_ext + d_v) / 2
-            z_upper_start = start_coords[2] + ver_ext
-            z_upper_end = end_coords[2] + ver_ext
-
-        else:
-            z_shifted_start = start_coords[2]
-            z_shifted_end = end_coords[2]
-            z_upper_start = z_shifted_start
-            z_upper_end = z_shifted_end
+        # Fallback method (neither "default" nor "sas") also zeroes the
+        # horizontal spread. Preserved from the previous inline else branch.
+        if sas_method not in ("default", "sas"):
             hor_ext = 0
 
         # Create 3D vertices using QgsPoint

--- a/openalaqs_standalone/source_dynamics.py
+++ b/openalaqs_standalone/source_dynamics.py
@@ -199,6 +199,57 @@ def lookup_params(
     return st.get(method)
 
 
+def _compute_z_envelope(method, s_v, d_v, z_ground):
+    """Pure vertical-envelope formula. Mirror of
+    ``open_alaqs.core.GeoTransformation._compute_z_envelope``.
+
+    Returns ``(z_lower, z_upper)`` for one endpoint / stationary source at
+    ground z = ``z_ground``, under smooth-and-shift ``method``
+    (``"default"`` or ``"sas"``; any other value takes the no-shift
+    fallback branch).
+
+    Expressions and evaluation order preserved verbatim from the previous
+    inline z-block of ``segment_footprint`` so the CAEP14 regression is
+    byte-identical before and after this extraction. ``ver_ext = d_v``
+    symbol identity from the original code is preserved rather than
+    algebraically simplified. No z clamping applied here.
+    """
+    ver_ext = d_v  # preserved: plugin sets ver_ext = d_v after lookup
+
+    if method == "default":
+        z_lower = z_ground + s_v
+        z_upper = z_lower + ver_ext
+    elif method == "sas":
+        z_lower = z_ground - (ver_ext + d_v) / 2.0
+        z_upper = z_ground + ver_ext
+    else:
+        z_lower = z_ground
+        z_upper = z_ground
+
+    return z_lower, z_upper
+
+
+def get_vertical_envelope(params, method, z_ground):
+    """Convenience wrapper: (params, method, z_ground) -> (z_lower, z_upper).
+
+    ``params`` is the pre-resolved dict from ``lookup_params`` or
+    ``load_emission_dynamics``, with keys ``horizontal_extension``,
+    ``vertical_shift``, ``vertical_extension``. Consumed by paths that need
+    only the vertical envelope of a stationary source (engine-test
+    emissions, phase 3), rather than a full footprint around a trajectory
+    segment.
+
+    Numerically equivalent to the plugin-side
+    ``GeoTransformation.get_vertical_envelope`` for the same inputs; the
+    signature differs only because the standalone resolves the DB lookup
+    separately upstream in ``lookup_params``, whereas the plugin's wrapper
+    performs the lookup itself from an ``Aircraft`` object.
+    """
+    return _compute_z_envelope(
+        method, params["vertical_shift"], params["vertical_extension"], z_ground
+    )
+
+
 def segment_footprint(
     p1: tuple,
     p2: tuple,
@@ -257,7 +308,6 @@ def segment_footprint(
     d_h = params["horizontal_extension"]
     s_v = params["vertical_shift"]
     d_v = params["vertical_extension"]
-    ver_ext = d_v  # plugin: ver_ext is the same vertical_extension as d_v
 
     hor_ext = d_h / 2.0  # half-width
 
@@ -265,23 +315,13 @@ def segment_footprint(
     perp_x = -dy / length
     perp_y = dx / length
 
-    if method == "default":
-        z_shifted_start = z1 + s_v
-        z_shifted_end = z2 + s_v
-        z_upper_start = z_shifted_start + ver_ext
-        z_upper_end = z_shifted_end + ver_ext
-    elif method == "sas":
-        z_shifted_start = z1 - (ver_ext + d_v) / 2.0
-        z_shifted_end = z2 - (ver_ext + d_v) / 2.0
-        z_upper_start = z1 + ver_ext
-        z_upper_end = z2 + ver_ext
-    else:
-        # Should not happen (resolve_method gates this), but mirror the
-        # plugin's "none" branch: no spread, no shift.
-        z_shifted_start = z1
-        z_shifted_end = z2
-        z_upper_start = z1
-        z_upper_end = z2
+    # z-envelope per endpoint, delegated to _compute_z_envelope.
+    z_shifted_start, z_upper_start = _compute_z_envelope(method, s_v, d_v, z1)
+    z_shifted_end, z_upper_end = _compute_z_envelope(method, s_v, d_v, z2)
+
+    # Fallback method (neither "default" nor "sas") also zeroes the
+    # horizontal spread. Preserved from the previous inline else branch.
+    if method not in ("default", "sas"):
         hor_ext = 0.0
 
     # Footprint rectangle, plugin bottom-face vertex order [0,1,2,3] =

--- a/openalaqs_standalone/validation/tests/test_phase1a_get_vertical_envelope_standalone.py
+++ b/openalaqs_standalone/validation/tests/test_phase1a_get_vertical_envelope_standalone.py
@@ -1,0 +1,218 @@
+"""Phase 1a T1a-4a: standalone-side tests for the extracted vertical
+envelope helper.
+
+Two goals:
+  * Byte-identical equivalence between the refactored code and the
+    pre-refactor inline formulas of segment_footprint.
+  * Coverage across every populated (ac_group, flight_stage, method)
+    combination in the training_v3 fixture.
+
+QGIS-free; runs under plain python + shapely.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from openalaqs_standalone.source_dynamics import (
+    _compute_z_envelope,
+    get_vertical_envelope,
+    load_emission_dynamics,
+    segment_footprint,
+)
+
+FIXTURE_PATH = Path(__file__).resolve().parent.parent / "data" / "training_v3.alaqs"
+
+
+# ---------------------------------------------------------------------------
+# Reference formulas: copied verbatim from the pre-refactor inline z-block of
+# segment_footprint (source_dynamics.py L268-L285 at 3f3e2af). Kept literal so
+# the byte-identity of the refactor can be checked without re-reading history.
+# ---------------------------------------------------------------------------
+def _pre_refactor_z(method, s_v, d_v, z1, z2):
+    """The four z values (z_shifted_start, z_shifted_end, z_upper_start,
+    z_upper_end) as segment_footprint computed them before the refactor.
+    """
+    ver_ext = d_v
+    if method == "default":
+        z_shifted_start = z1 + s_v
+        z_shifted_end = z2 + s_v
+        z_upper_start = z_shifted_start + ver_ext
+        z_upper_end = z_shifted_end + ver_ext
+    elif method == "sas":
+        z_shifted_start = z1 - (ver_ext + d_v) / 2.0
+        z_shifted_end = z2 - (ver_ext + d_v) / 2.0
+        z_upper_start = z1 + ver_ext
+        z_upper_end = z2 + ver_ext
+    else:
+        z_shifted_start = z1
+        z_shifted_end = z2
+        z_upper_start = z1
+        z_upper_end = z2
+    return z_shifted_start, z_shifted_end, z_upper_start, z_upper_end
+
+
+# ---------------------------------------------------------------------------
+# Fixture: enumerate every populated (group, stage, method) triple from
+# training_v3.alaqs. Skips the NULL sentinel rows the fixture contains.
+# ---------------------------------------------------------------------------
+def _fixture_triples():
+    if not FIXTURE_PATH.exists():
+        pytest.skip(f"fixture missing: {FIXTURE_PATH}")
+    with sqlite3.connect(str(FIXTURE_PATH)) as conn:
+        dyn = load_emission_dynamics(conn)
+    out = []
+    for group, stages in dyn.items():
+        if group is None:
+            continue
+        for stage, methods in stages.items():
+            if stage is None:
+                continue
+            for method in ("default", "sas"):
+                params = methods.get(method)
+                if params is None:
+                    continue
+                # Skip if all dynamics values are zero (indistinguishable from
+                # the fallback branch and useless as a discriminating case).
+                if (
+                    params["vertical_shift"] == 0.0
+                    and params["vertical_extension"] == 0.0
+                    and params["horizontal_extension"] == 0.0
+                ):
+                    continue
+                out.append((group, stage, method, params))
+    return out
+
+
+FIXTURE_TRIPLES = _fixture_triples()
+
+
+# ---------------------------------------------------------------------------
+# T1a-4a.1  Fixture-driven byte-identity for _compute_z_envelope.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "group,stage,method,params",
+    FIXTURE_TRIPLES,
+    ids=lambda v: v if isinstance(v, str) else "",
+)
+@pytest.mark.parametrize("z_ground", [0.0, 3.0, 100.0, -5.0])
+def test_compute_z_envelope_matches_pre_refactor_on_fixture(
+    group, stage, method, params, z_ground
+):
+    """For every populated (group, stage, method) in training_v3.alaqs and
+    a range of ground z values, the refactored helper must return the same
+    (z_lower, z_upper) as the pre-refactor inline formulas.
+
+    A single endpoint is enough: _compute_z_envelope takes one z, so
+    calling it once with z_ground reproduces the (z_shifted, z_upper) that
+    segment_footprint would compute for that endpoint.
+    """
+    s_v = params["vertical_shift"]
+    d_v = params["vertical_extension"]
+
+    # Pre-refactor: pass z_ground as both endpoints, take (z_shifted_start,
+    # z_upper_start). Guaranteed equal to the single-endpoint helper output.
+    ref = _pre_refactor_z(method, s_v, d_v, z_ground, z_ground)
+    expected = (ref[0], ref[2])
+
+    got = _compute_z_envelope(method, s_v, d_v, z_ground)
+
+    assert (
+        got == expected
+    ), f"{group}/{stage}/{method} at z={z_ground}: expected {expected}, got {got}"
+
+
+# ---------------------------------------------------------------------------
+# T1a-4a.2  segment_footprint end-to-end byte-identity.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("group,stage,method,params", FIXTURE_TRIPLES, ids=lambda v: "")
+@pytest.mark.parametrize(
+    "endpoints",
+    [
+        ((0.0, 0.0), (100.0, 0.0)),
+        ((10.0, 20.0), (110.0, 220.0)),
+        ((0.0, 0.0), (0.001, 0.001)),  # near-degenerate but non-zero
+    ],
+)
+@pytest.mark.parametrize("zs", [(0.0, 0.0), (5.0, 15.0), (100.0, 50.0)])
+def test_segment_footprint_zmin_zmax_pre_refactor(
+    group, stage, method, params, endpoints, zs
+):
+    """segment_footprint's returned (z_min, z_max) equals the pre-refactor
+    computation for the same params and endpoints.
+    """
+    p1, p2 = endpoints
+    z1, z2 = zs
+    zs_start, zs_end, zu_start, zu_end = _pre_refactor_z(
+        method, params["vertical_shift"], params["vertical_extension"], z1, z2
+    )
+    expected_zmin = min(zs_start, zs_end)
+    expected_zmax = max(zu_start, zu_end)
+
+    _, zmin, zmax = segment_footprint(p1, p2, z1, z2, method, params)
+    assert (zmin, zmax) == (expected_zmin, expected_zmax), (
+        f"{group}/{stage}/{method} endpoints={endpoints} zs={zs}: "
+        f"expected ({expected_zmin}, {expected_zmax}), got ({zmin}, {zmax})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T1a-4a.3  Fallback branch coverage.
+# ---------------------------------------------------------------------------
+def test_compute_z_envelope_fallback_method():
+    """A method other than 'default' or 'sas' returns (z_ground, z_ground)."""
+    got = _compute_z_envelope("none", -100.0, 25.0, 42.0)
+    assert got == (42.0, 42.0)
+
+
+def test_compute_z_envelope_zero_dynamics():
+    """Zero-dynamics inputs (the missing-mode fallback) collapse to the
+    ground plane in both real methods."""
+    for m in ("default", "sas"):
+        got = _compute_z_envelope(m, 0.0, 0.0, 7.5)
+        assert got == (7.5, 7.5), f"method={m}: got {got}"
+
+
+# ---------------------------------------------------------------------------
+# T1a-4a.4  get_vertical_envelope wrapper delegates correctly.
+# ---------------------------------------------------------------------------
+def test_get_vertical_envelope_wrapper():
+    """The public wrapper reads (vertical_shift, vertical_extension) from
+    the params dict and delegates to _compute_z_envelope.
+    """
+    params = {
+        "horizontal_extension": 50.0,
+        "vertical_shift": -100.0,
+        "vertical_extension": 25.0,
+    }
+    for method in ("default", "sas", "none"):
+        for z_g in (0.0, 3.0, 100.0):
+            direct = _compute_z_envelope(
+                method, params["vertical_shift"], params["vertical_extension"], z_g
+            )
+            via_wrapper = get_vertical_envelope(params, method, z_g)
+            assert (
+                direct == via_wrapper
+            ), f"method={method} z={z_g}: direct={direct} wrapper={via_wrapper}"
+
+
+# ---------------------------------------------------------------------------
+# T1a-4a.5  segment_footprint degenerate-length branch untouched.
+# ---------------------------------------------------------------------------
+def test_segment_footprint_zero_length_returns_none_footprint():
+    """A zero-length XY segment returns (None, z1, z2), unchanged by the
+    refactor."""
+    params = {
+        "horizontal_extension": 50.0,
+        "vertical_shift": -100.0,
+        "vertical_extension": 25.0,
+    }
+    fp, zmin, zmax = segment_footprint(
+        (0.0, 0.0), (0.0, 0.0), 5.0, 10.0, "default", params
+    )
+    assert fp is None
+    assert zmin == 5.0
+    assert zmax == 10.0

--- a/tests/test_phase1a_get_vertical_envelope_plugin.py
+++ b/tests/test_phase1a_get_vertical_envelope_plugin.py
@@ -1,0 +1,240 @@
+"""Phase 1a T1a-1 and T1a-3: plugin-side tests for the extracted vertical
+envelope helper.
+
+Requires QGIS Python (imports qgis.core). Run under OSGeo4W shell:
+    python-qgis.bat -m pytest tests/test_phase1a_get_vertical_envelope_plugin.py -v
+
+Covers:
+  * T1a-1  Unit-level equivalence of _compute_z_envelope against the
+           pre-refactor inline formulas across every populated
+           (group, stage, method) combination in training_v3.alaqs.
+  * T1a-3  Fallback branch coverage: missing mode dynamics triggers the
+           expected warning and returns zero-envelope; unknown method
+           collapses to no-shift.
+  * Additional: get_vertical_envelope wrapper delegation and
+                create_polygon_3d numerical equivalence check via a small
+                mocked Aircraft.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# QGIS imports guarded so the module still parses without QGIS in path;
+# tests requiring QGIS will collect-fail cleanly rather than import-fail.
+try:
+    from qgis.core import QgsPoint  # noqa: F401
+
+    from open_alaqs.core.GeoTransformation import GeoTransformation
+
+    HAS_QGIS = True
+except Exception as _exc:  # pragma: no cover
+    HAS_QGIS = False
+    _import_error = _exc
+
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "openalaqs_standalone"
+    / "validation"
+    / "data"
+    / "training_v3.alaqs"
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not HAS_QGIS, reason="QGIS Python not importable in this environment"
+)
+
+
+# ---------------------------------------------------------------------------
+# Reference formulas: copied verbatim from create_polygon_3d before the
+# refactor (GeoTransformation.py L129-L146 at 3f3e2af). ver_ext = d_v is
+# kept literal.
+# ---------------------------------------------------------------------------
+def _pre_refactor_z(sas_method, s_v, d_v, z_start, z_end):
+    ver_ext = d_v
+    ver_shift = s_v
+    if sas_method == "default":
+        z_shifted_start = z_start + ver_shift
+        z_shifted_end = z_end + ver_shift
+        z_upper_start = z_shifted_start + ver_ext
+        z_upper_end = z_shifted_end + ver_ext
+    elif sas_method == "sas":
+        z_shifted_start = z_start - (ver_ext + d_v) / 2
+        z_shifted_end = z_end - (ver_ext + d_v) / 2
+        z_upper_start = z_start + ver_ext
+        z_upper_end = z_end + ver_ext
+    else:
+        z_shifted_start = z_start
+        z_shifted_end = z_end
+        z_upper_start = z_shifted_start
+        z_upper_end = z_shifted_end
+    return z_shifted_start, z_shifted_end, z_upper_start, z_upper_end
+
+
+def _load_fixture_triples():
+    """Enumerate every populated (group, stage, method, params) from the
+    training_v3 fixture, skipping the NULL sentinel rows."""
+    if not FIXTURE_PATH.exists():
+        return []
+    with sqlite3.connect(str(FIXTURE_PATH)) as conn:
+        rows = conn.execute(
+            "SELECT ac_group, flight_stage, "
+            "horizontal_extent_m, vertical_extent_m, vertical_shift_m, "
+            "horizontal_extent_m_sas, vertical_extent_m_sas, "
+            "vertical_shift_m_sas "
+            "FROM default_emission_dynamics"
+        ).fetchall()
+    out = []
+    for g, s, he, ve, vs, hes, ves, vss in rows:
+        if g is None or s is None:
+            continue
+        for method, (h, v, sh) in (
+            ("default", (he, ve, vs)),
+            ("sas", (hes, ves, vss)),
+        ):
+            if h is None and v is None and sh is None:
+                continue
+            params = {
+                "horizontal_extension": float(h or 0.0),
+                "vertical_shift": float(sh or 0.0),
+                "vertical_extension": float(v or 0.0),
+            }
+            if (
+                params["vertical_shift"] == 0.0
+                and params["vertical_extension"] == 0.0
+                and params["horizontal_extension"] == 0.0
+            ):
+                continue
+            out.append((g, s, method, params))
+    return out
+
+
+FIXTURE_TRIPLES = _load_fixture_triples()
+
+
+# ---------------------------------------------------------------------------
+# T1a-1: fixture-driven byte-identity for _compute_z_envelope.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "group,stage,method,params",
+    FIXTURE_TRIPLES,
+    ids=lambda v: v if isinstance(v, str) else "",
+)
+@pytest.mark.parametrize("z_ground", [0.0, 3.0, 100.0, -5.0])
+def test_compute_z_envelope_matches_pre_refactor_on_fixture(
+    group, stage, method, params, z_ground
+):
+    """For every populated (group, stage, method) in training_v3.alaqs the
+    refactored helper must return exactly the same (z_lower, z_upper) as
+    the pre-refactor inline formulas."""
+    ref = _pre_refactor_z(
+        method,
+        params["vertical_shift"],
+        params["vertical_extension"],
+        z_ground,
+        z_ground,
+    )
+    expected = (ref[0], ref[2])
+
+    got = GeoTransformation._compute_z_envelope(
+        method,
+        params["vertical_shift"],
+        params["vertical_extension"],
+        z_ground,
+    )
+
+    assert got == expected, (
+        f"{group}/{stage}/{method} at z={z_ground}: " f"expected {expected}, got {got}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T1a-3: fallback branches.
+# ---------------------------------------------------------------------------
+def test_get_dynamics_params_missing_mode_warns(caplog):
+    """A KeyError from getEmissionDynamicsByMode()[mode] returns
+    zero-extension defaults and emits the pre-refactor warning."""
+    ac = MagicMock()
+    ac.getEmissionDynamicsByMode.return_value = {}  # missing mode
+    ac.getICAOIdentifier.return_value = "TEST"
+
+    with caplog.at_level(logging.WARNING):
+        params = GeoTransformation._get_dynamics_params(ac, "default", "CL")
+
+    assert params == {
+        "horizontal_extension": 0.0,
+        "vertical_shift": 0.0,
+        "vertical_extension": 0.0,
+    }
+    assert any(
+        "No emission dynamics found for mode 'CL' on aircraft 'TEST'" in r.message
+        for r in caplog.records
+    )
+
+
+def test_get_dynamics_params_method_fallback_to_default():
+    """If mode_dynamics.getEmissionDynamics(sas_method) raises, the code
+    falls back to getEmissionDynamics('default')."""
+    mode_dyn = MagicMock()
+
+    def fake_get(method):
+        if method == "sas":
+            raise KeyError("sas key missing")
+        return {
+            "horizontal_extension": 42.0,
+            "vertical_shift": -10.0,
+            "vertical_extension": 5.0,
+        }
+
+    mode_dyn.getEmissionDynamics.side_effect = fake_get
+    ac = MagicMock()
+    ac.getEmissionDynamicsByMode.return_value = {"CL": mode_dyn}
+
+    params = GeoTransformation._get_dynamics_params(ac, "sas", "CL")
+    assert params == {
+        "horizontal_extension": 42.0,
+        "vertical_shift": -10.0,
+        "vertical_extension": 5.0,
+    }
+
+
+def test_compute_z_envelope_fallback_method():
+    """Any method other than 'default' or 'sas' returns (z_ground, z_ground)."""
+    got = GeoTransformation._compute_z_envelope("none", -100.0, 25.0, 42.0)
+    assert got == (42.0, 42.0)
+
+
+def test_compute_z_envelope_zero_dynamics():
+    """Zero dynamics collapse to the ground plane in both real methods."""
+    for m in ("default", "sas"):
+        got = GeoTransformation._compute_z_envelope(m, 0.0, 0.0, 7.5)
+        assert got == (7.5, 7.5), f"method={m}: got {got}"
+
+
+# ---------------------------------------------------------------------------
+# Additional: wrapper delegation.
+# ---------------------------------------------------------------------------
+def test_get_vertical_envelope_delegates():
+    """get_vertical_envelope combines _get_dynamics_params and
+    _compute_z_envelope for the same numerical result."""
+    mode_dyn = MagicMock()
+    mode_dyn.getEmissionDynamics.return_value = {
+        "horizontal_extension": 50.0,
+        "vertical_shift": -100.0,
+        "vertical_extension": 25.0,
+    }
+    ac = MagicMock()
+    ac.getEmissionDynamicsByMode.return_value = {"CL": mode_dyn}
+
+    for method in ("default", "sas"):
+        for z_g in (0.0, 3.0, 100.0):
+            got = GeoTransformation.get_vertical_envelope(ac, method, "CL", z_g)
+            direct = GeoTransformation._compute_z_envelope(method, -100.0, 25.0, z_g)
+            assert got == direct


### PR DESCRIPTION
Non-behavioural refactor of `GeoTransformation.create_polygon_3d` to prepare
for the engine-test emissions add-on (phase 2 onwards).

## What changed

Three static methods extracted:

- `GeoTransformation._get_dynamics_params(aircraft, sas_method, lto_mode) -> dict`
- `GeoTransformation._compute_z_envelope(sas_method, s_v, d_v, z_ground) -> (z_lower, z_upper)`
- `GeoTransformation.get_vertical_envelope(aircraft, sas_method, lto_mode, z_ground) -> (z_lower, z_upper)`

The public wrapper is the entry point for callers (introduced in phase 3)
that need only the vertical plume envelope of a stationary source, without
constructing a trajectory-segment polygon. `create_polygon_3d` itself is
rewritten to delegate to the two internal helpers; all previous fix
comments (B1/B2/B4/E1) preserved on the branches that still contain their
targets. `ver_ext = d_v` symbol identity kept rather than algebraically
simplified.

The standalone package's `openalaqs_standalone/source_dynamics.py` mirror
of the same physics gets the same refactor in parallel, since it is a
QGIS-free reimplementation (cannot import from the plugin core here).

## Verification

- **T1a-1, T1a-3 (plugin unit tests):** 293 passed under OSGeo4W python-qgis-ltr.
- **T1a-2 (plugin movement inventory byte-identity):** GeoPackage of NOx
  emissions from `training_v3.alaqs`: 2500/2500 cells identical for both
  `default` and `sas` S&S methods.
- **T1a-4a (standalone unit tests):** 940 passed against every populated
  `(group, stage, method, z_ground)` combination in the training fixture.
- **T1a-4b (standalone CAEP14 regression):** pre-existing pinned values
  match on all three methods (`bymode`, `bffm2_anchor`, `bffm2_traj`).

## Notes

- No CHANGELOG entry needed; internal refactor only, no user-facing change.
- Uncovered by this PR: a pre-existing `AttributeError` in
  `SmoothAndShiftTransformer` for helicopter movements (`Helicopter`
  class does not implement `getEmissionDynamicsByMode()`). Not a
  regression of this refactor; both `main` at 3f3e2af and this branch
  crash identically on `training_v3.alaqs` without a workaround. Will
  be filed as a separate issue.

Depends on: none. Followed by: phase 1b schema (separate PR).