### PR TITLE
Phase 4a: CSV importer for engine_test_events

### DIFF
--- a/scripts/import_engine_test_events.py
+++ b/scripts/import_engine_test_events.py
@@ -1,0 +1,760 @@
+"""Import engine-test events from a CSV into an ALAQS project.
+
+Consumed by users after they have created their test-site area sources
+(``shapes_area_sources.is_test_site='1'``) and want to bulk-load event
+rows into ``engine_test_events``.
+
+CSV format
+----------
+
+Header row required. Column order is flexible; the importer maps by
+header name. UTF-8 encoding, comma-delimited (RFC 4180). Empty cells
+take the column default (not the literal string ``""``).
+
+Columns (all names match the DB schema exactly):
+
+  Required:
+    source_id         Test-site area source identifier
+    start_datetime    ISO 8601 (e.g. 2024-12-01T09:00:00)
+    end_datetime      ISO 8601, strictly after start_datetime
+    aircraft_type     ICAO code (e.g. C56X, B738)
+
+  Optional:
+    test_id           Free-form user reference
+    engine_uid        Engine EI table key. Falls back to aircraft
+                      default at compute time if empty
+    engine_count      Positive integer. Falls back to aircraft default
+                      at compute time if empty
+    t_TX_s            Seconds in taxi/ground-idle. Default 0
+    t_AP_s            Seconds in approach. Default 0
+    t_CL_s            Seconds in climb-out. Default 0
+    t_TO_s            Seconds in take-off. Default 0
+    instudy           '0' or '1'. Default '1'
+
+Not accepted from CSV:
+    thrust_mode       DB column exists with default 'snap'. Users who
+                      need 'meem' can UPDATE the row via SQL. Not in
+                      the CSV because misuse would be silent.
+
+Modes
+-----
+
+Default is dry-run: validate the CSV against the DB, print a summary,
+change nothing. Pass ``--apply`` to actually INSERT.
+
+``--mode`` controls what the INSERT does:
+
+  append              Add rows to existing engine_test_events (default)
+  replace-for-source  DELETE existing events for each source_id in the
+                      CSV, then insert. Useful for re-importing a
+                      corrected batch for one test site.
+  replace-all         DELETE every row in engine_test_events, then
+                      insert. Requires --i-mean-it as a safety flag.
+
+Warnings vs errors
+------------------
+
+Errors reject a row. Reasons:
+  * Missing required column value
+  * Unparseable datetime
+  * end_datetime <= start_datetime
+  * Negative t_*_s
+  * engine_count present but not a positive integer
+  * instudy present but not '0'/'1'
+
+Warnings do NOT reject a row on their own; they abort the whole import
+unless ``--tolerate-warnings`` is passed. Reasons:
+  * source_id not found in shapes_area_sources
+  * source_id found but is_test_site='0' (event would be ignored by
+    compute)
+  * aircraft_type not found in default_aircraft
+  * engine_uid not found in default_aircraft_engine_ei
+  * Running seconds sum exceeds event-window duration by more than
+    the tolerance (60 s, matching Phase 2's EngineTestEvent tolerance)
+
+Whole-CSV errors abort before any validation:
+  * Missing required column in header
+  * Duplicate rows (same source_id + start_datetime + aircraft_type)
+
+Exit codes:
+  0  Success (dry-run passed, or apply completed)
+  1  Fatal error (CSV parse fail, DB error, invalid arguments)
+  2  Validation failed (row errors, or warnings without
+     --tolerate-warnings)
+
+Example
+-------
+
+  # Dry-run a batch
+  python scripts/import_engine_test_events.py \
+      /path/to/study.alaqs /path/to/logbook.csv
+
+  # Apply after review
+  python scripts/import_engine_test_events.py \
+      /path/to/study.alaqs /path/to/logbook.csv --apply
+
+  # Re-import a corrected batch for source N1
+  python scripts/import_engine_test_events.py \
+      /path/to/study.alaqs /path/to/N1_fix.csv \
+      --apply --mode replace-for-source
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional
+
+# ── Column contract ────────────────────────────────────────────────────
+
+REQUIRED_COLUMNS = (
+    "source_id",
+    "start_datetime",
+    "end_datetime",
+    "aircraft_type",
+)
+
+OPTIONAL_COLUMNS = (
+    "test_id",
+    "engine_uid",
+    "engine_count",
+    "t_TX_s",
+    "t_AP_s",
+    "t_CL_s",
+    "t_TO_s",
+    "instudy",
+)
+
+ALL_COLUMNS = REQUIRED_COLUMNS + OPTIONAL_COLUMNS
+
+MODE_TIME_COLUMNS = ("t_TX_s", "t_AP_s", "t_CL_s", "t_TO_s")
+
+# Running-seconds tolerance for the running_exceeds_window warning.
+# Matches Phase 2's EngineTestEvent.getConsistencyWarnings tolerance.
+_RUNNING_EXCEEDS_WINDOW_TOLERANCE_S = 60
+
+
+# ── Result types ───────────────────────────────────────────────────────
+
+
+@dataclass
+class RowIssue:
+    """One error or warning against one CSV row."""
+
+    row_number: int  # 1-indexed, matching how spreadsheet software labels rows
+    code: str
+    message: str
+
+
+@dataclass
+class ValidatedRow:
+    """A row that passed all validation and is ready to insert."""
+
+    row_number: int
+    source_id: str
+    test_id: Optional[str]
+    start_datetime: str
+    end_datetime: str
+    aircraft_type: str
+    engine_uid: Optional[str]
+    engine_count: Optional[int]
+    t_TX_s: int
+    t_AP_s: int
+    t_CL_s: int
+    t_TO_s: int
+    instudy: str
+
+    def to_insert_tuple(self) -> tuple:
+        return (
+            self.source_id,
+            self.test_id,
+            self.start_datetime,
+            self.end_datetime,
+            self.aircraft_type,
+            self.engine_uid,
+            self.engine_count,
+            self.t_TX_s,
+            self.t_AP_s,
+            self.t_CL_s,
+            self.t_TO_s,
+            self.instudy,
+        )
+
+
+@dataclass
+class ValidationResult:
+    valid_rows: list[ValidatedRow] = field(default_factory=list)
+    errors: list[RowIssue] = field(default_factory=list)
+    warnings: list[RowIssue] = field(default_factory=list)
+    header_error: Optional[str] = None
+
+
+# ── Parsing helpers ────────────────────────────────────────────────────
+
+
+def _parse_iso_datetime(s: str) -> Optional[datetime]:
+    """Parse ISO 8601. Return None on failure so the caller emits a
+    single clear error rather than a raw ValueError."""
+    if s is None:
+        return None
+    s = s.strip()
+    if s == "":
+        return None
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(s)
+    except ValueError:
+        return None
+
+
+def _parse_optional_int(s: Optional[str]) -> tuple[bool, Optional[int]]:
+    """Return (ok, value). Empty string / None → (True, None). A digit
+    string that's non-negative → (True, int). Anything else → (False, None).
+    """
+    if s is None:
+        return True, None
+    s = s.strip()
+    if s == "":
+        return True, None
+    try:
+        v = int(s)
+        return True, v
+    except ValueError:
+        return False, None
+
+
+def _parse_mode_seconds(s: Optional[str]) -> tuple[bool, int, Optional[str]]:
+    """Parse a t_MODE_s column. Empty → (True, 0, None). Non-negative int
+    → (True, v, None). Negative → (False, 0, 'negative_running').
+    Malformed → (False, 0, 'not_an_integer')."""
+    if s is None:
+        return True, 0, None
+    s = s.strip()
+    if s == "":
+        return True, 0, None
+    try:
+        v = int(s)
+    except ValueError:
+        return False, 0, "not_an_integer"
+    if v < 0:
+        return False, 0, "negative_running"
+    return True, v, None
+
+
+# ── CSV → ValidationResult (no DB access) ──────────────────────────────
+
+
+def validate_csv_rows(
+    csv_rows: Iterable[dict[str, str]],
+) -> ValidationResult:
+    """Validate the CSV without touching the DB. DB cross-checks happen
+    downstream in ``validate_against_db``.
+    """
+    result = ValidationResult()
+    seen_dupe_keys: dict[tuple, int] = {}
+
+    for i, row in enumerate(csv_rows, start=2):  # header is line 1
+        errs: list[RowIssue] = []
+
+        # Required-value checks
+        for col in REQUIRED_COLUMNS:
+            val = (row.get(col) or "").strip()
+            if val == "":
+                errs.append(RowIssue(i, "missing_required", f"column {col!r} is empty"))
+
+        # If any required is missing, skip the rest; row is unusable.
+        if errs:
+            result.errors.extend(errs)
+            continue
+
+        source_id = row["source_id"].strip()
+        aircraft_type = row["aircraft_type"].strip()
+
+        # Datetimes
+        start_str = row["start_datetime"].strip()
+        end_str = row["end_datetime"].strip()
+        start_dt = _parse_iso_datetime(start_str)
+        end_dt = _parse_iso_datetime(end_str)
+        if start_dt is None:
+            errs.append(
+                RowIssue(
+                    i,
+                    "unparseable_datetime",
+                    f"start_datetime {start_str!r} is not ISO 8601",
+                )
+            )
+        if end_dt is None:
+            errs.append(
+                RowIssue(
+                    i,
+                    "unparseable_datetime",
+                    f"end_datetime {end_str!r} is not ISO 8601",
+                )
+            )
+        if start_dt is not None and end_dt is not None and end_dt <= start_dt:
+            errs.append(
+                RowIssue(
+                    i,
+                    "end_before_start",
+                    "end_datetime must be strictly after start_datetime",
+                )
+            )
+
+        # Duplicate detection: same (source_id, start_datetime, aircraft_type)
+        dupe_key = (source_id, start_str, aircraft_type)
+        if dupe_key in seen_dupe_keys:
+            errs.append(
+                RowIssue(
+                    i,
+                    "duplicate_row",
+                    f"same (source_id, start_datetime, aircraft_type) as row "
+                    f"{seen_dupe_keys[dupe_key]}",
+                )
+            )
+
+        # Optional-column parsing
+        test_id = (row.get("test_id") or "").strip() or None
+
+        engine_uid = (row.get("engine_uid") or "").strip() or None
+
+        ok_count, engine_count = _parse_optional_int(row.get("engine_count"))
+        if not ok_count:
+            errs.append(
+                RowIssue(
+                    i,
+                    "invalid_engine_count",
+                    f"engine_count {row.get('engine_count')!r} is not an integer",
+                )
+            )
+        elif engine_count is not None and engine_count <= 0:
+            errs.append(
+                RowIssue(
+                    i,
+                    "invalid_engine_count",
+                    f"engine_count must be a positive integer, got {engine_count}",
+                )
+            )
+
+        mode_times: dict[str, int] = {}
+        for col in MODE_TIME_COLUMNS:
+            ok_mt, v_mt, mt_err = _parse_mode_seconds(row.get(col))
+            if not ok_mt:
+                errs.append(
+                    RowIssue(
+                        i,
+                        "invalid_mode_time",
+                        f"{col}={row.get(col)!r}: {mt_err}",
+                    )
+                )
+            mode_times[col] = v_mt
+
+        instudy = (row.get("instudy") or "1").strip()
+        if instudy == "":
+            instudy = "1"
+        if instudy not in ("0", "1"):
+            errs.append(
+                RowIssue(
+                    i,
+                    "invalid_instudy",
+                    f"instudy {row.get('instudy')!r} must be '0' or '1'",
+                )
+            )
+
+        if errs:
+            result.errors.extend(errs)
+            continue
+
+        # Record dupe key only for successfully-validated (so-far) rows.
+        seen_dupe_keys[dupe_key] = i
+
+        # Running-seconds vs window warning (D from Phase 2).
+        running = sum(mode_times.values())
+        if engine_count is not None and engine_count > 0:
+            running_total = running * engine_count
+        else:
+            running_total = running
+        window_s = (end_dt - start_dt).total_seconds()
+        if running_total > window_s + _RUNNING_EXCEEDS_WINDOW_TOLERANCE_S:
+            result.warnings.append(
+                RowIssue(
+                    i,
+                    "running_exceeds_window",
+                    f"sum of mode times ({running_total}s across "
+                    f"{engine_count or 1} engine(s)) exceeds the "
+                    f"event window ({int(window_s)}s) by more than "
+                    f"{_RUNNING_EXCEEDS_WINDOW_TOLERANCE_S}s tolerance",
+                )
+            )
+
+        result.valid_rows.append(
+            ValidatedRow(
+                row_number=i,
+                source_id=source_id,
+                test_id=test_id,
+                start_datetime=start_str,
+                end_datetime=end_str,
+                aircraft_type=aircraft_type,
+                engine_uid=engine_uid,
+                engine_count=engine_count,
+                t_TX_s=mode_times["t_TX_s"],
+                t_AP_s=mode_times["t_AP_s"],
+                t_CL_s=mode_times["t_CL_s"],
+                t_TO_s=mode_times["t_TO_s"],
+                instudy=instudy,
+            )
+        )
+
+    return result
+
+
+def read_csv(csv_path: Path) -> tuple[list[dict[str, str]], Optional[str]]:
+    """Read the CSV. Return (rows, header_error). If the header is
+    missing a required column, ``header_error`` is set and ``rows`` is
+    empty.
+    """
+    with csv_path.open("r", encoding="utf-8-sig", newline="") as f:
+        reader = csv.DictReader(f)
+        fieldnames = reader.fieldnames or []
+        missing = [c for c in REQUIRED_COLUMNS if c not in fieldnames]
+        if missing:
+            return [], (
+                "CSV header missing required column(s): "
+                + ", ".join(missing)
+                + f"\n  header seen: {fieldnames}"
+                + f"\n  columns expected: {list(ALL_COLUMNS)}"
+            )
+        rows = list(reader)
+    return rows, None
+
+
+# ── DB cross-checks ────────────────────────────────────────────────────
+
+
+def _fetch_lookup_sets(conn: sqlite3.Connection) -> dict[str, set]:
+    """Read reference tables into sets for O(1) membership checks.
+    Missing tables return empty sets and yield warnings on all lookups
+    (informative when the DB is un-migrated or bare)."""
+    cur = conn.cursor()
+    sets: dict[str, set] = {
+        "shapes_area_sources": set(),
+        "test_site_source_ids": set(),
+        "default_aircraft": set(),
+        "default_aircraft_engine_ei": set(),
+    }
+
+    try:
+        for sid, is_test_site in cur.execute(
+            "SELECT source_id, is_test_site FROM shapes_area_sources"
+        ):
+            if sid is None:
+                continue
+            sets["shapes_area_sources"].add(str(sid))
+            if str(is_test_site or "0").strip() == "1":
+                sets["test_site_source_ids"].add(str(sid))
+    except sqlite3.OperationalError:
+        pass  # table absent or is_test_site column absent
+
+    try:
+        for (icao,) in cur.execute("SELECT icao FROM default_aircraft"):
+            if icao is not None:
+                sets["default_aircraft"].add(str(icao))
+    except sqlite3.OperationalError:
+        pass
+
+    try:
+        for (uid,) in cur.execute(
+            "SELECT engine_full_name FROM default_aircraft_engine_ei"
+        ):
+            if uid is not None:
+                sets["default_aircraft_engine_ei"].add(str(uid))
+    except sqlite3.OperationalError:
+        # Try alternate column name
+        try:
+            for (uid,) in cur.execute(
+                "SELECT engine_uid FROM default_aircraft_engine_ei"
+            ):
+                if uid is not None:
+                    sets["default_aircraft_engine_ei"].add(str(uid))
+        except sqlite3.OperationalError:
+            pass
+
+    return sets
+
+
+def validate_against_db(
+    valid_rows: list[ValidatedRow],
+    conn: sqlite3.Connection,
+) -> list[RowIssue]:
+    """Cross-check each already-CSV-valid row against reference tables
+    in the DB. Emits warnings (not errors) so the caller decides whether
+    to abort."""
+    lookups = _fetch_lookup_sets(conn)
+    warnings: list[RowIssue] = []
+
+    for r in valid_rows:
+        if r.source_id not in lookups["shapes_area_sources"]:
+            warnings.append(
+                RowIssue(
+                    r.row_number,
+                    "unknown_source_id",
+                    f"source_id {r.source_id!r} not found in shapes_area_sources",
+                )
+            )
+        elif r.source_id not in lookups["test_site_source_ids"]:
+            warnings.append(
+                RowIssue(
+                    r.row_number,
+                    "source_not_test_site",
+                    f"source_id {r.source_id!r} exists but is_test_site='0'; "
+                    "compute would ignore its events",
+                )
+            )
+
+        if (
+            lookups["default_aircraft"]
+            and r.aircraft_type not in lookups["default_aircraft"]
+        ):
+            warnings.append(
+                RowIssue(
+                    r.row_number,
+                    "unknown_aircraft_type",
+                    f"aircraft_type {r.aircraft_type!r} not in default_aircraft",
+                )
+            )
+
+        if (
+            r.engine_uid is not None
+            and lookups["default_aircraft_engine_ei"]
+            and r.engine_uid not in lookups["default_aircraft_engine_ei"]
+        ):
+            warnings.append(
+                RowIssue(
+                    r.row_number,
+                    "unknown_engine_uid",
+                    f"engine_uid {r.engine_uid!r} not in default_aircraft_engine_ei",
+                )
+            )
+
+    return warnings
+
+
+# ── Insert ─────────────────────────────────────────────────────────────
+
+
+_INSERT_SQL = (
+    "INSERT INTO engine_test_events ("
+    "source_id, test_id, start_datetime, end_datetime, aircraft_type, "
+    "engine_uid, engine_count, t_TX_s, t_AP_s, t_CL_s, t_TO_s, instudy"
+    ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+)
+
+
+def apply_insert(
+    conn: sqlite3.Connection,
+    rows: list[ValidatedRow],
+    mode: str,
+) -> dict:
+    """Insert rows into engine_test_events under one of the three modes.
+    All-or-nothing: uses a single transaction; on any SQLite error the
+    caller sees the exception and the DB is rolled back."""
+    cur = conn.cursor()
+
+    if mode == "replace-all":
+        cur.execute("DELETE FROM engine_test_events")
+    elif mode == "replace-for-source":
+        source_ids = sorted({r.source_id for r in rows})
+        # Chunk the IN() to keep parameter count sane on ancient sqlite
+        # builds; 500 is well under any known SQLITE_MAX_VARIABLE_NUMBER.
+        for i in range(0, len(source_ids), 500):
+            chunk = source_ids[i : i + 500]
+            placeholders = ",".join("?" * len(chunk))
+            cur.execute(
+                f"DELETE FROM engine_test_events WHERE source_id IN ({placeholders})",
+                chunk,
+            )
+
+    per_source: dict[str, int] = {}
+    for r in rows:
+        cur.execute(_INSERT_SQL, r.to_insert_tuple())
+        per_source[r.source_id] = per_source.get(r.source_id, 0) + 1
+
+    conn.commit()
+    return per_source
+
+
+# ── Reporting ──────────────────────────────────────────────────────────
+
+
+def format_summary(
+    result: ValidationResult,
+    db_warnings: list[RowIssue],
+    csv_row_count: int,
+) -> str:
+    lines = []
+    total_warnings = len(result.warnings) + len(db_warnings)
+    lines.append("Import summary")
+    lines.append(f"  CSV rows read:          {csv_row_count}")
+    lines.append(f"  Rows valid:             {len(result.valid_rows)}")
+    lines.append(f"  Rows rejected:          {len(result.errors)}")
+    lines.append(f"  Warnings:               {total_warnings}")
+
+    if result.errors:
+        lines.append("")
+        lines.append("Errors:")
+        for e in result.errors:
+            lines.append(f"  Row {e.row_number}: [{e.code}] {e.message}")
+
+    all_warnings = result.warnings + db_warnings
+    all_warnings.sort(key=lambda x: (x.row_number, x.code))
+    if all_warnings:
+        lines.append("")
+        lines.append("Warnings:")
+        for w in all_warnings:
+            lines.append(f"  Row {w.row_number}: [{w.code}] {w.message}")
+
+    return "\n".join(lines)
+
+
+def format_apply_summary(per_source: dict[str, int], mode: str) -> str:
+    lines = ["", f"Applied ({mode}):"]
+    total = sum(per_source.values())
+    for sid in sorted(per_source):
+        lines.append(f"  {sid}: {per_source[sid]} event(s)")
+    lines.append(f"  total: {total} event(s) inserted")
+    return "\n".join(lines)
+
+
+# ── CLI ────────────────────────────────────────────────────────────────
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Import engine-test events from a CSV into an ALAQS project.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("alaqs_path", type=Path, help="Path to the .alaqs project file")
+    p.add_argument("csv_path", type=Path, help="Path to the input CSV file")
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually INSERT rows. Default is dry-run (validate only, no writes).",
+    )
+    p.add_argument(
+        "--mode",
+        choices=("append", "replace-for-source", "replace-all"),
+        default="append",
+        help="Insert mode (default: append)",
+    )
+    p.add_argument(
+        "--i-mean-it",
+        action="store_true",
+        help="Required with --mode replace-all. Confirms you accept "
+        "that ALL existing engine_test_events rows will be deleted first.",
+    )
+    p.add_argument(
+        "--tolerate-warnings",
+        action="store_true",
+        help="Proceed even if the CSV has warnings (unknown source_id, "
+        "unknown engine_uid, running exceeds window). Default is to "
+        "fail on any warning.",
+    )
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    # Precondition: --i-mean-it required for replace-all.
+    if args.mode == "replace-all" and args.apply and not args.i_mean_it:
+        print(
+            "ERROR: --mode replace-all with --apply requires --i-mean-it. "
+            "Aborting to protect existing data.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not args.alaqs_path.exists():
+        print(f"ERROR: alaqs file not found: {args.alaqs_path}", file=sys.stderr)
+        return 1
+    if not args.csv_path.exists():
+        print(f"ERROR: CSV file not found: {args.csv_path}", file=sys.stderr)
+        return 1
+
+    # Read CSV
+    try:
+        rows, header_error = read_csv(args.csv_path)
+    except Exception as e:
+        print(f"ERROR: could not read CSV: {e}", file=sys.stderr)
+        return 1
+    if header_error is not None:
+        print(f"ERROR: {header_error}", file=sys.stderr)
+        return 1
+
+    # CSV validation
+    result = validate_csv_rows(rows)
+
+    # DB cross-checks
+    try:
+        conn = sqlite3.connect(args.alaqs_path)
+    except sqlite3.Error as e:
+        print(f"ERROR: could not open alaqs file: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        db_warnings = validate_against_db(result.valid_rows, conn)
+    finally:
+        # Close before any apply, since apply reopens with the right
+        # transaction semantics.
+        pass
+
+    print(format_summary(result, db_warnings, csv_row_count=len(rows)))
+
+    total_warnings = len(result.warnings) + len(db_warnings)
+
+    # Refusal criteria
+    if result.errors:
+        print("\nFail: rows contain errors. Fix the CSV and re-run.", file=sys.stderr)
+        conn.close()
+        return 2
+    if total_warnings and not args.tolerate_warnings:
+        print(
+            "\nFail: --tolerate-warnings not set. "
+            "Fix the warnings above or re-run with --tolerate-warnings.",
+            file=sys.stderr,
+        )
+        conn.close()
+        return 2
+
+    # Dry-run terminates here.
+    if not args.apply:
+        print("\nDry-run OK. Re-run with --apply to insert.")
+        conn.close()
+        return 0
+
+    # Apply
+    try:
+        per_source = apply_insert(conn, result.valid_rows, args.mode)
+    except sqlite3.Error as e:
+        conn.rollback()
+        conn.close()
+        print(f"ERROR: DB write failed, rolled back: {e}", file=sys.stderr)
+        return 1
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    print(format_apply_summary(per_source, args.mode))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/test_import_engine_test_events.py
+++ b/tests/test_import_engine_test_events.py
@@ -1,0 +1,741 @@
+"""Tests for ``scripts/import_engine_test_events.py``.
+
+QGIS-free. Uses raw sqlite3 fixtures and StringIO for CSVs.
+
+Coverage:
+  * validate_csv_rows: all 8 row-level error codes + all warnings.
+  * validate_against_db: reference-table cross-checks.
+  * apply_insert: three modes (append / replace-for-source / replace-all).
+  * CLI end-to-end: dry-run, --apply, exit codes, --tolerate-warnings,
+    --i-mean-it protection.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Add the scripts/ dir to sys.path so the module is importable. Tests
+# run from the repo root under pytest.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+import import_engine_test_events as importer  # noqa: E402
+
+# ═══════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _rows_from_string(csv_text: str) -> list[dict[str, str]]:
+    reader = csv.DictReader(io.StringIO(csv_text))
+    return list(reader)
+
+
+def _make_scratch_db(
+    area_sources: list[dict] = None,
+    default_aircraft: list[str] = None,
+    default_engine_ei_uids: list[str] = None,
+) -> tuple[str, sqlite3.Connection]:
+    """Create a scratch .alaqs-shaped DB with just the tables the
+    importer reads. Returns (path, open connection)."""
+    path = tempfile.NamedTemporaryFile(suffix=".alaqs", delete=False).name
+    conn = sqlite3.connect(path)
+
+    conn.execute(
+        """
+        CREATE TABLE shapes_area_sources (
+            oid INTEGER PRIMARY KEY,
+            source_id TEXT,
+            is_test_site TEXT DEFAULT '0'
+        )
+        """
+    )
+    for src in area_sources or []:
+        conn.execute(
+            "INSERT INTO shapes_area_sources (source_id, is_test_site) VALUES (?, ?)",
+            (src["source_id"], src.get("is_test_site", "0")),
+        )
+
+    conn.execute("CREATE TABLE default_aircraft (icao TEXT)")
+    for icao in default_aircraft or []:
+        conn.execute("INSERT INTO default_aircraft (icao) VALUES (?)", (icao,))
+
+    conn.execute("CREATE TABLE default_aircraft_engine_ei (engine_full_name TEXT)")
+    for uid in default_engine_ei_uids or []:
+        conn.execute(
+            "INSERT INTO default_aircraft_engine_ei (engine_full_name) VALUES (?)",
+            (uid,),
+        )
+
+    conn.execute(
+        """
+        CREATE TABLE engine_test_events (
+            event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            source_id TEXT NOT NULL,
+            test_id TEXT,
+            start_datetime TEXT NOT NULL,
+            end_datetime TEXT NOT NULL,
+            aircraft_type TEXT NOT NULL,
+            engine_uid TEXT,
+            engine_count INTEGER,
+            t_TX_s INTEGER NOT NULL DEFAULT 0,
+            t_AP_s INTEGER NOT NULL DEFAULT 0,
+            t_CL_s INTEGER NOT NULL DEFAULT 0,
+            t_TO_s INTEGER NOT NULL DEFAULT 0,
+            thrust_mode TEXT NOT NULL DEFAULT 'snap',
+            instudy TEXT NOT NULL DEFAULT '1'
+        )
+        """
+    )
+    conn.commit()
+    return path, conn
+
+
+CSV_HEADER = (
+    "source_id,start_datetime,end_datetime,aircraft_type,test_id,"
+    "engine_uid,engine_count,t_TX_s,t_AP_s,t_CL_s,t_TO_s,instudy"
+)
+
+
+def _row(
+    source_id="N1",
+    start="2024-12-01T09:00:00",
+    end="2024-12-01T09:30:00",
+    aircraft="C56X",
+    test_id="",
+    engine_uid="",
+    engine_count="",
+    t_TX_s="",
+    t_AP_s="",
+    t_CL_s="",
+    t_TO_s="",
+    instudy="",
+):
+    return (
+        f"{source_id},{start},{end},{aircraft},{test_id},"
+        f"{engine_uid},{engine_count},{t_TX_s},{t_AP_s},{t_CL_s},{t_TO_s},"
+        f"{instudy}"
+    )
+
+
+def _csv_text(*rows: str) -> str:
+    return CSV_HEADER + "\n" + "\n".join(rows) + "\n"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 1: read_csv header check
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_read_csv_flags_missing_required_column(tmp_path):
+    """CSV missing the aircraft_type header → header_error returned; no
+    rows returned. Whole-file abort."""
+    p = tmp_path / "bad.csv"
+    p.write_text("source_id,start_datetime,end_datetime\nN1,x,y\n")
+    rows, err = importer.read_csv(p)
+    assert rows == []
+    assert err is not None
+    assert "aircraft_type" in err
+
+
+def test_read_csv_accepts_extra_columns(tmp_path):
+    """Unknown columns are ignored (forward-compatible)."""
+    p = tmp_path / "ok.csv"
+    p.write_text(CSV_HEADER + ",extra_column\n" + _row() + ",whatever\n")
+    rows, err = importer.read_csv(p)
+    assert err is None
+    assert len(rows) == 1
+
+
+def test_read_csv_handles_utf8_bom(tmp_path):
+    """utf-8-sig strips the BOM if the CSV was saved from Excel."""
+    p = tmp_path / "bom.csv"
+    p.write_bytes(("\ufeff" + _csv_text(_row())).encode("utf-8"))
+    rows, err = importer.read_csv(p)
+    assert err is None
+    assert len(rows) == 1
+    assert rows[0]["source_id"] == "N1"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 2: validate_csv_rows — row-level errors
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_valid_row_produces_no_issues():
+    rows = _rows_from_string(_csv_text(_row(t_CL_s="900")))
+    result = importer.validate_csv_rows(rows)
+    assert result.errors == []
+    assert result.warnings == []
+    assert len(result.valid_rows) == 1
+    r = result.valid_rows[0]
+    assert r.source_id == "N1"
+    assert r.t_CL_s == 900
+
+
+def test_missing_required_column_value_rejects():
+    rows = _rows_from_string(_csv_text(_row(source_id="")))
+    result = importer.validate_csv_rows(rows)
+    assert len(result.errors) == 1
+    assert result.errors[0].code == "missing_required"
+    assert result.valid_rows == []
+
+
+def test_unparseable_datetime_rejects():
+    rows = _rows_from_string(_csv_text(_row(start="not-a-date")))
+    result = importer.validate_csv_rows(rows)
+    assert any(e.code == "unparseable_datetime" for e in result.errors)
+
+
+def test_end_before_start_rejects():
+    rows = _rows_from_string(
+        _csv_text(
+            _row(start="2024-12-01T10:00:00", end="2024-12-01T09:30:00"),
+        )
+    )
+    result = importer.validate_csv_rows(rows)
+    assert any(e.code == "end_before_start" for e in result.errors)
+
+
+def test_end_equal_start_rejects():
+    """end == start is not a valid event window."""
+    rows = _rows_from_string(
+        _csv_text(
+            _row(start="2024-12-01T09:00:00", end="2024-12-01T09:00:00"),
+        )
+    )
+    result = importer.validate_csv_rows(rows)
+    assert any(e.code == "end_before_start" for e in result.errors)
+
+
+def test_negative_mode_time_rejects():
+    rows = _rows_from_string(_csv_text(_row(t_CL_s="-100")))
+    result = importer.validate_csv_rows(rows)
+    assert any(e.code == "invalid_mode_time" for e in result.errors)
+
+
+def test_non_integer_mode_time_rejects():
+    rows = _rows_from_string(_csv_text(_row(t_CL_s="900.5")))
+    result = importer.validate_csv_rows(rows)
+    assert any(e.code == "invalid_mode_time" for e in result.errors)
+
+
+def test_zero_or_negative_engine_count_rejects():
+    """engine_count present but not a POSITIVE integer."""
+    rows = _rows_from_string(_csv_text(_row(engine_count="0", t_CL_s="900")))
+    result = importer.validate_csv_rows(rows)
+    assert any(e.code == "invalid_engine_count" for e in result.errors)
+
+
+def test_non_numeric_engine_count_rejects():
+    rows = _rows_from_string(_csv_text(_row(engine_count="two", t_CL_s="900")))
+    result = importer.validate_csv_rows(rows)
+    assert any(e.code == "invalid_engine_count" for e in result.errors)
+
+
+def test_invalid_instudy_rejects():
+    rows = _rows_from_string(_csv_text(_row(instudy="maybe", t_CL_s="900")))
+    result = importer.validate_csv_rows(rows)
+    assert any(e.code == "invalid_instudy" for e in result.errors)
+
+
+def test_duplicate_row_rejected():
+    """Same (source_id, start_datetime, aircraft_type) in two rows."""
+    r1 = _row(source_id="N1", start="2024-12-01T09:00:00", aircraft="C56X")
+    r2 = _row(
+        source_id="N1",
+        start="2024-12-01T09:00:00",
+        end="2024-12-01T10:00:00",  # different, but key still matches
+        aircraft="C56X",
+    )
+    result = importer.validate_csv_rows(_rows_from_string(_csv_text(r1, r2)))
+    assert any(e.code == "duplicate_row" for e in result.errors)
+
+
+def test_multiple_errors_all_reported():
+    """One row can accumulate multiple errors; all are surfaced so users
+    fix everything in one pass."""
+    rows = _rows_from_string(_csv_text(_row(start="bad", end="also-bad", t_CL_s="-1")))
+    result = importer.validate_csv_rows(rows)
+    codes = {e.code for e in result.errors}
+    # start and end each unparseable → 2 "unparseable_datetime" errors
+    # negative t_CL_s → "invalid_mode_time"
+    assert "unparseable_datetime" in codes
+    assert "invalid_mode_time" in codes
+
+
+def test_empty_optional_columns_take_defaults():
+    """Empty engine_uid, engine_count, mode-time cols → None or 0."""
+    rows = _rows_from_string(_csv_text(_row(t_CL_s="900")))
+    result = importer.validate_csv_rows(rows)
+    r = result.valid_rows[0]
+    assert r.engine_uid is None
+    assert r.engine_count is None
+    assert r.t_TX_s == 0
+    assert r.t_AP_s == 0
+    assert r.t_TO_s == 0
+    assert r.instudy == "1"
+
+
+def test_row_numbers_are_1_indexed_from_header():
+    """Header is line 1, first data row is line 2. Errors reference the
+    spreadsheet-visible line number."""
+    rows = _rows_from_string(_csv_text(_row(t_CL_s="900"), _row(source_id="")))
+    result = importer.validate_csv_rows(rows)
+    assert len(result.errors) == 1
+    assert result.errors[0].row_number == 3
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 3: validate_csv_rows — warnings
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_running_exceeds_window_warns():
+    """Sum of mode-times * engine_count exceeds window by > 60s → warn."""
+    # window = 30min = 1800s. mode times sum = 1900 * 2 engines = 3800s.
+    # Over by 2000s, well past 60s tolerance.
+    rows = _rows_from_string(_csv_text(_row(t_CL_s="1900", engine_count="2")))
+    result = importer.validate_csv_rows(rows)
+    assert any(w.code == "running_exceeds_window" for w in result.warnings)
+    # But still valid; not an error.
+    assert len(result.valid_rows) == 1
+
+
+def test_running_within_tolerance_no_warning():
+    """Within 60s tolerance → no warning."""
+    # window = 30min = 1800s. mode times sum = 1830 * 1 engine = 1830s.
+    # Over by 30s, within 60s tolerance.
+    rows = _rows_from_string(_csv_text(_row(t_CL_s="1830", engine_count="1")))
+    result = importer.validate_csv_rows(rows)
+    assert not any(w.code == "running_exceeds_window" for w in result.warnings)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 4: validate_against_db — reference lookups
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_unknown_source_id_warns():
+    path, conn = _make_scratch_db(
+        area_sources=[{"source_id": "N1", "is_test_site": "1"}]
+    )
+    try:
+        rows = _rows_from_string(_csv_text(_row(source_id="GHOST")))
+        result = importer.validate_csv_rows(rows)
+        assert result.errors == []
+        db_warnings = importer.validate_against_db(result.valid_rows, conn)
+        assert any(w.code == "unknown_source_id" for w in db_warnings)
+    finally:
+        conn.close()
+        os.unlink(path)
+
+
+def test_source_id_not_test_site_warns():
+    """source_id exists but is_test_site='0' → compute would ignore
+    events. Surface as a warning."""
+    path, conn = _make_scratch_db(
+        area_sources=[{"source_id": "A1", "is_test_site": "0"}]
+    )
+    try:
+        rows = _rows_from_string(_csv_text(_row(source_id="A1")))
+        result = importer.validate_csv_rows(rows)
+        db_warnings = importer.validate_against_db(result.valid_rows, conn)
+        assert any(w.code == "source_not_test_site" for w in db_warnings)
+    finally:
+        conn.close()
+        os.unlink(path)
+
+
+def test_unknown_aircraft_warns():
+    path, conn = _make_scratch_db(
+        area_sources=[{"source_id": "N1", "is_test_site": "1"}],
+        default_aircraft=["B738", "C56X"],
+    )
+    try:
+        rows = _rows_from_string(_csv_text(_row(aircraft="A380")))
+        result = importer.validate_csv_rows(rows)
+        db_warnings = importer.validate_against_db(result.valid_rows, conn)
+        assert any(w.code == "unknown_aircraft_type" for w in db_warnings)
+    finally:
+        conn.close()
+        os.unlink(path)
+
+
+def test_unknown_engine_uid_warns():
+    path, conn = _make_scratch_db(
+        area_sources=[{"source_id": "N1", "is_test_site": "1"}],
+        default_engine_ei_uids=["B602", "B603"],
+    )
+    try:
+        rows = _rows_from_string(_csv_text(_row(engine_uid="B999")))
+        result = importer.validate_csv_rows(rows)
+        db_warnings = importer.validate_against_db(result.valid_rows, conn)
+        assert any(w.code == "unknown_engine_uid" for w in db_warnings)
+    finally:
+        conn.close()
+        os.unlink(path)
+
+
+def test_no_warnings_when_all_references_resolve():
+    path, conn = _make_scratch_db(
+        area_sources=[{"source_id": "N1", "is_test_site": "1"}],
+        default_aircraft=["C56X"],
+        default_engine_ei_uids=["B602"],
+    )
+    try:
+        rows = _rows_from_string(_csv_text(_row(engine_uid="B602")))
+        result = importer.validate_csv_rows(rows)
+        db_warnings = importer.validate_against_db(result.valid_rows, conn)
+        assert db_warnings == []
+    finally:
+        conn.close()
+        os.unlink(path)
+
+
+def test_missing_reference_tables_do_not_crash():
+    """Bare DB without default_aircraft / default_aircraft_engine_ei →
+    lookups silently return empty sets; no lookup produces spurious
+    'unknown' warnings (since we can't check against nothing)."""
+    path = tempfile.NamedTemporaryFile(suffix=".alaqs", delete=False).name
+    try:
+        conn = sqlite3.connect(path)
+        conn.execute(
+            "CREATE TABLE shapes_area_sources (source_id TEXT, is_test_site TEXT)"
+        )
+        conn.execute("INSERT INTO shapes_area_sources VALUES ('N1', '1')")
+        conn.commit()
+
+        rows = _rows_from_string(_csv_text(_row(engine_uid="whatever")))
+        result = importer.validate_csv_rows(rows)
+        db_warnings = importer.validate_against_db(result.valid_rows, conn)
+        # source_id is known, and engine_uid check is skipped when
+        # the ref table has no rows.
+        assert db_warnings == []
+        conn.close()
+    finally:
+        os.unlink(path)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 5: apply_insert — three modes
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _apply_prep(mode: str):
+    """Set up a DB with one pre-existing event and one validated row
+    ready to insert."""
+    path, conn = _make_scratch_db(
+        area_sources=[
+            {"source_id": "N1", "is_test_site": "1"},
+            {"source_id": "COMP", "is_test_site": "1"},
+        ]
+    )
+    conn.execute(
+        "INSERT INTO engine_test_events "
+        "(source_id, start_datetime, end_datetime, aircraft_type) "
+        "VALUES ('N1', '2024-11-15T08:00:00', '2024-11-15T08:20:00', 'C56X')"
+    )
+    conn.commit()
+
+    row = importer.ValidatedRow(
+        row_number=2,
+        source_id="N1",
+        test_id=None,
+        start_datetime="2024-12-01T09:00:00",
+        end_datetime="2024-12-01T09:30:00",
+        aircraft_type="C56X",
+        engine_uid=None,
+        engine_count=2,
+        t_TX_s=0,
+        t_AP_s=0,
+        t_CL_s=900,
+        t_TO_s=0,
+        instudy="1",
+    )
+    return path, conn, row
+
+
+def test_apply_append_leaves_existing_rows():
+    path, conn, row = _apply_prep("append")
+    try:
+        importer.apply_insert(conn, [row], "append")
+        n = conn.execute("SELECT COUNT(*) FROM engine_test_events").fetchone()[0]
+        assert n == 2  # 1 pre-existing + 1 new
+    finally:
+        conn.close()
+        os.unlink(path)
+
+
+def test_apply_replace_for_source_deletes_matching_source_only():
+    path, conn, row = _apply_prep("replace-for-source")
+    # Add another pre-existing event on a DIFFERENT source
+    conn.execute(
+        "INSERT INTO engine_test_events "
+        "(source_id, start_datetime, end_datetime, aircraft_type) "
+        "VALUES ('COMP', '2024-11-15T14:00:00', '2024-11-15T14:15:00', 'B738')"
+    )
+    conn.commit()
+    try:
+        importer.apply_insert(conn, [row], "replace-for-source")
+        rows_after = conn.execute(
+            "SELECT source_id FROM engine_test_events ORDER BY source_id"
+        ).fetchall()
+        # N1: pre-existing deleted, new inserted (1 total).
+        # COMP: pre-existing preserved (1 total).
+        assert [r[0] for r in rows_after] == ["COMP", "N1"]
+    finally:
+        conn.close()
+        os.unlink(path)
+
+
+def test_apply_replace_all_wipes_the_table():
+    path, conn, row = _apply_prep("replace-all")
+    try:
+        importer.apply_insert(conn, [row], "replace-all")
+        rows_after = conn.execute("SELECT source_id FROM engine_test_events").fetchall()
+        assert [r[0] for r in rows_after] == ["N1"]  # only the new one
+    finally:
+        conn.close()
+        os.unlink(path)
+
+
+def test_apply_returns_per_source_counts():
+    path, conn = _make_scratch_db(
+        area_sources=[{"source_id": s, "is_test_site": "1"} for s in ("N1", "COMP")]
+    )
+
+    def _r(sid, i):
+        return importer.ValidatedRow(
+            row_number=i,
+            source_id=sid,
+            test_id=None,
+            start_datetime=f"2024-12-{i:02d}T09:00:00",
+            end_datetime=f"2024-12-{i:02d}T09:30:00",
+            aircraft_type="C56X",
+            engine_uid=None,
+            engine_count=1,
+            t_TX_s=0,
+            t_AP_s=0,
+            t_CL_s=900,
+            t_TO_s=0,
+            instudy="1",
+        )
+
+    rows = [_r("N1", 2), _r("N1", 3), _r("COMP", 4)]
+    try:
+        per_source = importer.apply_insert(conn, rows, "append")
+        assert per_source == {"N1": 2, "COMP": 1}
+    finally:
+        conn.close()
+        os.unlink(path)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 6: CLI end-to-end
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def scratch_db_with_test_site(tmp_path):
+    path = str(tmp_path / "study.alaqs")
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE shapes_area_sources ("
+        "oid INTEGER PRIMARY KEY, source_id TEXT, is_test_site TEXT DEFAULT '0')"
+    )
+    conn.execute(
+        "INSERT INTO shapes_area_sources (source_id, is_test_site) "
+        "VALUES ('N1', '1')"
+    )
+    conn.execute("CREATE TABLE default_aircraft (icao TEXT)")
+    conn.execute("INSERT INTO default_aircraft VALUES ('C56X')")
+    conn.execute("CREATE TABLE default_aircraft_engine_ei (engine_full_name TEXT)")
+    conn.execute("INSERT INTO default_aircraft_engine_ei VALUES ('B602')")
+    conn.execute(
+        """
+        CREATE TABLE engine_test_events (
+            event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            source_id TEXT NOT NULL,
+            test_id TEXT,
+            start_datetime TEXT NOT NULL,
+            end_datetime TEXT NOT NULL,
+            aircraft_type TEXT NOT NULL,
+            engine_uid TEXT,
+            engine_count INTEGER,
+            t_TX_s INTEGER NOT NULL DEFAULT 0,
+            t_AP_s INTEGER NOT NULL DEFAULT 0,
+            t_CL_s INTEGER NOT NULL DEFAULT 0,
+            t_TO_s INTEGER NOT NULL DEFAULT 0,
+            thrust_mode TEXT NOT NULL DEFAULT 'snap',
+            instudy TEXT NOT NULL DEFAULT '1'
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _write_csv(tmp_path, name, *rows):
+    p = tmp_path / name
+    p.write_text(_csv_text(*rows))
+    return str(p)
+
+
+def test_cli_dry_run_returns_0_for_clean_csv(
+    scratch_db_with_test_site, tmp_path, capsys
+):
+    csv_path = _write_csv(
+        tmp_path,
+        "clean.csv",
+        _row(engine_uid="B602", t_CL_s="900"),
+    )
+    rc = importer.main([scratch_db_with_test_site, csv_path])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Rows valid:             1" in out
+    assert "Dry-run OK" in out
+
+
+def test_cli_dry_run_returns_2_on_errors(scratch_db_with_test_site, tmp_path, capsys):
+    csv_path = _write_csv(
+        tmp_path,
+        "bad.csv",
+        _row(start="not-a-date", t_CL_s="900"),
+    )
+    rc = importer.main([scratch_db_with_test_site, csv_path])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "Rows rejected:          1" in captured.out
+    assert "unparseable_datetime" in captured.out
+
+
+def test_cli_returns_2_on_warnings_without_tolerate(
+    scratch_db_with_test_site, tmp_path, capsys
+):
+    """Unknown engine_uid: warning. Without --tolerate-warnings, fails."""
+    csv_path = _write_csv(
+        tmp_path,
+        "warn.csv",
+        _row(engine_uid="B999", t_CL_s="900"),
+    )
+    rc = importer.main([scratch_db_with_test_site, csv_path])
+    assert rc == 2
+    out = capsys.readouterr().out
+    assert "unknown_engine_uid" in out
+
+
+def test_cli_returns_0_with_tolerate_warnings(
+    scratch_db_with_test_site, tmp_path, capsys
+):
+    csv_path = _write_csv(
+        tmp_path,
+        "warn.csv",
+        _row(engine_uid="B999", t_CL_s="900"),
+    )
+    rc = importer.main([scratch_db_with_test_site, csv_path, "--tolerate-warnings"])
+    assert rc == 0
+
+
+def test_cli_apply_inserts_rows(scratch_db_with_test_site, tmp_path, capsys):
+    csv_path = _write_csv(
+        tmp_path,
+        "apply.csv",
+        _row(engine_uid="B602", t_CL_s="900"),
+    )
+    rc = importer.main([scratch_db_with_test_site, csv_path, "--apply"])
+    assert rc == 0
+    conn = sqlite3.connect(scratch_db_with_test_site)
+    n = conn.execute("SELECT COUNT(*) FROM engine_test_events").fetchone()[0]
+    conn.close()
+    assert n == 1
+    out = capsys.readouterr().out
+    assert "Applied (append)" in out
+    assert "N1: 1 event(s)" in out
+
+
+def test_cli_replace_all_requires_i_mean_it(
+    scratch_db_with_test_site, tmp_path, capsys
+):
+    csv_path = _write_csv(
+        tmp_path,
+        "replace.csv",
+        _row(engine_uid="B602", t_CL_s="900"),
+    )
+    rc = importer.main(
+        [scratch_db_with_test_site, csv_path, "--apply", "--mode", "replace-all"]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "--i-mean-it" in err
+
+
+def test_cli_replace_all_with_i_mean_it_works(
+    scratch_db_with_test_site, tmp_path, capsys
+):
+    # Pre-load a stale event
+    conn = sqlite3.connect(scratch_db_with_test_site)
+    conn.execute(
+        "INSERT INTO engine_test_events "
+        "(source_id, start_datetime, end_datetime, aircraft_type) "
+        "VALUES ('STALE', '2024-01-01T00:00:00', '2024-01-01T00:30:00', 'X')"
+    )
+    conn.commit()
+    conn.close()
+
+    csv_path = _write_csv(
+        tmp_path,
+        "replace.csv",
+        _row(engine_uid="B602", t_CL_s="900"),
+    )
+    rc = importer.main(
+        [
+            scratch_db_with_test_site,
+            csv_path,
+            "--apply",
+            "--mode",
+            "replace-all",
+            "--i-mean-it",
+        ]
+    )
+    assert rc == 0
+    conn = sqlite3.connect(scratch_db_with_test_site)
+    rows = conn.execute("SELECT source_id FROM engine_test_events").fetchall()
+    conn.close()
+    assert [r[0] for r in rows] == ["N1"]  # STALE gone; N1 inserted
+
+
+def test_cli_dry_run_makes_no_writes(scratch_db_with_test_site, tmp_path, capsys):
+    csv_path = _write_csv(
+        tmp_path,
+        "dry.csv",
+        _row(engine_uid="B602", t_CL_s="900"),
+    )
+    rc = importer.main([scratch_db_with_test_site, csv_path])
+    assert rc == 0
+    conn = sqlite3.connect(scratch_db_with_test_site)
+    n = conn.execute("SELECT COUNT(*) FROM engine_test_events").fetchone()[0]
+    conn.close()
+    assert n == 0
+
+
+def test_cli_missing_csv_returns_1(scratch_db_with_test_site, tmp_path, capsys):
+    rc = importer.main(
+        [scratch_db_with_test_site, str(tmp_path / "does-not-exist.csv")]
+    )
+    assert rc == 1
+
+
+def test_cli_missing_alaqs_returns_1(tmp_path, capsys):
+    csv_path = _write_csv(tmp_path, "x.csv", _row(t_CL_s="900"))
+    rc = importer.main([str(tmp_path / "no.alaqs"), csv_path])
+    assert rc == 1


### PR DESCRIPTION
Bulk-loads engine-test event rows from a CSV into an ALAQS project.
Consumed after users have created their test-site area sources
(`is_test_site='1'`) and want to populate `engine_test_events` without
hand-writing SQL.

## What changed

* `scripts/import_engine_test_events.py` (new)
* `tests/test_import_engine_test_events.py` (new, 39 tests, QGIS-free)

## CSV format

Wide format (one row per event), header required. Column names match
the DB schema:

- Required: `source_id`, `start_datetime`, `end_datetime`,
  `aircraft_type`
- Optional: `test_id`, `engine_uid`, `engine_count`, `t_TX_s`,
  `t_AP_s`, `t_CL_s`, `t_TO_s`, `instudy`

`thrust_mode` is intentionally NOT accepted from CSV: the DB column
still exists and defaults to `'snap'`, so users who need `'meem'` can
`UPDATE` via SQL. Silent misuse ruled out at the import boundary.

BFFM2 is a deferred Phase 5 item (needs a compute-time
implementation first).

## Modes

- Default is dry-run: validate against the DB, print summary, no
  writes.
- `--apply` performs the INSERT.
- `--mode {append,replace-for-source,replace-all}`
  - `append`: default. Add rows.
  - `replace-for-source`: DELETE existing events for each `source_id`
    in the CSV before insert. Re-import a corrected batch cleanly.
  - `replace-all`: DELETE all events first. Requires `--i-mean-it`.
- `--tolerate-warnings`: opt-in to proceed with warnings.

## Validation

**Errors reject a row**:
`missing_required`, `unparseable_datetime`, `end_before_start`,
`invalid_mode_time`, `invalid_engine_count`, `invalid_instudy`,
`duplicate_row`.

**Warnings abort the whole import unless `--tolerate-warnings`**:
`unknown_source_id`, `source_not_test_site`, `unknown_aircraft_type`,
`unknown_engine_uid`, `running_exceeds_window` (matches Phase 2's
60s tolerance).

All errors and warnings for all rows surface at once so users can fix
the entire batch in one pass.

Exit codes: 0 success, 1 fatal, 2 validation failure.

## Tests

39 tests, QGIS-free, all passing in 0.32s on my sandbox. Sections:

1. `read_csv` header check (3): missing required, forward-compat
   extra columns, UTF-8 BOM.
2. Row-level errors: all 8 codes + multi-error + row-numbering (13).
3. Warnings: `running_exceeds_window` + within-tolerance (2).
4. DB cross-checks: unknown source/aircraft/engine +
   not-test-site + no-crash on missing reference tables (6).
5. `apply_insert` three modes + per-source counts (4).
6. CLI end-to-end: dry-run OK/error/warning, `--apply`,
   `--tolerate-warnings`, `--i-mean-it` protection, no-writes on
   dry-run, missing file exits (10).

Depends on: #331 (Phase 1a), #332 (Phase 1b), #333 (vector-layer
copy fix), #334 (Phase 2), Phase 3 compute. All merged.

Followed by: Phase 4b — `is_test_site` UI toggle on the area-source
form (separate PR).