### PR TITLE
Phase 5a: MEEM-for-engine-test doc cleanup, remove misleading diagnostic

### DIFF
--- a/open_alaqs/core/modules/EngineTestSourceModule.py
+++ b/open_alaqs/core/modules/EngineTestSourceModule.py
@@ -370,6 +370,19 @@ def _resolve_ei(engine, mode: str, thrust_mode: str):
         at sea-level ambient, Mach 0 (correct for stationary run-ups at
         airport elevation).
 
+    Note on MEEM for engine-test events: MEEM V1 only corrects nvPM EIs,
+    and its LTO branch (which applies here — engine test runs are at
+    ground level, Mach 0) is a log-log / linear interpolation across
+    the four ICAO EEDB anchor points. Since engine-test modes always
+    correspond to those anchor thrust settings (TX=0.07, AP=0.30,
+    CL=0.85, TO=1.00 F00), MEEM V1 returns the anchor's own nvPM value
+    unchanged. Gas-phase EIs (NOx, CO, HC, SOx) are untouched by MEEM V1
+    in any case. So for engine-test events, ``'meem'`` and ``'snap'``
+    produce numerically identical results. The MEEM path is kept for
+    consistency with the wider ALAQS emission methodology and to leave
+    room for future work (e.g. non-anchor thrust events with an
+    explicit ``power_setting`` column).
+
     Falls back to ``'snap'`` if MEEM is unavailable on the engine (older
     EEDB entries without enough data for the correction). Returns None
     if even the snap lookup fails.

--- a/openalaqs_standalone/compute_engine_test.py
+++ b/openalaqs_standalone/compute_engine_test.py
@@ -14,9 +14,18 @@ Design (per phase 0 memo):
   * D4 window-fraction hour-split: identical formula to the plugin,
     reimplemented here in native Python.
   * D2 thrust-mode override: per event; ``'snap'`` uses the raw EI
-    for that mode, ``'meem'`` is not yet supported here and falls
-    back to snap with a diagnostic (proper MEEM standalone port is
-    a Phase 5 concern).
+    for that mode. ``'meem'`` is accepted and produces numerically
+    identical results to ``'snap'`` for engine-test events. This is
+    NOT a coverage gap: MEEM V1 only corrects nvPM EIs, and its LTO
+    branch is a log-log / linear interpolation across the four ICAO
+    EEDB anchor points. Since engine-test events always run at one of
+    those anchor thrust settings (TX=0.07, AP=0.30, CL=0.85, TO=1.00
+    F00), the interpolation trivially returns the anchor's own nvPM
+    value. Gas-phase pollutants (NOx, CO, HC, SOx) are untouched by
+    MEEM V1 in any case. See the plugin's ``getEmissionIndexByModeWithMEEM``
+    for the reference implementation. If future work introduces
+    non-anchor thrust events, the standalone path here becomes
+    non-trivial and must delegate to ``open_alaqs.core.tools.meem_v1``.
   * D5 one aircraft/engine per event: mixed run-ups appear as
     multiple events sharing source_id.
   * D10 interval-overlap: same strict ``<`` semantics.
@@ -242,13 +251,17 @@ def compute_engine_test_for_period(
             )
             thrust_mode = "snap"
 
-        # Standalone does not implement MEEM yet; fall back to snap.
-        # Kept as an explicit diagnostic so callers know the coverage gap.
+        # Standalone treats 'meem' as 'snap' for engine-test events
+        # because MEEM V1 at an ICAO anchor thrust setting (which is
+        # what every engine-test mode is) reduces to the anchor's own
+        # nvPM value. Log-log/linear interpolation at a knot returns
+        # the knot. Gas-phase EIs are unaffected by MEEM V1. Result:
+        # snap and meem produce byte-identical numbers here. No
+        # diagnostic emitted; users legitimately choosing 'meem' get
+        # the answer they expect. See the module docstring for the
+        # future-work note if non-anchor thrust events are ever added.
         if thrust_mode == "meem":
-            diagnostics.append(
-                f"event {event.get('event_id')}: meem thrust mode not "
-                "implemented in standalone; falling back to snap"
-            )
+            thrust_mode = "snap"
 
         source_id = event.get("source_id")
         if source_id is None:

--- a/openalaqs_standalone/validation/tests/test_phase3_engine_test_standalone.py
+++ b/openalaqs_standalone/validation/tests/test_phase3_engine_test_standalone.py
@@ -411,13 +411,37 @@ def test_compute_unresolvable_engine_count_flagged():
     assert any("engine count unresolved" in msg for msg in diagnostics)
 
 
