### PR TITLE
Phase 4b: is_test_site UI toggle on the area-source form

### DIFF
--- a/open_alaqs/ui/_area_sources_helpers.py
+++ b/open_alaqs/ui/_area_sources_helpers.py
@@ -1,0 +1,46 @@
+"""Small helpers shared by ``ui_area_sources.py``.
+
+Kept dependency-free (no qgis, no plugin imports) so unit tests can
+exercise them without a QGIS session or the full plugin import chain.
+"""
+
+from __future__ import annotations
+
+
+def seed_is_test_site_from_feature(checkbox, feature) -> None:
+    """Read ``feature["is_test_site"]`` and set the checkbox state.
+
+    Tolerated shapes for the field value:
+      * ``'1'`` (or trimmed whitespace equivalent, or integer 1) → checked
+      * anything else (``'0'``, NULL/None, empty string, unexpected
+        values) → unchecked
+      * KeyError (pre-v1b schema without the column) → unchecked
+
+    ``checkbox`` must have ``.setChecked(bool)``. ``feature`` must
+    support ``feature[key]`` reads with KeyError on missing keys.
+    """
+    try:
+        raw = feature["is_test_site"]
+    except (KeyError, IndexError):
+        checkbox.setChecked(False)
+        return
+    if raw is None:
+        checkbox.setChecked(False)
+        return
+    checkbox.setChecked(str(raw).strip() == "1")
+
+
+def write_is_test_site_to_feature(checkbox, feature) -> None:
+    """Write the checkbox state back to ``feature["is_test_site"]`` as
+    the TEXT ``'1'`` or ``'0'`` matching the DB column type.
+
+    ``AreaSources.isTestSite()`` reads by string comparison so the
+    integer/text distinction matters for round-trip consistency.
+    """
+    feature["is_test_site"] = str(int(checkbox.isChecked()))
+
+
+__all__ = [
+    "seed_is_test_site_from_feature",
+    "write_is_test_site_to_feature",
+]

--- a/open_alaqs/ui/ui_area_sources.py
+++ b/open_alaqs/ui/ui_area_sources.py
@@ -3,6 +3,10 @@ from qgis.PyQt import QtWidgets
 from open_alaqs.core import alaqs, alaqsutils
 from open_alaqs.core.alaqslogging import get_logger
 from open_alaqs.openalaqsuitoolkit import validate_field
+from open_alaqs.ui._area_sources_helpers import (
+    seed_is_test_site_from_feature,
+    write_is_test_site_to_feature,
+)
 
 logger = get_logger(__name__)
 
@@ -49,10 +53,17 @@ def form_open(form, layer, feature):
         p2_kg_unit_field=form.findChild(QtWidgets.QLineEdit, "p2_kg_unit"),
         button_box=form.findChild(QtWidgets.QDialogButtonBox, "buttonBox"),
         instudy=form.findChild(QtWidgets.QCheckBox, "instudy"),
+        is_test_site=form.findChild(QtWidgets.QCheckBox, "is_test_site"),
     )
 
     # Hide the instudy field
     fields["instudy"].setHidden(True)
+
+    # Seed the is_test_site checkbox from the feature. Values arrive as
+    # TEXT '1' / '0' (matching the DB), NULL (from ALTER TABLE ADD COLUMN
+    # on migrated projects), or absent entirely (pre-v1b schema — the
+    # widget still exists on the form but has nothing to read).
+    seed_is_test_site_from_feature(fields["is_test_site"], feature)
 
     # Disable heat flux fields
     fields["heat_flux_field"].setText("0")
@@ -85,6 +96,10 @@ def form_open(form, layer, feature):
             "monthly_profile", fields["month_profile_field"].currentText()
         )
         feature["instudy"] = str(int(fields["instudy"].isChecked()))
+        # is_test_site as TEXT '1' / '0' to match the DB column type
+        # (see EngineTestEvents.py schema). AreaSources.isTestSite()
+        # reads by string comparison.
+        write_is_test_site_to_feature(fields["is_test_site"], feature)
 
     fields["button_box"].accepted.connect(on_save)
 

--- a/open_alaqs/ui/ui_area_sources.ui
+++ b/open_alaqs/ui/ui_area_sources.ui
@@ -46,7 +46,27 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_is_test_site">
+     <property name="text">
+      <string>Engine test site</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QCheckBox" name="is_test_site">
+     <property name="toolTip">
+      <string>When enabled, this source's emissions come from engine_test_events records (loaded via scripts/import_engine_test_events.py) and the *_kg_unit rates on the Emissions tab are ignored.</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>

