### PR TITLE
Phase 1b: schema — is_test_site column and engine_test_events table

### DIFF
--- a/open_alaqs/core/interfaces/AreaSources.py
+++ b/open_alaqs/core/interfaces/AreaSources.py
@@ -35,6 +35,14 @@ class AreaSources(Source):
         self._unit_year = _ctf(val.get("unit_year", 0), default=0.0)
         self._heat_flux = _ctf(val.get("heat_flux"), default=None)
 
+        # is_test_site: TEXT '1' / '0', matching the instudy convention.
+        # '1' = this area source is an engine-test site (emissions come from
+        # per-event records, not from the *_kg_unit fixed rates). '0' or
+        # missing = a normal area source, unchanged behaviour. Consumed by
+        # the engine-test source module (added in a later phase); no
+        # effect on existing area-source processing.
+        self._is_test_site = str(val.get("is_test_site", "0")).strip() == "1"
+
         if self._geometry_text and self._height is not None:
             self.setGeometryText(
                 spatial.addHeightToGeometryWkt(self.getGeometryText(), self.getHeight())
@@ -62,6 +70,21 @@ class AreaSources(Source):
 
     def setHeatFlux(self, var):
         self._heat_flux = var
+
+    def isTestSite(self) -> bool:
+        """True if this area source is flagged as an engine-test site.
+
+        Test-site area sources emit via per-event records in the
+        ``engine_test_events`` table, not via the fixed ``*_kg_unit``
+        rates on the row itself. Consumed by the engine-test source
+        module. No effect on existing area-source processing when
+        False (which includes rows written by older plugin versions
+        that predate the flag).
+        """
+        return self._is_test_site
+
+    def setTestSite(self, flag: bool) -> None:
+        self._is_test_site = bool(flag)
 
     def __str__(self):
         val = "\n AreaSources with id '%s'" % (self.getName())
@@ -149,6 +172,7 @@ class AreaSourcesDatabase(SQLSerializable, metaclass=Singleton):
                     ("p1_kg_unit", "DECIMAL"),
                     ("p2_kg_unit", "DECIMAL"),
                     ("instudy", "TEXT"),
+                    ("is_test_site", "TEXT"),
                 ]
             )
         if geometry_columns is None:

--- a/open_alaqs/core/interfaces/EngineTestEvents.py
+++ b/open_alaqs/core/interfaces/EngineTestEvents.py
@@ -1,0 +1,99 @@
+"""Schema definition for the ``engine_test_events`` table.
+
+Phase 1b introduces only the schema. The Python interface layer
+(``EngineTestEvent`` dataclass, ``EngineTestEventsStore``) is deferred
+to Phase 2. This file exists so ``tools/template_build/generate_templates.py``
+can register the table via the standard ``SQLSerializable`` mechanism, so
+that fresh projects created from the template already contain the table.
+
+Design context (per phase 0 decisions memo):
+
+- D5: one aircraft/engine type per event. Mixed-type tests are represented
+  as two rows sharing ``source_id``, ``start_datetime``, ``end_datetime``.
+- D12: mode times stored as INTEGER seconds (``t_TX_s`` etc.). Sub-second
+  precision is not meaningful for run-up events.
+- D2 (thrust mode): per-event override of the study-wide default. The
+  ``thrust_mode`` column carries either ``'snap'`` (nearest ICAO point) or
+  ``'meem'`` (interpolation). Default ``'snap'``.
+- Boolean convention (per Phase 1b decision): ``instudy`` uses TEXT
+  ``'0'`` / ``'1'`` for parity with the rest of the codebase.
+
+Foreign key is intentionally NOT declared. SQLite does not enforce FKs
+by default in this codebase, and orphaned events must be tolerated
+(a user might delete the parent area source in QGIS without
+ON DELETE CASCADE). The engine-test source module (Phase 3) handles
+orphans by skip-with-warning.
+
+Index on ``(source_id, start_datetime)`` supports the period-window
+query pattern of the compute module.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+from open_alaqs.core.interfaces.SQLSerializable import SQLSerializable
+from open_alaqs.core.tools.Singleton import Singleton
+
+
+class EngineTestEventsDatabase(SQLSerializable, metaclass=Singleton):
+    """Schema-only representation of the ``engine_test_events`` table.
+
+    Instantiating this class against a database is enough for the
+    template-generation pipeline to CREATE the table. Reading and
+    writing rows is deferred to ``EngineTestEventsStore`` in Phase 2.
+    """
+
+    TABLE_NAME = "engine_test_events"
+
+    def __init__(
+        self,
+        db_path_string,
+        table_columns_type_dict=None,
+        primary_key="",
+        geometry_columns=None,
+        deserialize=True,
+    ):
+        if table_columns_type_dict is None:
+            table_columns_type_dict = OrderedDict(
+                [
+                    ("event_id", "INTEGER PRIMARY KEY AUTOINCREMENT"),
+                    ("source_id", "TEXT NOT NULL"),
+                    ("test_id", "TEXT"),
+                    ("start_datetime", "TEXT NOT NULL"),
+                    ("end_datetime", "TEXT NOT NULL"),
+                    ("aircraft_type", "TEXT NOT NULL"),
+                    ("engine_uid", "TEXT"),
+                    ("engine_count", "INTEGER"),
+                    ("t_TX_s", "INTEGER NOT NULL DEFAULT 0"),
+                    ("t_AP_s", "INTEGER NOT NULL DEFAULT 0"),
+                    ("t_CL_s", "INTEGER NOT NULL DEFAULT 0"),
+                    ("t_TO_s", "INTEGER NOT NULL DEFAULT 0"),
+                    ("thrust_mode", "TEXT NOT NULL DEFAULT 'snap'"),
+                    ("instudy", "TEXT NOT NULL DEFAULT '1'"),
+                ]
+            )
+
+        # No geometry columns: events reference an area source via
+        # source_id; the geometry lives on shapes_area_sources.
+        if geometry_columns is None:
+            geometry_columns = []
+
+        SQLSerializable.__init__(
+            self,
+            db_path_string,
+            self.TABLE_NAME,
+            table_columns_type_dict,
+            primary_key,
+            geometry_columns,
+        )
+
+        # Deserialize is a no-op for Phase 1b since we do not yet own
+        # a dataclass reader; the table just needs to exist.
+        if deserialize:
+            try:
+                self.deserialize()
+            except Exception:
+                # Fresh project: table not present yet. Non-fatal —
+                # recreate_table() will create it during template generation.
+                pass

--- a/openalaqs_standalone/extract_sources.py
+++ b/openalaqs_standalone/extract_sources.py
@@ -332,8 +332,22 @@ def _extract_area_sources(conn: sqlite3.Connection) -> list[dict]:
         return []
     cols = [d[0] for d in cur.description]
     rows = []
+    n_test_sites_skipped = 0
     for raw in cur.fetchall():
         rec = dict(zip(cols, raw))
+
+        # Skip engine-test sites (is_test_site='1'). Their emissions come
+        # from the engine_test_events table, not from the *_kg_unit fixed
+        # rates on this row, and the compute module for engine tests is
+        # introduced in a later phase. The IS NULL / '' fallbacks preserve
+        # backward compatibility with pre-v1b projects that lack the
+        # column entirely (SQLite's SELECT * still returns their rows,
+        # just without the column, so rec.get returns None).
+        is_test_site = str(rec.get("is_test_site") or "0").strip()
+        if is_test_site == "1":
+            n_test_sites_skipped += 1
+            continue
+
         wkt, kind, length_m, area_m2 = _wkb_to_wkt_via_shapely(rec.get("geometry"))
         raw_id = rec.get("source_id") or rec.get("oid")
         rows.append(
@@ -365,6 +379,11 @@ def _extract_area_sources(conn: sqlite3.Connection) -> list[dict]:
                     default=str,
                 ),
             }
+        )
+    if n_test_sites_skipped:
+        print(
+            f"  [extract_sources] {n_test_sites_skipped} engine-test site(s) "
+            "skipped: engine-test emissions module not yet available"
         )
     return rows
 

--- a/openalaqs_standalone/validation/tests/test_phase1b_extract_sources_standalone.py
+++ b/openalaqs_standalone/validation/tests/test_phase1b_extract_sources_standalone.py
@@ -1,0 +1,211 @@
+"""Phase 1b: standalone-side extract_sources filter for engine-test sites.
+
+Verifies that ``_extract_area_sources`` skips rows flagged
+``is_test_site='1'`` and emits a diagnostic log line, while continuing
+to yield normal area sources unchanged. Backward compatibility for
+pre-v1b projects (rows without the column) is preserved.
+
+QGIS-free. Uses a scratch SQLite DB with the current
+``shapes_area_sources`` shape.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sqlite3
+import tempfile
+from contextlib import redirect_stdout
+
+from openalaqs_standalone.extract_sources import _extract_area_sources
+
+
+def _make_scratch_db_with_column(rows):
+    """Create a scratch DB whose shapes_area_sources includes is_test_site."""
+    path = tempfile.NamedTemporaryFile(suffix=".alaqs", delete=False).name
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE shapes_area_sources (
+            oid INTEGER PRIMARY KEY,
+            source_id TEXT,
+            unit_year TEXT,
+            height DECIMAL,
+            heat_flux DECIMAL,
+            hourly_profile TEXT,
+            daily_profile TEXT,
+            monthly_profile TEXT,
+            co_kg_unit DECIMAL,
+            hc_kg_unit DECIMAL,
+            nox_kg_unit DECIMAL,
+            sox_kg_unit DECIMAL,
+            pm10_kg_unit DECIMAL,
+            p1_kg_unit DECIMAL,
+            p2_kg_unit DECIMAL,
+            instudy TEXT DEFAULT '1',
+            is_test_site TEXT DEFAULT '0',
+            geometry BLOB
+        )
+        """
+    )
+    for r in rows:
+        placeholders = ", ".join(["?"] * len(r))
+        cols = ", ".join(r.keys())
+        conn.execute(
+            f"INSERT INTO shapes_area_sources ({cols}) VALUES ({placeholders})",
+            list(r.values()),
+        )
+    conn.commit()
+    return path, conn
+
+
+def _make_scratch_db_pre_v1b(rows):
+    """Create a scratch DB whose shapes_area_sources omits is_test_site
+    (pre-v1b schema shape)."""
+    path = tempfile.NamedTemporaryFile(suffix=".alaqs", delete=False).name
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE shapes_area_sources (
+            oid INTEGER PRIMARY KEY,
+            source_id TEXT,
+            unit_year TEXT,
+            height DECIMAL,
+            heat_flux DECIMAL,
+            hourly_profile TEXT,
+            daily_profile TEXT,
+            monthly_profile TEXT,
+            co_kg_unit DECIMAL,
+            hc_kg_unit DECIMAL,
+            nox_kg_unit DECIMAL,
+            sox_kg_unit DECIMAL,
+            pm10_kg_unit DECIMAL,
+            p1_kg_unit DECIMAL,
+            p2_kg_unit DECIMAL,
+            instudy TEXT DEFAULT '1',
+            geometry BLOB
+        )
+        """
+    )
+    for r in rows:
+        placeholders = ", ".join(["?"] * len(r))
+        cols = ", ".join(r.keys())
+        conn.execute(
+            f"INSERT INTO shapes_area_sources ({cols}) VALUES ({placeholders})",
+            list(r.values()),
+        )
+    conn.commit()
+    return path, conn
+
+
+# ---------------------------------------------------------------------------
+
+
+def test_extract_skips_test_sites_and_logs():
+    """A row with is_test_site='1' is filtered out; the diagnostic log
+    line reports how many were skipped."""
+    path, conn = _make_scratch_db_with_column(
+        [
+            {"source_id": "A1", "is_test_site": "0", "geometry": None},
+            {"source_id": "N1", "is_test_site": "1", "geometry": None},
+            {"source_id": "A2", "is_test_site": "0", "geometry": None},
+        ]
+    )
+    try:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rows = _extract_area_sources(conn)
+        conn.close()
+
+        # A1 and A2 kept, N1 skipped
+        labels = sorted(r["label"] for r in rows)
+        assert labels == ["A1", "A2"], f"expected A1, A2; got {labels}"
+
+        # Diagnostic printed with correct count
+        out = buf.getvalue()
+        assert "1 engine-test site(s) skipped" in out, f"log missing: {out!r}"
+    finally:
+        os.unlink(path)
+
+
+def test_extract_multiple_test_sites_counted():
+    """Two test-site rows yields a count of 2 in the log line."""
+    path, conn = _make_scratch_db_with_column(
+        [
+            {"source_id": "N1", "is_test_site": "1", "geometry": None},
+            {"source_id": "COMP", "is_test_site": "1", "geometry": None},
+            {"source_id": "A1", "is_test_site": "0", "geometry": None},
+        ]
+    )
+    try:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rows = _extract_area_sources(conn)
+        conn.close()
+        assert len(rows) == 1
+        assert rows[0]["label"] == "A1"
+        assert "2 engine-test site(s) skipped" in buf.getvalue()
+    finally:
+        os.unlink(path)
+
+
+def test_extract_no_test_sites_silent():
+    """When no rows are flagged, no diagnostic is emitted."""
+    path, conn = _make_scratch_db_with_column(
+        [
+            {"source_id": "A1", "is_test_site": "0", "geometry": None},
+            {"source_id": "A2", "is_test_site": "0", "geometry": None},
+        ]
+    )
+    try:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rows = _extract_area_sources(conn)
+        conn.close()
+        assert len(rows) == 2
+        # No skip-log line at all
+        assert "engine-test site(s) skipped" not in buf.getvalue()
+    finally:
+        os.unlink(path)
+
+
+def test_extract_pre_v1b_schema_no_column_treated_as_normal():
+    """Backward compat: a pre-v1b project whose shapes_area_sources has
+    no is_test_site column yields all rows as normal area sources, with
+    no diagnostic emitted."""
+    path, conn = _make_scratch_db_pre_v1b(
+        [
+            {"source_id": "A1", "geometry": None},
+            {"source_id": "A2", "geometry": None},
+        ]
+    )
+    try:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rows = _extract_area_sources(conn)
+        conn.close()
+        assert len(rows) == 2
+        assert sorted(r["label"] for r in rows) == ["A1", "A2"]
+        assert "engine-test site(s) skipped" not in buf.getvalue()
+    finally:
+        os.unlink(path)
+
+
+def test_extract_null_and_empty_string_treated_as_normal():
+    """is_test_site=NULL and is_test_site='' are treated as normal area
+    sources (equivalent to '0')."""
+    path, conn = _make_scratch_db_with_column(
+        [
+            {"source_id": "A1", "is_test_site": None, "geometry": None},
+            {"source_id": "A2", "is_test_site": "", "geometry": None},
+        ]
+    )
+    try:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rows = _extract_area_sources(conn)
+        conn.close()
+        assert len(rows) == 2
+        assert "engine-test site(s) skipped" not in buf.getvalue()
+    finally:
+        os.unlink(path)

