### PR TITLE
Phase 2: interfaces — EngineTestEvent + EngineTestEventsStore

### DIFF
--- a/open_alaqs/core/interfaces/AreaSources.py
+++ b/open_alaqs/core/interfaces/AreaSources.py
@@ -86,6 +86,21 @@ class AreaSources(Source):
     def setTestSite(self, flag: bool) -> None:
         self._is_test_site = bool(flag)
 
+    def getEngineTestEvents(self, events_store) -> list:
+        """Return the ``EngineTestEvent`` objects associated with this
+        area source.
+
+        Returns ``[]`` for area sources not flagged as test sites, even
+        if an event happens to share the same ``source_id`` in the
+        database (defensive against stale rows in ``engine_test_events``
+        after a source's ``is_test_site`` flag has been flipped back
+        to ``'0'``). To retrieve events regardless of the flag, call
+        ``events_store.getEventsBySourceId(source_id)`` directly.
+        """
+        if not self._is_test_site or events_store is None:
+            return []
+        return events_store.getEventsBySourceId(self._id)
+
     def __str__(self):
         val = "\n AreaSources with id '%s'" % (self.getName())
         val += "\n\t Units per Year: %f" % (self.getUnitsPerYear())

--- a/open_alaqs/core/interfaces/EngineTestEvent.py
+++ b/open_alaqs/core/interfaces/EngineTestEvent.py
@@ -1,0 +1,331 @@
+"""Dataclass wrapping one row of ``engine_test_events``.
+
+Introduced in Phase 2 alongside ``EngineTestEventsStore``. Consumed by
+the Phase 3 compute module (``EngineTestSourceModule``) and by the
+convenience accessor ``AreaSources.getEngineTestEvents``.
+
+Structurally mirrors ``Movement`` in ``Movement.py``: field parsing in
+``__init__`` from a dict, accessor methods per field, resolvers against
+the aircraft/engine stores.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from open_alaqs.core.alaqslogging import get_logger
+
+logger = get_logger(__name__)
+
+
+# Tolerance for the "running seconds exceed the window duration" consistency
+# check. Kept generous (60 s) because logbook remarks in the wild commonly
+# round to the nearest minute; a stricter tolerance would fire on innocuous
+# rounding and drown out the real anomalies.
+_RUNNING_EXCEEDS_WINDOW_TOLERANCE_S = 60
+
+_MODE_KEYS = ("TX", "AP", "CL", "TO")
+_MODE_COLUMN = {
+    "TX": "t_TX_s",
+    "AP": "t_AP_s",
+    "CL": "t_CL_s",
+    "TO": "t_TO_s",
+}
+
+
+def _parse_iso_datetime(s: Any) -> Optional[datetime]:
+    """Best-effort ISO 8601 parser for ``start_datetime`` / ``end_datetime``.
+
+    Returns ``None`` for empty inputs. Raises ``ValueError`` for
+    unparseable non-empty inputs, matching the datetime module's own
+    behaviour so bad data is loud, not silent.
+    """
+    if s is None:
+        return None
+    s = str(s).strip()
+    if s == "":
+        return None
+    # datetime.fromisoformat accepts YYYY-MM-DDTHH:MM:SS and variants.
+    # Normalise a trailing "Z" (UTC) into "+00:00" for py<3.11 compat.
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    return datetime.fromisoformat(s)
+
+
+def _to_int(v: Any, default: int = 0) -> int:
+    """Coerce to int with a default. Used for engine_count and mode-time
+    columns to tolerate NULL / empty-string values coming from SQLite.
+    """
+    if v is None or v == "":
+        return default
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+class EngineTestEvent:
+    """One engine-test event, wrapping one row of ``engine_test_events``.
+
+    Constructed either from a ``val`` dict (as returned by
+    ``EngineTestEventsDatabase.getEntries().values()``) or field-by-field
+    via the setters. Missing / empty fields fall back to safe defaults so
+    partial rows do not crash construction; ``getConsistencyWarnings``
+    surfaces anything unusual.
+    """
+
+    def __init__(self, val: Optional[dict] = None):
+        if val is None:
+            val = {}
+
+        self._event_id: Optional[int] = (
+            _to_int(val.get("event_id"), default=None)
+            if val.get("event_id") is not None
+            else None
+        )
+        self._source_id: str = str(val.get("source_id", "")).strip()
+        self._test_id: str = str(val.get("test_id", "") or "").strip()
+
+        # Datetimes: parsed lazily so a bad string doesn't abort construction,
+        # but the raw string is preserved on the instance so callers can see
+        # the offending input in error messages.
+        self._start_datetime_raw = val.get("start_datetime")
+        self._end_datetime_raw = val.get("end_datetime")
+        try:
+            self._start_datetime = _parse_iso_datetime(self._start_datetime_raw)
+        except ValueError:
+            logger.warning(
+                "EngineTestEvent %s: unparseable start_datetime %r",
+                self._event_id,
+                self._start_datetime_raw,
+            )
+            self._start_datetime = None
+        try:
+            self._end_datetime = _parse_iso_datetime(self._end_datetime_raw)
+        except ValueError:
+            logger.warning(
+                "EngineTestEvent %s: unparseable end_datetime %r",
+                self._event_id,
+                self._end_datetime_raw,
+            )
+            self._end_datetime = None
+
+        self._aircraft_type: str = str(val.get("aircraft_type", "")).strip()
+
+        # engine_uid may be NULL in the schema; empty string treated same as NULL.
+        raw_uid = val.get("engine_uid")
+        self._engine_uid: Optional[str] = (
+            str(raw_uid).strip() if raw_uid not in (None, "") else None
+        )
+
+        # engine_count may be NULL; None means "use aircraft default at
+        # resolve time".
+        raw_count = val.get("engine_count")
+        self._engine_count: Optional[int] = (
+            _to_int(raw_count) if raw_count not in (None, "") else None
+        )
+
+        self._t_TX_s: int = _to_int(val.get("t_TX_s"))
+        self._t_AP_s: int = _to_int(val.get("t_AP_s"))
+        self._t_CL_s: int = _to_int(val.get("t_CL_s"))
+        self._t_TO_s: int = _to_int(val.get("t_TO_s"))
+
+        self._thrust_mode: str = str(val.get("thrust_mode", "snap") or "snap").strip()
+
+        # instudy: TEXT '1' / '0'; treat NULL/empty as in-study (default '1'
+        # in schema). Matches how AreaSources handles instudy.
+        self._instudy: bool = str(val.get("instudy", "1") or "1").strip() == "1"
+
+    # ── Identity ────────────────────────────────────────────────────────
+
+    def getEventId(self) -> Optional[int]:
+        return self._event_id
+
+    def getSourceId(self) -> str:
+        return self._source_id
+
+    def getTestId(self) -> str:
+        return self._test_id
+
+    # ── Datetime / duration ─────────────────────────────────────────────
+
+    def getStartDateTime(self) -> Optional[datetime]:
+        return self._start_datetime
+
+    def getEndDateTime(self) -> Optional[datetime]:
+        return self._end_datetime
+
+    def getDurationSeconds(self) -> Optional[float]:
+        """Total seconds between start and end. Returns None if either
+        datetime failed to parse."""
+        if self._start_datetime is None or self._end_datetime is None:
+            return None
+        return (self._end_datetime - self._start_datetime).total_seconds()
+
+    # ── Mode times ──────────────────────────────────────────────────────
+
+    def getModeTimes(self) -> dict:
+        """Return per-mode seconds as a dict keyed by ICAO mode code."""
+        return {
+            "TX": self._t_TX_s,
+            "AP": self._t_AP_s,
+            "CL": self._t_CL_s,
+            "TO": self._t_TO_s,
+        }
+
+    def getRunningSeconds(self) -> int:
+        """Sum of the four per-mode seconds. Total time the engine is
+        producing emissions during the event."""
+        return self._t_TX_s + self._t_AP_s + self._t_CL_s + self._t_TO_s
+
+    # ── Aircraft / engine identity ──────────────────────────────────────
+
+    def getAircraftType(self) -> str:
+        return self._aircraft_type
+
+    def getEngineUid(self) -> Optional[str]:
+        return self._engine_uid
+
+    def getEngineCount(self) -> Optional[int]:
+        """Raw engine_count as stored on the row. None means "not set;
+        resolve against aircraft default at compute time". Use
+        ``resolveEngineCount`` when you want the effective count.
+        """
+        return self._engine_count
+
+    def getThrustMode(self) -> str:
+        return self._thrust_mode
+
+    def isInStudy(self) -> bool:
+        return self._instudy
+
+    # ── Resolvers against upstream stores ───────────────────────────────
+
+    def getAircraft(self, aircraft_store) -> Optional[Any]:
+        """Resolve ``aircraft_type`` against an ``AircraftStore``.
+
+        Returns the ``Aircraft`` instance if found, else ``None``. Does
+        not raise; the caller decides whether an unresolved type is
+        fatal or just a warning.
+        """
+        if not self._aircraft_type or aircraft_store is None:
+            return None
+        try:
+            return aircraft_store.getObject(self._aircraft_type)
+        except Exception:  # pragma: no cover
+            return None
+
+    def getEngine(self, engine_store, aircraft=None) -> Optional[Any]:
+        """Resolve the engine for this event.
+
+        Precedence:
+          1. If ``engine_uid`` is set on the row, look it up in the
+             ``EngineStore``.
+          2. Otherwise fall back to ``aircraft.getDefaultEngine()`` if
+             ``aircraft`` is provided.
+          3. Otherwise ``None``.
+
+        Does not raise; unresolved returns ``None``.
+        """
+        if self._engine_uid and engine_store is not None:
+            try:
+                eng = engine_store.getObject(self._engine_uid)
+                if eng is not None:
+                    return eng
+            except Exception:  # pragma: no cover
+                pass
+
+        if aircraft is not None:
+            try:
+                return aircraft.getDefaultEngine()
+            except Exception:  # pragma: no cover
+                return None
+
+        return None
+
+    def resolveEngineCount(self, aircraft=None) -> Optional[int]:
+        """Return the effective engine count for this event.
+
+        Uses the row's ``engine_count`` if set, else the aircraft's
+        default engine count if ``aircraft`` is provided, else ``None``.
+        """
+        if self._engine_count is not None:
+            return self._engine_count
+        if aircraft is not None:
+            for attr in ("engine_count", "getEngineCount"):
+                candidate = getattr(aircraft, attr, None)
+                if callable(candidate):
+                    try:
+                        return int(candidate())
+                    except Exception:  # pragma: no cover
+                        pass
+                elif candidate is not None:
+                    try:
+                        return int(candidate)
+                    except Exception:  # pragma: no cover
+                        pass
+        return None
+
+    # ── Diagnostics ─────────────────────────────────────────────────────
+
+    def getConsistencyWarnings(self) -> list:
+        """Return a list of non-fatal issues detected on this event.
+
+        Codes returned:
+          * ``"missing_start_datetime"`` / ``"missing_end_datetime"``:
+            datetime failed to parse.
+          * ``"end_before_start"``: end is chronologically before start.
+          * ``"negative_running"``: at least one t_* is negative.
+          * ``"running_exceeds_window"``: sum of t_* exceeds
+            ``duration + tolerance`` (tolerance = 60 s, generous because
+            logbook remarks commonly round to the minute).
+          * ``"zero_running"``: sum of t_* is zero; the event will
+            emit nothing.
+          * ``"missing_aircraft_type"``: aircraft_type is empty.
+        """
+        warnings = []
+
+        if self._start_datetime is None:
+            warnings.append("missing_start_datetime")
+        if self._end_datetime is None:
+            warnings.append("missing_end_datetime")
+
+        if (
+            self._start_datetime is not None
+            and self._end_datetime is not None
+            and self._end_datetime < self._start_datetime
+        ):
+            warnings.append("end_before_start")
+
+        if any(t < 0 for t in (self._t_TX_s, self._t_AP_s, self._t_CL_s, self._t_TO_s)):
+            warnings.append("negative_running")
+
+        running = self.getRunningSeconds()
+        duration = self.getDurationSeconds()
+        if (
+            duration is not None
+            and running > duration + _RUNNING_EXCEEDS_WINDOW_TOLERANCE_S
+        ):
+            warnings.append("running_exceeds_window")
+
+        if running == 0:
+            warnings.append("zero_running")
+
+        if not self._aircraft_type:
+            warnings.append("missing_aircraft_type")
+
+        return warnings
+
+    # ── Debug / logging ─────────────────────────────────────────────────
+
+    def __repr__(self) -> str:
+        return (
+            f"EngineTestEvent(event_id={self._event_id!r}, "
+            f"source_id={self._source_id!r}, test_id={self._test_id!r}, "
+            f"aircraft_type={self._aircraft_type!r}, "
+            f"engine_uid={self._engine_uid!r}, "
+            f"start={self._start_datetime!r}, end={self._end_datetime!r}, "
+            f"running={self.getRunningSeconds()}s, "
+            f"thrust_mode={self._thrust_mode!r}, instudy={self._instudy})"
+        )

--- a/open_alaqs/core/interfaces/EngineTestEvents.py
+++ b/open_alaqs/core/interfaces/EngineTestEvents.py
@@ -1,28 +1,28 @@
-"""Schema definition for the ``engine_test_events`` table.
+"""Schema and store for the ``engine_test_events`` table.
 
-Phase 1b introduces only the schema. The Python interface layer
-(``EngineTestEvent`` dataclass, ``EngineTestEventsStore``) is deferred
-to Phase 2. This file exists so ``tools/template_build/generate_templates.py``
-can register the table via the standard ``SQLSerializable`` mechanism, so
-that fresh projects created from the template already contain the table.
+Phase 1b introduced the schema (``EngineTestEventsDatabase``). Phase 2
+adds the loader (``EngineTestEventsStore``), which reads rows into
+``EngineTestEvent`` instances and offers period-window and
+source-window filters used by the Phase 3 compute module.
 
 Design context (per phase 0 decisions memo):
 
 - D5: one aircraft/engine type per event. Mixed-type tests are represented
   as two rows sharing ``source_id``, ``start_datetime``, ``end_datetime``.
-- D12: mode times stored as INTEGER seconds (``t_TX_s`` etc.). Sub-second
-  precision is not meaningful for run-up events.
+- D10: interval-overlap semantics for period membership. An event with
+  window ``[e_start, e_end]`` overlaps a period ``[p_start, p_end]`` iff
+  ``e_start < p_end AND e_end > p_start``. Strict ``<`` (event touching
+  the period boundary does not overlap it).
+- D12: mode times stored as INTEGER seconds. Sub-second precision is not
+  meaningful for run-up events.
 - D2 (thrust mode): per-event override of the study-wide default. The
   ``thrust_mode`` column carries either ``'snap'`` (nearest ICAO point) or
   ``'meem'`` (interpolation). Default ``'snap'``.
-- Boolean convention (per Phase 1b decision): ``instudy`` uses TEXT
-  ``'0'`` / ``'1'`` for parity with the rest of the codebase.
 
-Foreign key is intentionally NOT declared. SQLite does not enforce FKs
-by default in this codebase, and orphaned events must be tolerated
-(a user might delete the parent area source in QGIS without
-ON DELETE CASCADE). The engine-test source module (Phase 3) handles
-orphans by skip-with-warning.
+Foreign key on ``source_id`` intentionally NOT declared. SQLite does not
+enforce FKs by default in this codebase, and orphaned events must be
+tolerated (a user might delete the parent area source without ON DELETE
+CASCADE). The Phase 3 compute module handles orphans by skip-with-warning.
 
 Index on ``(source_id, start_datetime)`` supports the period-window
 query pattern of the compute module.
@@ -31,17 +31,25 @@ query pattern of the compute module.
 from __future__ import annotations
 
 from collections import OrderedDict
+from datetime import datetime
+from typing import Optional
 
+from open_alaqs.core.alaqslogging import get_logger
+from open_alaqs.core.interfaces.EngineTestEvent import EngineTestEvent
 from open_alaqs.core.interfaces.SQLSerializable import SQLSerializable
+from open_alaqs.core.interfaces.Store import Store
 from open_alaqs.core.tools.Singleton import Singleton
+
+logger = get_logger(__name__)
 
 
 class EngineTestEventsDatabase(SQLSerializable, metaclass=Singleton):
-    """Schema-only representation of the ``engine_test_events`` table.
+    """Schema wrapper for the ``engine_test_events`` table.
 
     Instantiating this class against a database is enough for the
-    template-generation pipeline to CREATE the table. Reading and
-    writing rows is deferred to ``EngineTestEventsStore`` in Phase 2.
+    template-generation pipeline to CREATE the table. Loading rows into
+    ``EngineTestEvent`` objects is the responsibility of
+    ``EngineTestEventsStore``.
     """
 
     TABLE_NAME = "engine_test_events"