--- a/tests/test_ui_area_sources_toggle.py
+++ b/tests/test_ui_area_sources_toggle.py
@@ -1,0 +1,182 @@
+"""Phase 4b: unit tests for the is_test_site UI helpers.
+
+QGIS-free. Tests import from ``open_alaqs.ui._area_sources_helpers``
+(dependency-free by design), so no QGIS session or plugin bootstrap is
+needed.
+
+Coverage:
+  * seed_is_test_site_from_feature: '1'/'0'/None/missing/whitespace/
+    unexpected/int-1 handling.
+  * write_is_test_site_to_feature: writes '1' when checked, '0' when
+    unchecked.
+  * Roundtrip: seed → toggle → write → re-seed lands on same state.
+"""
+
+from __future__ import annotations
+
+from open_alaqs.ui._area_sources_helpers import (
+    seed_is_test_site_from_feature,
+    write_is_test_site_to_feature,
+)
+
+# ── Fakes ──────────────────────────────────────────────────────────────
+
+
+class _FakeCheckbox:
+    """QCheckBox stand-in with .setChecked / .isChecked."""
+
+    def __init__(self, checked: bool = False):
+        self._checked = checked
+
+    def setChecked(self, val: bool) -> None:
+        self._checked = bool(val)
+
+    def isChecked(self) -> bool:
+        return self._checked
+
+
+class _FakeFeature:
+    """QgsFeature stand-in supporting ``feature['key']`` reads/writes
+    and KeyError on missing keys."""
+
+    def __init__(self, data: dict = None):
+        self._data = dict(data or {})
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __setitem__(self, key, value):
+        self._data[key] = value
+
+    def __contains__(self, key):
+        return key in self._data
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 1: seed helper
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_seed_from_feature_value_1_checks_the_box():
+    cb = _FakeCheckbox()
+    seed_is_test_site_from_feature(cb, _FakeFeature({"is_test_site": "1"}))
+    assert cb.isChecked() is True
+
+
+def test_seed_from_feature_value_0_leaves_unchecked():
+    cb = _FakeCheckbox(checked=True)  # start wrong to verify write
+    seed_is_test_site_from_feature(cb, _FakeFeature({"is_test_site": "0"}))
+    assert cb.isChecked() is False
+
+
+def test_seed_from_feature_value_none_leaves_unchecked():
+    """NULL in DB (from ALTER TABLE ADD COLUMN on migrated projects)
+    arrives as Python None."""
+    cb = _FakeCheckbox(checked=True)
+    seed_is_test_site_from_feature(cb, _FakeFeature({"is_test_site": None}))
+    assert cb.isChecked() is False
+
+
+def test_seed_from_feature_missing_key_leaves_unchecked_no_exception():
+    """Pre-v1b schema: the .ui still declares the widget but the feature
+    layer's schema has no is_test_site column. Read must not raise."""
+    cb = _FakeCheckbox(checked=True)
+    seed_is_test_site_from_feature(cb, _FakeFeature({}))
+    assert cb.isChecked() is False
+
+
+def test_seed_from_feature_whitespace_around_one_still_checks():
+    cb = _FakeCheckbox()
+    seed_is_test_site_from_feature(cb, _FakeFeature({"is_test_site": "  1  "}))
+    assert cb.isChecked() is True
+
+
+def test_seed_from_feature_unexpected_value_leaves_unchecked():
+    """Defensive: something unexpected like 'yes' or '2' shouldn't check
+    the box. Only literal '1' does."""
+    for val in ("yes", "2", "", "TRUE"):
+        cb = _FakeCheckbox(checked=True)
+        seed_is_test_site_from_feature(cb, _FakeFeature({"is_test_site": val}))
+        assert cb.isChecked() is False, f"unexpected {val!r} should leave unchecked"
+
+
+def test_seed_from_feature_integer_one_also_checks():
+    """QgsFeature attribute reads can return int rather than str
+    depending on how the layer's field type is inferred (INTEGER vs
+    TEXT). Support both by stringifying before comparison."""
+    cb = _FakeCheckbox()
+    seed_is_test_site_from_feature(cb, _FakeFeature({"is_test_site": 1}))
+    assert cb.isChecked() is True
+
+
+def test_seed_from_feature_integer_zero_leaves_unchecked():
+    cb = _FakeCheckbox(checked=True)
+    seed_is_test_site_from_feature(cb, _FakeFeature({"is_test_site": 0}))
+    assert cb.isChecked() is False
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 2: write helper
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_write_writes_1_when_checked():
+    feature = _FakeFeature({"is_test_site": "0"})
+    cb = _FakeCheckbox(checked=True)
+    write_is_test_site_to_feature(cb, feature)
+    assert feature["is_test_site"] == "1"
+
+
+def test_write_writes_0_when_unchecked():
+    feature = _FakeFeature({"is_test_site": "1"})
+    cb = _FakeCheckbox(checked=False)
+    write_is_test_site_to_feature(cb, feature)
+    assert feature["is_test_site"] == "0"
+
+
+def test_write_creates_key_when_absent():
+    """A pre-v1b feature layer that gained is_test_site during the
+    edit session; the write should still work."""
+    feature = _FakeFeature({})  # key missing
+    cb = _FakeCheckbox(checked=True)
+    write_is_test_site_to_feature(cb, feature)
+    assert feature["is_test_site"] == "1"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 3: roundtrip
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_roundtrip_from_seeded_state():
+    """Seed → user toggles → write → re-seed a fresh box → same state.
+    Guards against future edits to seed/write drift."""
+    feature = _FakeFeature({"is_test_site": "0"})
+    cb = _FakeCheckbox()
+
+    seed_is_test_site_from_feature(cb, feature)
+    assert cb.isChecked() is False
+
+    cb.setChecked(True)  # user toggles on
+    write_is_test_site_to_feature(cb, feature)
+    assert feature["is_test_site"] == "1"
+
+    cb2 = _FakeCheckbox()
+    seed_is_test_site_from_feature(cb2, feature)
+    assert cb2.isChecked() is True
+
+
+def test_roundtrip_toggling_back_off():
+    feature = _FakeFeature({"is_test_site": "1"})
+    cb = _FakeCheckbox()
+
+    seed_is_test_site_from_feature(cb, feature)
+    assert cb.isChecked() is True
+
+    cb.setChecked(False)
+    write_is_test_site_to_feature(cb, feature)
+    assert feature["is_test_site"] == "0"
+
+    cb2 = _FakeCheckbox()
+    seed_is_test_site_from_feature(cb2, feature)
+    assert cb2.isChecked() is False