-def test_compute_meem_falls_back_to_snap_with_diagnostic():
-    """meem thrust mode currently reuses snap EI; diagnostic emitted."""
+def test_compute_meem_produces_same_result_as_snap():
+    """MEEM for engine-test events is numerically identical to snap
+    because engine-test modes are always at ICAO EEDB anchor thrust
+    settings, where MEEM V1's interpolation trivially returns the
+    anchor value. See compute_engine_test.py module docstring."""
+    ei_lookup = {("B602", "CL"): _ei(fuel_kg_sec=1.0, nox=20.0)}
+    aircraft_lookup = {"C56X": {"engine_count": 1, "engine_uid": "B602"}}
+
+    snap_events = [_event_dict(t_CL_s=100, engine_count=1, thrust_mode="snap")]
+    meem_events = [_event_dict(t_CL_s=100, engine_count=1, thrust_mode="meem")]
+
+    snap_totals = compute_engine_test_for_period(
+        snap_events, _dt(1, 9), _dt(1, 10), ei_lookup, aircraft_lookup
+    )
+    meem_totals = compute_engine_test_for_period(
+        meem_events, _dt(1, 9), _dt(1, 10), ei_lookup, aircraft_lookup
+    )
+    # Byte-identical results.
+    assert snap_totals == meem_totals
+
+
+def test_compute_meem_does_not_emit_diagnostic():
+    """No diagnostic should be emitted for the meem thrust mode. The
+    'not implemented' diagnostic was misleading (meem = snap at anchor
+    thrust, so nothing is unimplemented in a way that changes results)
+    and was removed in Phase 5a."""
     ei_lookup = {("B602", "CL"): _ei(fuel_kg_sec=1.0)}
     aircraft_lookup = {"C56X": {"engine_count": 1, "engine_uid": "B602"}}
     events = [_event_dict(t_CL_s=100, engine_count=1, thrust_mode="meem")]
     diagnostics = []
-    totals = compute_engine_test_for_period(
+    compute_engine_test_for_period(
         events,
         _dt(1, 9),
         _dt(1, 10),
@@ -425,9 +449,10 @@ def test_compute_meem_falls_back_to_snap_with_diagnostic():
         aircraft_lookup,
         diagnostics=diagnostics,
     )
-    # Fuel still computed via snap fallback.
-    assert abs(totals["N1"]["fuel"] - 100.0) < 1e-9
-    assert any("meem thrust mode not implemented" in msg for msg in diagnostics)
+    # The old diagnostic string must be absent.
+    assert not any("not implemented" in msg for msg in diagnostics)
+    # And no meem-specific diagnostic should be emitted at all.
+    assert not any("meem" in msg.lower() for msg in diagnostics)
 
 
 def test_compute_engine_uid_row_takes_precedence():


### PR DESCRIPTION
MEEM V1 for engine-test events is numerically identical to snap. This
PR clarifies that in the code and removes a misleading diagnostic that
implied a coverage gap where none exists.

## Why they're identical

MEEM V1 corrects ONLY nvPM EIs (`nvpm_g_kg`, `nvpm_number_kg`); every
other pollutant passes through unchanged. Its LTO branch (which
applies at ground level, which is where engine tests happen) is a
log-log / linear interpolation between the four ICAO EEDB anchor
points, on power setting in [0.07, 1.00].

Engine-test events run at ICAO anchor thrust settings by
construction: each mode maps to exactly one anchor (TX=0.07, AP=0.30,
CL=0.85, TO=1.00 F00). Interpolating at an anchor returns the
anchor's own value. So MEEM V1's nvPM correction is a no-op, and
gas-phase EIs weren't touched anyway. Snap and meem produce
byte-identical results.

## Files

* `openalaqs_standalone/compute_engine_test.py`
  - Module docstring: replace "meem not yet supported here and falls
    back to snap with a diagnostic (proper MEEM standalone port is a
    Phase 5 concern)" with an explanation of why meem = snap for
    engine-test events, and a note that future non-anchor thrust
    support would require delegating to
    `open_alaqs.core.tools.meem_v1`.
  - `compute_engine_test_for_period`: remove the "meem thrust mode
    not implemented in standalone; falling back to snap" diagnostic.
    Silently treat `'meem'` as `'snap'` (same numerical result). Keep
    the branch to be explicit about the acceptance of both values.

* `open_alaqs/core/modules/EngineTestSourceModule.py`
  - `_resolve_ei` docstring: add the same "MEEM = snap for
    engine-test" note for symmetry. The plugin's code path is
    unchanged; the doc just makes clear WHY the two paths return the
    same numbers.

* `openalaqs_standalone/validation/tests/test_phase3_engine_test_standalone.py`
  - Replace `test_compute_meem_falls_back_to_snap_with_diagnostic`
    (which asserted the old misleading diagnostic) with two focused
    tests:
    * `test_compute_meem_produces_same_result_as_snap`: byte-equality
      of the totals dict between snap and meem for the same event.
    * `test_compute_meem_does_not_emit_diagnostic`: no meem-related
      diagnostic appears in the diagnostics list.

## Standalone regression

18 passed on my sandbox (was 17: -1 removed, +2 added).

## Not in this PR

Phase 5b (BFFM2 for engine-test) is a separate PR. BFFM2 corrects
gas-phase EIs (NOx, CO, HC) with ambient conditions, which IS
numerically different from snap when `tbl_InvMeteo` is not ISA. That
work is where the real Phase 5 substance lives.