@@ -88,12 +96,113 @@ class EngineTestEventsDatabase(SQLSerializable, metaclass=Singleton):
             geometry_columns,
         )
 
-        # Deserialize is a no-op for Phase 1b since we do not yet own
-        # a dataclass reader; the table just needs to exist.
+        # deserialize is defensive: fresh projects lack the table; the
+        # table also doesn't exist in pre-v1b projects opened by the new
+        # plugin before migration has been run. Both cases are non-fatal
+        # here (the Store instantiates with an empty entry set); the
+        # migration script or template creation restore the table.
         if deserialize:
             try:
                 self.deserialize()
             except Exception:
-                # Fresh project: table not present yet. Non-fatal —
-                # recreate_table() will create it during template generation.
                 pass
+
+
+class EngineTestEventsStore(Store, metaclass=Singleton):
+    """Loader for ``engine_test_events`` into ``EngineTestEvent`` objects.
+
+    Consumed by the Phase 3 ``EngineTestSourceModule`` and by the
+    ``AreaSources.getEngineTestEvents`` convenience accessor. Provides
+    two filtered views:
+      * ``getEventsBySourceId(source_id)`` — all events for one test site.
+      * ``getEventsInPeriod(start, end)`` — all events overlapping a
+        period window, across all test sites. Interval-overlap semantics
+        (per D10 in the phase 0 memo): ``e_start < p_end AND e_end > p_start``.
+    """
+
+    def __init__(self, db_path: str = "", db: Optional[dict] = None):
+        if db is None:
+            db = {}
+        Store.__init__(self, ordered=True)
+
+        self._db_path = db_path
+
+        self._events_db: Optional[EngineTestEventsDatabase] = None
+        if "engine_test_events_db" in db:
+            candidate = db["engine_test_events_db"]
+            if isinstance(candidate, EngineTestEventsDatabase):
+                self._events_db = candidate
+
+        if self._events_db is None:
+            self._events_db = EngineTestEventsDatabase(db_path)
+
+        self.initEngineTestEvents()
+
+    def initEngineTestEvents(self) -> None:
+        """Load all rows from the database into ``EngineTestEvent``
+        instances keyed by ``event_id`` in the Store's ordered map.
+
+        Rows with a NULL / missing ``event_id`` are skipped with a
+        warning; they cannot be reliably indexed. (This should never
+        happen in practice because the schema declares
+        ``INTEGER PRIMARY KEY AUTOINCREMENT``, but defensive.)
+        """
+        try:
+            entries = self._events_db.getEntries()
+        except Exception as e:
+            # Table absent (pre-v1b project pre-migration, or a fresh
+            # DB that has not run recreate_table). Non-fatal; store
+            # stays empty and downstream sees no events.
+            logger.debug("EngineTestEventsStore: no entries loaded (%s)", e)
+            return
+
+        for key, event_dict in list(entries.items()):
+            event = EngineTestEvent(event_dict)
+            event_id = event.getEventId()
+            if event_id is None:
+                logger.warning(
+                    "EngineTestEventsStore: row with no event_id skipped: %r",
+                    event_dict,
+                )
+                continue
+            # Store keyed by event_id, an int. Store's ordered=True
+            # preserves insertion (= DB row) order for stable iteration.
+            self.setObject(event_id, event)
+
+    def getEngineTestEventsDatabase(self) -> EngineTestEventsDatabase:
+        return self._events_db
+
+    def getEventsBySourceId(self, source_id: str) -> list:
+        """Return all events whose ``source_id`` matches. Order is stable
+        (row order in the database). Returns ``[]`` for unknown ids.
+        """
+        if not source_id:
+            return []
+        return [
+            event
+            for event in self._objects.values()
+            if event.getSourceId() == source_id
+        ]
+
+    def getEventsInPeriod(self, period_start: datetime, period_end: datetime) -> list:
+        """Return all events whose window overlaps ``[period_start, period_end]``.
+
+        Interval-overlap semantics (D10 in the phase 0 memo):
+        ``e_start < period_end AND e_end > period_start``. Strict ``<`` /
+        ``>``; an event ending exactly at ``period_start`` or starting
+        exactly at ``period_end`` does not overlap.
+
+        Events with missing or unparseable start / end datetimes are
+        skipped (they surface as consistency warnings elsewhere).
+        """
+        if period_start is None or period_end is None:
+            return []
+        out = []
+        for event in self._objects.values():
+            e_start = event.getStartDateTime()
+            e_end = event.getEndDateTime()
+            if e_start is None or e_end is None:
+                continue
+            if e_start < period_end and e_end > period_start:
+                out.append(event)
+        return out