### PR DESCRIPTION
Adds a labelled "Engine test site" checkbox to the QGIS area-source
edit dialog. When checked, the source's `is_test_site` column is
written as TEXT `'1'` on save, which routes the source through
`EngineTestSourceModule` (Phase 3) at emission-compute time instead of
`AreaSourceWithTimeProfileModule`.

## Files

* `open_alaqs/ui/ui_area_sources.ui`
  * New QLabel "Engine test site" at row 4 col 0.
  * New QCheckBox `is_test_site` at row 4 col 1, with a tooltip
    explaining that emissions come from `engine_test_events` records
    (loaded via `scripts/import_engine_test_events.py`) when enabled.
  * Existing `tabWidget` shifted from row 4 to row 5. `instudy`
    stays hidden at row 3 col 1.

* `open_alaqs/ui/ui_area_sources.py`
  * `form_open` finds the new checkbox via `findChild`, seeds it from
    the feature via `seed_is_test_site_from_feature`, and writes it
    back in the `on_save` closure via `write_is_test_site_to_feature`.
  * Actual seed/write logic moved to a sibling helper module so unit
    tests don't need a QGIS session.

* `open_alaqs/ui/_area_sources_helpers.py` (new, dependency-free)
  * `seed_is_test_site_from_feature(checkbox, feature)`: reads the
    field, tolerates all realistic values (`'1'`/`'0'`/None/missing/
    whitespace/int-1/int-0/unexpected). Only literal `'1'` (after
    strip) checks the box.
  * `write_is_test_site_to_feature(checkbox, feature)`: writes TEXT
    `'1'` or `'0'` to match the DB column type.

## Tests

`tests/test_ui_area_sources_toggle.py` — 13 tests, QGIS-free.
Sections:

1. Seed helper: 8 cases covering `'1'`, `'0'`, None, missing key,
   whitespace, unexpected strings, integer 1, integer 0.
2. Write helper: 3 cases covering checked, unchecked, absent
   feature key.
3. Roundtrip: seed → toggle → write → re-seed lands on same state,
   in both directions.

All 13 tests pass in 0.04s on my sandbox.

## Value contract

The DB column is TEXT with legal values `'0'` (default) and `'1'`.
`AreaSources.isTestSite()` (Phase 1b) reads by string comparison:
`str(val).strip() == "1"`. The UI seed/write matches that contract
exactly. NULL values (from `ALTER TABLE ADD COLUMN` on pre-v1b
projects) map to unchecked, matching the read-side semantics too.

## Not in this PR

- No visual gray-out of the emission fields when the checkbox is
  checked. Users see the box, and can read the tooltip explaining
  that the `*_kg_unit` rates are ignored. A future refinement could
  auto-disable the Emissions tab; kept out of Phase 4b for scope.
- No changes to compute (Phase 3), CSV import (Phase 4a), or any
  other module.

Depends on: #331 (Phase 1a), #332 (Phase 1b), #333 (vector-layer
copy fix), #334 (Phase 2), Phase 3 compute, Phase 4a CSV import. All
merged.