--- a/tests/test_phase1b_schema_plugin.py
+++ b/tests/test_phase1b_schema_plugin.py
@@ -1,0 +1,200 @@
+"""Phase 1b: plugin-side schema tests.
+
+Verifies:
+  * ``AreaSources`` dataclass exposes the ``is_test_site`` flag with the
+    expected default and TEXT '1'/'0' round-trip.
+  * ``EngineTestEventsDatabase`` creates the table with the expected
+    schema when instantiated against a scratch database.
+  * The ``shapes_area_sources`` column dict on ``AreaSourcesDatabase``
+    contains ``is_test_site``.
+
+Requires QGIS Python for the SQLSerializable-based instantiation of
+``EngineTestEventsDatabase``, because SQLSerializable imports
+``sql_interface`` which pulls in ``qgis.utils.spatialite_connect``.
+Run under OSGeo4W shell:
+
+    python-qgis-ltr -m pytest tests/test_phase1b_schema_plugin.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+try:
+    from qgis.core import QgsApplication  # noqa: F401
+
+    from open_alaqs.core.interfaces.AreaSources import (
+        AreaSources,
+        AreaSourcesDatabase,
+    )
+    from open_alaqs.core.interfaces.EngineTestEvents import (
+        EngineTestEventsDatabase,
+    )
+
+    HAS_QGIS = True
+except Exception:  # pragma: no cover
+    HAS_QGIS = False
+
+
+pytestmark = pytest.mark.skipif(
+    not HAS_QGIS, reason="QGIS Python not importable in this environment"
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    """Reset the Singleton caches on the two Database classes before every
+    test so each test instantiates a fresh instance against its own
+    tempfile. Without this, a Database created by an earlier test (in this
+    file or the wider suite) is returned by the Singleton metaclass and
+    still points at a now-deleted temp path, causing INSERT/SELECT against
+    the current test's tempfile to see an empty database.
+    """
+    if HAS_QGIS:
+        AreaSourcesDatabase.reset()
+        EngineTestEventsDatabase.reset()
+    yield
+    if HAS_QGIS:
+        AreaSourcesDatabase.reset()
+        EngineTestEventsDatabase.reset()
+
+
+# ---------------------------------------------------------------------------
+# AreaSources dataclass: is_test_site flag
+# ---------------------------------------------------------------------------
+
+
+def test_area_sources_is_test_site_default_false():
+    """A row with no is_test_site field is treated as a normal area source
+    (False), preserving backward compatibility with pre-v1b rows.
+    """
+    src = AreaSources({"source_id": "A1"})
+    assert src.isTestSite() is False
+
+
+def test_area_sources_is_test_site_true_when_flagged():
+    """A row with is_test_site='1' is a test site."""
+    src = AreaSources({"source_id": "A1", "is_test_site": "1"})
+    assert src.isTestSite() is True
+
+
+def test_area_sources_is_test_site_zero_string_false():
+    """A row with is_test_site='0' is not a test site."""
+    src = AreaSources({"source_id": "A1", "is_test_site": "0"})
+    assert src.isTestSite() is False
+
+
+def test_area_sources_is_test_site_setter():
+    """setTestSite flips the flag."""
+    src = AreaSources({"source_id": "A1"})
+    src.setTestSite(True)
+    assert src.isTestSite() is True
+    src.setTestSite(False)
+    assert src.isTestSite() is False
+
+
+# ---------------------------------------------------------------------------
+# AreaSourcesDatabase: columns dict contains is_test_site
+# ---------------------------------------------------------------------------
+
+
+def test_area_sources_database_columns_dict_has_is_test_site():
+    """The static column-definition dict on the database class contains
+    is_test_site so the template pipeline creates the column on new
+    projects.
+    """
+    tmp = tempfile.NamedTemporaryFile(suffix=".alaqs", delete=False).name
+    try:
+        # deserialize=False: the test is about the class's column dict,
+        # not the DB state. Instantiating against an empty tempfile with
+        # deserialize=True would run SELECT against a non-existent table
+        # and raise sqlite3.OperationalError before the assertion runs.
+        db = AreaSourcesDatabase(tmp, deserialize=False)
+        cols = list(db._table_columns.keys())
+        assert "is_test_site" in cols, f"is_test_site absent from cols: {cols}"
+        # Positioned after instudy per convention
+        assert cols.index("is_test_site") > cols.index("instudy")
+    finally:
+        os.unlink(tmp)
+
+
+# ---------------------------------------------------------------------------
+# EngineTestEventsDatabase: table creation and defaults
+# ---------------------------------------------------------------------------
+
+
+def test_engine_test_events_table_created():
+    """recreate_table creates the engine_test_events table with the
+    expected column set.
+    """
+    tmp = tempfile.NamedTemporaryFile(suffix=".alaqs", delete=False).name
+    try:
+        db = EngineTestEventsDatabase(tmp)
+        db.recreate_table()
+        with sqlite3.connect(tmp) as c:
+            info = c.execute("PRAGMA table_info(engine_test_events)").fetchall()
+        col_names = [r[1] for r in info]
+        assert col_names == [
+            "event_id",
+            "source_id",
+            "test_id",
+            "start_datetime",
+            "end_datetime",
+            "aircraft_type",
+            "engine_uid",
+            "engine_count",
+            "t_TX_s",
+            "t_AP_s",
+            "t_CL_s",
+            "t_TO_s",
+            "thrust_mode",
+            "instudy",
+        ]
+    finally:
+        os.unlink(tmp)
+
+
+def test_engine_test_events_defaults():
+    """A row inserted with only required fields picks up the defaults
+    (zero seconds, 'snap' thrust mode, in-study).
+    """
+    tmp = tempfile.NamedTemporaryFile(suffix=".alaqs", delete=False).name
+    try:
+        db = EngineTestEventsDatabase(tmp)
+        db.recreate_table()
+        with sqlite3.connect(tmp) as c:
+            c.execute(
+                "INSERT INTO engine_test_events "
+                "(source_id, start_datetime, end_datetime, aircraft_type) "
+                "VALUES (?, ?, ?, ?)",
+                ("N1", "2024-12-01T09:15:00", "2024-12-01T09:45:00", "C56X"),
+            )
+            row = c.execute(
+                "SELECT t_TX_s, t_AP_s, t_CL_s, t_TO_s, thrust_mode, instudy "
+                "FROM engine_test_events"
+            ).fetchone()
+        assert row == (0, 0, 0, 0, "snap", "1")
+    finally:
+        os.unlink(tmp)
+
+
+def test_engine_test_events_source_id_not_null_enforced():
+    """SQLite enforces the NOT NULL constraint on source_id."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".alaqs", delete=False).name
+    try:
+        db = EngineTestEventsDatabase(tmp)
+        db.recreate_table()
+        with sqlite3.connect(tmp) as c:
+            with pytest.raises(sqlite3.IntegrityError):
+                c.execute(
+                    "INSERT INTO engine_test_events "
+                    "(start_datetime, end_datetime, aircraft_type) "
+                    "VALUES (?, ?, ?)",
+                    ("2024-12-01T09:15:00", "2024-12-01T09:45:00", "C56X"),
+                )
+    finally:
+        os.unlink(tmp)