--- a/tests/test_phase2_engine_test_event_plugin.py
+++ b/tests/test_phase2_engine_test_event_plugin.py
@@ -1,0 +1,580 @@
+"""Phase 2: plugin-side tests for the ``EngineTestEvent`` dataclass,
+``EngineTestEventsStore``, and the ``AreaSources.getEngineTestEvents``
+convenience accessor.
+
+Requires QGIS Python for the SQLSerializable-based instantiation of
+``EngineTestEventsDatabase`` and ``AreaSourcesDatabase``, because
+``SQLSerializable`` imports ``sql_interface`` which pulls in
+``qgis.utils.spatialite_connect``. Run under OSGeo4W shell:
+
+    python-qgis-ltr -m pytest tests/test_phase2_engine_test_event_plugin.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+from datetime import datetime
+
+import pytest
+
+try:
+    from qgis.core import QgsApplication  # noqa: F401
+
+    from open_alaqs.core.interfaces.AreaSources import (
+        AreaSources,
+        AreaSourcesDatabase,
+        AreaSourcesStore,
+    )
+    from open_alaqs.core.interfaces.EngineTestEvent import EngineTestEvent
+    from open_alaqs.core.interfaces.EngineTestEvents import (
+        EngineTestEventsDatabase,
+        EngineTestEventsStore,
+    )
+
+    HAS_QGIS = True
+except Exception:  # pragma: no cover
+    HAS_QGIS = False
+
+
+pytestmark = pytest.mark.skipif(
+    not HAS_QGIS, reason="QGIS Python not importable in this environment"
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    """Reset the Singleton caches on every Database and Store class this
+    test file touches, before AND after every test. Without this, a
+    Database or Store created by an earlier test (in this file or the
+    wider suite) is returned by the Singleton metaclass and still points
+    at a now-deleted temp path, causing INSERT/SELECT against the current
+    test's tempfile to see an empty database.
+    """
+    if HAS_QGIS:
+        AreaSourcesDatabase.reset()
+        AreaSourcesStore.reset()
+        EngineTestEventsDatabase.reset()
+        EngineTestEventsStore.reset()
+    yield
+    if HAS_QGIS:
+        AreaSourcesDatabase.reset()
+        AreaSourcesStore.reset()
+        EngineTestEventsDatabase.reset()
+        EngineTestEventsStore.reset()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 1: EngineTestEvent dataclass
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _row(**kwargs):
+    """Return a fully-populated event row dict, with sensible defaults so
+    each test can override just the fields it cares about."""
+    base = {
+        "event_id": 1,
+        "source_id": "N1",
+        "test_id": "T-001",
+        "start_datetime": "2024-12-01T09:00:00",
+        "end_datetime": "2024-12-01T09:30:00",
+        "aircraft_type": "C56X",
+        "engine_uid": "B602",
+        "engine_count": 2,
+        "t_TX_s": 300,
+        "t_AP_s": 0,
+        "t_CL_s": 900,
+        "t_TO_s": 0,
+        "thrust_mode": "snap",
+        "instudy": "1",
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_event_field_parsing():
+    e = EngineTestEvent(_row())
+    assert e.getEventId() == 1
+    assert e.getSourceId() == "N1"
+    assert e.getTestId() == "T-001"
+    assert e.getAircraftType() == "C56X"
+    assert e.getEngineUid() == "B602"
+    assert e.getEngineCount() == 2
+    assert e.getThrustMode() == "snap"
+    assert e.isInStudy() is True
+    assert e.getStartDateTime() == datetime(2024, 12, 1, 9, 0, 0)
+    assert e.getEndDateTime() == datetime(2024, 12, 1, 9, 30, 0)
+
+
+def test_event_duration_and_running_seconds():
+    e = EngineTestEvent(_row())  # 30-min window, 300+900 = 1200s running
+    assert e.getDurationSeconds() == 30 * 60
+    assert e.getRunningSeconds() == 300 + 900
+
+
+def test_event_mode_times_dict():
+    e = EngineTestEvent(_row(t_TX_s=100, t_AP_s=200, t_CL_s=300, t_TO_s=400))
+    assert e.getModeTimes() == {"TX": 100, "AP": 200, "CL": 300, "TO": 400}
+
+
+def test_event_null_engine_uid_and_count():
+    """engine_uid=None and engine_count=None are represented as Python
+    None on the dataclass, not empty string or 0."""
+    e = EngineTestEvent(_row(engine_uid=None, engine_count=None))
+    assert e.getEngineUid() is None
+    assert e.getEngineCount() is None
+
+
+def test_event_empty_string_engine_uid_treated_as_none():
+    """Empty-string engine_uid is treated the same as NULL."""
+    e = EngineTestEvent(_row(engine_uid=""))
+    assert e.getEngineUid() is None
+
+
+def test_event_instudy_zero_string():
+    e = EngineTestEvent(_row(instudy="0"))
+    assert e.isInStudy() is False
+
+
+def test_event_thrust_mode_default_snap_on_empty():
+    """Empty / missing thrust_mode falls back to 'snap'."""
+    row = _row()
+    row.pop("thrust_mode")
+    e = EngineTestEvent(row)
+    assert e.getThrustMode() == "snap"
+
+
+# ── Consistency warnings ────────────────────────────────────────────────
+
+
+def test_event_consistency_clean_row_no_warnings():
+    e = EngineTestEvent(_row())
+    assert e.getConsistencyWarnings() == []
+
+
+def test_event_consistency_zero_running_flagged():
+    e = EngineTestEvent(_row(t_TX_s=0, t_AP_s=0, t_CL_s=0, t_TO_s=0))
+    assert "zero_running" in e.getConsistencyWarnings()
+
+
+def test_event_consistency_negative_time_flagged():
+    e = EngineTestEvent(_row(t_TX_s=-100))
+    assert "negative_running" in e.getConsistencyWarnings()
+
+
+def test_event_consistency_running_exceeds_window_flagged():
+    """A 30-min window (1800s) with 2000s of running (200s > 60s tolerance)
+    fires the warning."""
+    e = EngineTestEvent(
+        _row(
+            start_datetime="2024-12-01T09:00:00",
+            end_datetime="2024-12-01T09:30:00",
+            t_TX_s=2000,
+            t_AP_s=0,
+            t_CL_s=0,
+            t_TO_s=0,
+        )
+    )
+    assert "running_exceeds_window" in e.getConsistencyWarnings()
+
+
+def test_event_consistency_running_within_tolerance_no_warning():
+    """Sub-tolerance overshoot (running - duration <= 60s) does not fire
+    the warning. Justifies the tolerance value against the RTHA-style
+    logbook precision."""
+    e = EngineTestEvent(
+        _row(
+            start_datetime="2024-12-01T09:00:00",
+            end_datetime="2024-12-01T09:30:00",  # 1800s window
+            # Override all four mode times so the total running is what
+            # the assertion expects. Leaving the _row() defaults in place
+            # would add t_CL_s=900 on top of t_TX_s=1850 for a total of
+            # 2750s (a 950s overshoot, well above the 60s tolerance).
+            t_TX_s=1850,  # +50s over the window, within 60s tolerance
+            t_AP_s=0,
+            t_CL_s=0,
+            t_TO_s=0,
+        )
+    )
+    assert "running_exceeds_window" not in e.getConsistencyWarnings()
+
+
+def test_event_consistency_end_before_start_flagged():
+    e = EngineTestEvent(
+        _row(
+            start_datetime="2024-12-01T10:00:00",
+            end_datetime="2024-12-01T09:30:00",
+        )
+    )
+    assert "end_before_start" in e.getConsistencyWarnings()
+
+
+def test_event_consistency_missing_aircraft_type_flagged():
+    e = EngineTestEvent(_row(aircraft_type=""))
+    assert "missing_aircraft_type" in e.getConsistencyWarnings()
+
+
+def test_event_consistency_unparseable_datetime_flagged():
+    e = EngineTestEvent(_row(start_datetime="not-a-date"))
+    warnings = e.getConsistencyWarnings()
+    assert "missing_start_datetime" in warnings
+
+
+# ── Resolvers with mocks ────────────────────────────────────────────────
+
+
+def test_event_get_aircraft_returns_from_store():
+    class FakeStore:
+        def getObject(self, key):
+            return f"aircraft-for-{key}"
+
+    e = EngineTestEvent(_row(aircraft_type="C56X"))
+    assert e.getAircraft(FakeStore()) == "aircraft-for-C56X"
+
+
+def test_event_get_aircraft_none_on_empty_type():
+    class FakeStore:
+        def getObject(self, key):  # pragma: no cover
+            return "should-not-be-called"
+
+    e = EngineTestEvent(_row(aircraft_type=""))
+    assert e.getAircraft(FakeStore()) is None
+
+
+def test_event_get_engine_uid_wins_over_aircraft_default():
+    """When engine_uid is set on the row, the row's UID is looked up in
+    the engine store; the aircraft's default engine is not consulted."""
+
+    class FakeEngineStore:
+        def getObject(self, key):
+            return f"engine-{key}"
+
+    class FakeAircraft:
+        def getDefaultEngine(self):  # pragma: no cover
+            return "aircraft-default-engine"
+
+    e = EngineTestEvent(_row(engine_uid="B602"))
+    assert e.getEngine(FakeEngineStore(), FakeAircraft()) == "engine-B602"
+
+
+def test_event_get_engine_falls_back_to_aircraft_default_when_uid_missing():
+    class FakeEngineStore:
+        def getObject(self, key):  # pragma: no cover
+            return "should-not-be-called"
+
+    class FakeAircraft:
+        def getDefaultEngine(self):
+            return "aircraft-default-engine"
+
+    e = EngineTestEvent(_row(engine_uid=None))
+    assert e.getEngine(FakeEngineStore(), FakeAircraft()) == "aircraft-default-engine"
+
+
+def test_event_get_engine_none_when_both_paths_unavailable():
+    e = EngineTestEvent(_row(engine_uid=None))
+    assert e.getEngine(engine_store=None, aircraft=None) is None
+
+
+def test_event_resolve_engine_count_row_wins():
+    class FakeAircraft:
+        engine_count = 4
+
+    e = EngineTestEvent(_row(engine_count=2))
+    assert e.resolveEngineCount(FakeAircraft()) == 2
+
+
+def test_event_resolve_engine_count_falls_back_to_aircraft_attribute():
+    class FakeAircraft:
+        engine_count = 4
+
+    e = EngineTestEvent(_row(engine_count=None))
+    assert e.resolveEngineCount(FakeAircraft()) == 4
+
+
+def test_event_resolve_engine_count_falls_back_to_aircraft_method():
+    class FakeAircraft:
+        def getEngineCount(self):
+            return 3
+
+    e = EngineTestEvent(_row(engine_count=None))
+    assert e.resolveEngineCount(FakeAircraft()) == 3
+
+
+def test_event_resolve_engine_count_none_when_all_paths_unavailable():
+    e = EngineTestEvent(_row(engine_count=None))
+    assert e.resolveEngineCount(aircraft=None) is None
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 2: EngineTestEventsStore
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _seed_events_db(db_path: str, rows: list[dict]) -> None:
+    """Directly insert engine_test_events rows into a scratch DB, bypassing
+    the SQLSerializable layer. Used to construct fixtures for the store
+    tests. The Store class picks the rows up on load."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS engine_test_events (
+            event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            source_id TEXT NOT NULL,
+            test_id TEXT,
+            start_datetime TEXT NOT NULL,
+            end_datetime TEXT NOT NULL,
+            aircraft_type TEXT NOT NULL,
+            engine_uid TEXT,
+            engine_count INTEGER,
+            t_TX_s INTEGER NOT NULL DEFAULT 0,
+            t_AP_s INTEGER NOT NULL DEFAULT 0,
+            t_CL_s INTEGER NOT NULL DEFAULT 0,
+            t_TO_s INTEGER NOT NULL DEFAULT 0,
+            thrust_mode TEXT NOT NULL DEFAULT 'snap',
+            instudy TEXT NOT NULL DEFAULT '1'
+        )
+        """
+    )
+    for r in rows:
+        cols = ", ".join(r.keys())
+        ph = ", ".join(["?"] * len(r))
+        conn.execute(
+            f"INSERT INTO engine_test_events ({cols}) VALUES ({ph})",
+            list(r.values()),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_store_loads_events_from_db():
+    tmp = tempfile.NamedTemporaryFile(suffix=".alaqs", delete=False).name
+    try:
+        _seed_events_db(
+            tmp,
+            [
+                {
+                    "source_id": "N1",
+                    "start_datetime": "2024-12-01T09:00:00",
+                    "end_datetime": "2024-12-01T09:30:00",
+                    "aircraft_type": "C56X",
+                },
+                {
+                    "source_id": "COMP",
+                    "start_datetime": "2024-12-01T14:00:00",
+                    "end_datetime": "2024-12-01T14:20:00",
+                    "aircraft_type": "B738",
+                },
+            ],
+        )
+        store = EngineTestEventsStore(tmp)
+        events = list(store._objects.values())
+        assert len(events) == 2
+        assert {e.getSourceId() for e in events} == {"N1", "COMP"}
+    finally:
+        os.unlink(tmp)
+
+
+def test_store_get_events_by_source_id():
+    tmp = tempfile.NamedTemporaryFile(suffix=".alaqs", delete=False).name
+    try:
+        _seed_events_db(
+            tmp,
+            [
+                {
+                    "source_id": "N1",
+                    "start_datetime": "2024-12-01T09:00:00",
+                    "end_datetime": "2024-12-01T09:30:00",
+                    "aircraft_type": "C56X",
+                },
+                {
+                    "source_id": "N1",
+                    "start_datetime": "2024-12-02T10:00:00",
+                    "end_datetime": "2024-12-02T10:15:00",
+                    "aircraft_type": "C56X",
+                },
+                {
+                    "source_id": "COMP",
+                    "start_datetime": "2024-12-01T14:00:00",
+                    "end_datetime": "2024-12-01T14:20:00",
+                    "aircraft_type": "B738",
+                },
+            ],
+        )
+        store = EngineTestEventsStore(tmp)
+        n1_events = store.getEventsBySourceId("N1")
+        assert len(n1_events) == 2
+        assert all(e.getSourceId() == "N1" for e in n1_events)
+
+        comp_events = store.getEventsBySourceId("COMP")
+        assert len(comp_events) == 1
+
+        assert store.getEventsBySourceId("UNKNOWN") == []
+        assert store.getEventsBySourceId("") == []
+    finally:
+        os.unlink(tmp)
+
+
+def test_store_get_events_in_period_overlap_semantics():
+    """Interval-overlap check across all five topology cases."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".alaqs", delete=False).name
+    try:
+        _seed_events_db(
+            tmp,
+            [
+                # 0: entirely before window
+                {
+                    "source_id": "N1",
+                    "start_datetime": "2024-12-01T08:00:00",
+                    "end_datetime": "2024-12-01T08:30:00",
+                    "aircraft_type": "C56X",
+                },
+                # 1: ending exactly at window start (touches; does NOT overlap)
+                {
+                    "source_id": "N1",
+                    "start_datetime": "2024-12-01T08:30:00",
+                    "end_datetime": "2024-12-01T09:00:00",
+                    "aircraft_type": "C56X",
+                },
+                # 2: spanning window start
+                {
+                    "source_id": "N1",
+                    "start_datetime": "2024-12-01T08:45:00",
+                    "end_datetime": "2024-12-01T09:15:00",
+                    "aircraft_type": "C56X",
+                },
+                # 3: entirely within window
+                {
+                    "source_id": "N1",
+                    "start_datetime": "2024-12-01T09:15:00",
+                    "end_datetime": "2024-12-01T09:45:00",
+                    "aircraft_type": "C56X",
+                },
+                # 4: spanning window end
+                {
+                    "source_id": "N1",
+                    "start_datetime": "2024-12-01T09:45:00",
+                    "end_datetime": "2024-12-01T10:15:00",
+                    "aircraft_type": "C56X",
+                },
+                # 5: starting exactly at window end (touches; does NOT overlap)
+                {
+                    "source_id": "N1",
+                    "start_datetime": "2024-12-01T10:00:00",
+                    "end_datetime": "2024-12-01T10:30:00",
+                    "aircraft_type": "C56X",
+                },
+                # 6: entirely after window
+                {
+                    "source_id": "N1",
+                    "start_datetime": "2024-12-01T11:00:00",
+                    "end_datetime": "2024-12-01T11:30:00",
+                    "aircraft_type": "C56X",
+                },
+            ],
+        )
+        store = EngineTestEventsStore(tmp)
+        period_start = datetime(2024, 12, 1, 9, 0, 0)
+        period_end = datetime(2024, 12, 1, 10, 0, 0)
+        overlapping = store.getEventsInPeriod(period_start, period_end)
+
+        # Expected: 2 (spanning start), 3 (in window), 4 (spanning end).
+        # NOT expected: 0 (before), 1 (touches start), 5 (touches end), 6 (after).
+        assert len(overlapping) == 3
+        starts = sorted(e.getStartDateTime() for e in overlapping)
+        assert starts == [
+            datetime(2024, 12, 1, 8, 45),
+            datetime(2024, 12, 1, 9, 15),
+            datetime(2024, 12, 1, 9, 45),
+        ]
+    finally:
+        os.unlink(tmp)
+
+
+def test_store_get_events_in_period_none_period_returns_empty():
+    tmp = tempfile.NamedTemporaryFile(suffix=".alaqs", delete=False).name
+    try:
+        _seed_events_db(tmp, [])
+        store = EngineTestEventsStore(tmp)
+        assert store.getEventsInPeriod(None, None) == []
+    finally:
+        os.unlink(tmp)
+
+
+def test_store_skips_events_with_unparseable_datetime_in_period_filter():
+    """Events whose start / end failed to parse are not returned by the
+    period filter (they surface via consistency warnings instead)."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".alaqs", delete=False).name
+    try:
+        _seed_events_db(
+            tmp,
+            [
+                {
+                    "source_id": "N1",
+                    "start_datetime": "garbage",
+                    "end_datetime": "also-garbage",
+                    "aircraft_type": "C56X",
+                },
+                {
+                    "source_id": "N1",
+                    "start_datetime": "2024-12-01T09:15:00",
+                    "end_datetime": "2024-12-01T09:45:00",
+                    "aircraft_type": "C56X",
+                },
+            ],
+        )
+        store = EngineTestEventsStore(tmp)
+        period_start = datetime(2024, 12, 1, 9, 0, 0)
+        period_end = datetime(2024, 12, 1, 10, 0, 0)
+        overlapping = store.getEventsInPeriod(period_start, period_end)
+        assert len(overlapping) == 1
+        assert overlapping[0].getStartDateTime() == datetime(2024, 12, 1, 9, 15)
+    finally:
+        os.unlink(tmp)
+
+
+def test_store_tolerates_missing_table():
+    """A DB with no engine_test_events table: store instantiates empty,
+    no exception."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".alaqs", delete=False).name
+    try:
+        # Fresh empty DB, no CREATE TABLE
+        store = EngineTestEventsStore(tmp)
+        assert store.getEventsBySourceId("N1") == []
+        assert (
+            store.getEventsInPeriod(datetime(2024, 1, 1), datetime(2024, 12, 31)) == []
+        )
+    finally:
+        os.unlink(tmp)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 3: AreaSource.getEngineTestEvents accessor
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_area_source_get_engine_test_events_returns_empty_for_normal_source():
+    """A normal area source (is_test_site='0') returns [] even if there
+    are events matching its source_id in the store."""
+
+    class FakeStore:
+        def getEventsBySourceId(self, source_id):  # pragma: no cover
+            return ["should-not-be-returned"]
+
+    src = AreaSources({"source_id": "A1", "is_test_site": "0"})
+    assert src.getEngineTestEvents(FakeStore()) == []
+
+
+def test_area_source_get_engine_test_events_returns_store_result_for_test_site():
+    class FakeStore:
+        def getEventsBySourceId(self, source_id):
+            return [f"event-{source_id}-1", f"event-{source_id}-2"]
+
+    src = AreaSources({"source_id": "N1", "is_test_site": "1"})
+    result = src.getEngineTestEvents(FakeStore())
+    assert result == ["event-N1-1", "event-N1-2"]
+
+
+def test_area_source_get_engine_test_events_none_store_returns_empty():
+    src = AreaSources({"source_id": "N1", "is_test_site": "1"})
+    assert src.getEngineTestEvents(None) == []


### PR DESCRIPTION
Python interface layer for engine-test events, on top of the Phase 1b
schema. Consumed by the Phase 3 compute module (not part of this PR).

## What changed

* `open_alaqs/core/interfaces/EngineTestEvent.py` (new)
  Dataclass wrapping one row of `engine_test_events`. Field parsing,
  time methods (`getDurationSeconds`, `getRunningSeconds`, `getModeTimes`),
  aircraft/engine resolvers against `AircraftStore` / `EngineStore`, and
  a `getConsistencyWarnings` surface for the seven anomalies expected
  in practice (missing/unparseable datetimes, end before start, negative
  running, running exceeding window, zero running, missing aircraft
  type). Running-exceeds-window tolerance = 60 s.

* `open_alaqs/core/interfaces/EngineTestEvents.py` (extended)
  New class `EngineTestEventsStore(Store, metaclass=Singleton)` that
  loads events via `getEntries()` into `EngineTestEvent` objects keyed
  by `event_id`. Public filters:
  - `getEventsBySourceId(source_id)`
  - `getEventsInPeriod(start_dt, end_dt)` with strict interval-overlap
    semantics per D10 in the phase 0 memo (events touching a period
    boundary do NOT overlap it).
  Store tolerates missing-table (pre-v1b projects opened before
  migration): `getEntries()` error is caught, store stays empty.

* `open_alaqs/core/interfaces/AreaSources.py` (extended)
  `AreaSources.getEngineTestEvents(events_store)` convenience accessor.
  Returns `[]` for area sources not flagged as test sites, even if
  matching event rows exist in the store (defensive against stale data
  after `is_test_site` has been flipped back).

## Tests

33 tests in `tests/test_phase2_engine_test_event_plugin.py`, QGIS-gated.
Three sections:

1. `EngineTestEvent` dataclass: field parsing, duration/running seconds,
   mode-times, NULL / empty-string handling for `engine_uid` and
   `engine_count`, `thrust_mode` fallback, consistency-warnings surface
   for each of the seven codes, aircraft/engine resolvers with fakes,
   `resolveEngineCount` precedence (row > aircraft attribute > method
   > None).

2. `EngineTestEventsStore`: load-from-DB, `getEventsBySourceId`,
   `getEventsInPeriod` interval-overlap across all seven topology cases
   (before / touches-start / spanning-start / inside /