--- a/tools/template_build/generate_templates.py
+++ b/tools/template_build/generate_templates.py
@@ -56,6 +56,7 @@ def get_sql_serializable_registry(file_type: str) -> list:
         EngineEmissionIndicesDatabase,
         EngineModeDatabase,
     )
+    from open_alaqs.core.interfaces.EngineTestEvents import EngineTestEventsDatabase
     from open_alaqs.core.interfaces.Gate import (
         DefaultGateEmissionProfileDatabase,
         GateDatabase,
@@ -112,9 +113,11 @@ def get_sql_serializable_registry(file_type: str) -> list:
         UserMonthProfileDatabase,
     ]
     # Per-template extras: project-only and inventory-only tables.
-    # Currently empty; reserved for future per-template-only schemas.
+    # engine_test_events lives in the project template (it holds user-editable
+    # test-run event definitions), not in the inventory template (inventory
+    # holds computed emissions, no event tables).
     template_specific = {
-        "project": [],
+        "project": [EngineTestEventsDatabase],
         "inventory": [],
     }
     return shared + template_specific[file_type]


### PR DESCRIPTION
Schema-only change in preparation for the engine-test emissions add-on.
No behavioural change to existing area sources; nothing downstream
consumes the new columns yet (bindings arrive in phase 2 interfaces
and phase 3 compute module).

## What changed

Plugin side:
- `shapes_area_sources` gains `is_test_site TEXT` column (matches the
  `instudy` boolean convention: `'0'`/`'1'`, default `'0'`).
- New `engine_test_events` table (14 columns) with index on
  `(source_id, start_datetime)`, registered in the project-only
  extras of the template registry.
- `AreaSources` dataclass exposes `isTestSite()` / `setTestSite()`.
  Rows written by pre-1b plugin versions read as `False` (backward
  compatible).
- 8 plugin unit tests (QGIS-gated).

Standalone side:
- `openalaqs_standalone/extract_sources.py` skips `is_test_site='1'`
  rows with a single diagnostic log line. Backward compatible with
  pre-1b projects whose `shapes_area_sources` lacks the column.
- 5 standalone tests, QGIS-free.

## Migration for existing projects

No new migration code. Users run `python scripts/migrate_alaqs.py
my_project.alaqs` on their existing projects. The existing migration
tool diffs against the regenerated template and applies
`ALTER TABLE ADD COLUMN` and `CREATE TABLE` automatically. This is the
same UX the codebase already uses for schema evolution.

## Not in this PR

- **Template regeneration** (`open_alaqs/core/templates/project.alaqs`).
  A separate commit / PR should run `python tools/template_build/
  generate_templates.py` and commit the regenerated template so fresh
  projects pick up the new schema. Not folded in here because
  regeneration requires the plugin's Python env and may pick up
  unrelated template drift that needs a review pass.
- No compute module, no UI toggle, no dataclass/store for events.
  Those are Phase 2 and Phase 3.

## Verification

- **DDL**: exact `CREATE TABLE` executed against plain SQLite; column
  order, defaults (`t_*_s = 0`, `thrust_mode = 'snap'`, `instudy = '1'`),
  and NOT NULL constraints all confirmed.
- **Standalone tests**: 950 passed (940 phase-1a + 5 pre-existing BFFM2
  + 5 new phase-1b) in 2.79s.
- **pre-commit**: autoflake / isort / black / flake8 all clean under
  the pinned versions.

Depends on: #331 (phase 1a, already merged as cb9024e).
Followed by: template regeneration (small follow-up PR), then phase 2
interfaces (EngineTestEvent dataclass, EngineTestEventsStore).