### PR TITLE
Phase 5b: BFFM2 thrust mode for engine-test events

### DIFF
--- a/open_alaqs/core/interfaces/AmbientCondition.py
+++ b/open_alaqs/core/interfaces/AmbientCondition.py
@@ -278,6 +278,53 @@ class AmbientConditionStore(Store, metaclass=Singleton):
         else:
             return sorted(list(self.getObjects().values()), key=lambda ac: ac.getDate())
 
+    def getNearestByTime(self, timestamp_s):
+        """Return the ``AmbientCondition`` whose ``DateTime`` is closest
+        (nearest neighbour) to ``timestamp_s`` (a Unix timestamp).
+
+        Returns an empty ``AmbientCondition()`` if the store has no
+        entries. Callers that need to know whether the store was empty
+        can check ``bool(self.getObjects())`` before calling; the
+        returned empty instance has getters that return None (matching
+        the pre-existing "no meteo loaded" contract used by
+        ``EmissionCalculation.getAmbientCondition``).
+
+        Mirrors the bisect semantics of
+        ``EmissionCalculation.getAmbientCondition`` so per-time lookups
+        that pass through the SourceModule layer produce the same
+        AmbientCondition as those done inside EmissionCalculation.
+
+        :param timestamp_s: Unix timestamp (seconds since epoch).
+        :return: nearest ``AmbientCondition`` or empty instance.
+        """
+        import bisect
+
+        # Sort once per call; the store's contents change rarely and the
+        # cost is O(n log n) but n is typically small (one row per hour
+        # for a year = 8760). If profiling shows this is hot, cache the
+        # sorted list on the store as EmissionCalculation does.
+        sorted_ac = self.getAmbientConditions(scenario="")
+        if not sorted_ac:
+            return AmbientCondition()
+
+        times = [
+            (ac.getDate().timestamp() if hasattr(ac.getDate(), "timestamp") else 0.0)
+            for ac in sorted_ac
+        ]
+
+        idx = bisect.bisect_left(times, timestamp_s)
+        if idx == 0:
+            return sorted_ac[0]
+        if idx >= len(times):
+            return sorted_ac[-1]
+        before = sorted_ac[idx - 1]
+        after = sorted_ac[idx]
+        return (
+            before
+            if abs(timestamp_s - times[idx - 1]) <= abs(times[idx] - timestamp_s)
+            else after
+        )
+
     def serialize(self):
         if not self.getAmbientConditionDatabase().serialize():
             logger.error(

--- a/open_alaqs/core/interfaces/Engine.py
+++ b/open_alaqs/core/interfaces/Engine.py
@@ -300,6 +300,84 @@ class EngineEmissionIndex(Store):
             )
             return base_ei
 
+    def getEmissionIndexByModeWithBFFM2(
+        self,
+        mode,
+        ambient_conditions,
+        mach=0.0,
+    ):
+        """Per-mode EI with BFFM2 ambient corrections applied to gas-phase
+        pollutants.
+
+        BFFM2 corrects NOx, CO, HC EIs and the ambient-adjusted fuel
+        flow using the temperature/pressure/humidity/Mach dependence.
+        PM10 (and PM sub-classes), SOx, and CO2 pass through unchanged
+        from the base mode EI. Composed result: base EI overlaid with
+        BFFM2-corrected gas-phase EIs and ambient FF.
+
+        Semantics matches ``MovementEmissionCalculator._get_emission_index_bffm2``:
+        gas from BFFM2 twin-quadratic path, PM from EEDB per-mode.
+        Falls back to plain ``getEmissionIndexByMode(mode)`` if BFFM2
+        raises for any reason (missing FF at anchors, twin-quadratic
+        out-of-range, etc). See phase 5b design memo for the choice of
+        MEEM-PM composition.
+
+        :param mode: operating mode ("T/O","C/O","App","Idle" or the
+                     aliases "TO","CL","AP","TX",...).
+        :param ambient_conditions: an ``AmbientCondition`` instance with
+                                   getTemperature (K), getPressure (Pa),
+                                   getRelativeHumidity (0..1). Passed
+                                   into ``method["config"]``.
+        :param mach: flight Mach number. Default 0.0 (stationary engine
+                     at airport elevation — the correct value for
+                     engine-test events).
+        :return: composite EmissionIndex, or the plain ``getEmissionIndexByMode``
+                 result if BFFM2 fails.
+        """
+        base_ei = self.getEmissionIndexByMode(mode)
+        if base_ei is None:
+            return None
+
+        power_setting = self.getPowerSettingByMode(mode)
+        if power_setting is None:
+            # Alternative mode names (e.g. mode="C/O" but stored as "CL").
+            alt = self.getAlternativeModeNames().get(mode)
+            if alt is not None:
+                power_setting = self.getPowerSettingByMode(alt)
+        if power_setting is None:
+            return base_ei
+
+        try:
+            method = {
+                "name": "BFFM2",
+                "config": {
+                    "ambient_conditions": ambient_conditions,
+                    "mach_number": float(mach),
+                },
+            }
+            bffm2_ei = self.getEmissionIndexByEngineState(
+                float(power_setting), method=method
+            )
+        except Exception as exc:
+            logger.debug("BFFM2 fall-through for mode %s: %s", mode, exc)
+            return base_ei
+
+        if bffm2_ei is None:
+            return base_ei
+
+        # Compose: start from base EI (which carries PM, SOx, CO2 fields
+        # in EEDB values), overlay BFFM2 gas-phase and ambient FF. Matches
+        # the plugin's MovementEmissionCalculator._get_emission_index_bffm2
+        # ordering.
+        composite = EmissionIndex(
+            initValues=dict(base_ei._objects), defaultValues=defaultEI
+        )
+        for field in ("fuel_kg_sec", "nox_g_kg", "co_g_kg", "hc_g_kg"):
+            val = bffm2_ei.getObject(field)
+            if val is not None:
+                composite.setObject(field, val)
+        return composite
+
     def getICAOEngineEmissionsDB(self, index1_power=False, id2=None, format=""):
         icao_eedb: dict[float, EmissionIndex] = {}
         for mode_, obj_ in list(self.getObjects().items()):

--- a/open_alaqs/core/modules/EngineTestSourceModule.py
+++ b/open_alaqs/core/modules/EngineTestSourceModule.py
@@ -90,6 +90,12 @@ class EngineTestSourceModule(SourceModule):
         self._events_store: Optional[EngineTestEventsStore] = None
         self._aircraft_store = None
         self._engine_store = None
+        self._ambient_store = None  # AmbientConditionStore; only used for BFFM2
+
+        # Diagnostic: set to True the first time an event asks for BFFM2
+        # and the ambient store is empty. Prevents log flooding when a
+        # study uses BFFM2 without a populated tbl_InvMeteo.
+        self._bffm2_isa_fallback_logged: bool = False
 
         # Default thrust-mode override; per-event ``thrust_mode`` still
         # takes precedence. Kept for potential future study-level
@@ -116,6 +122,12 @@ class EngineTestSourceModule(SourceModule):
     def setEngineStore(self, store) -> None:
         self._engine_store = store
 
+    def getAmbientStore(self):
+        return self._ambient_store
+
+    def setAmbientStore(self, store) -> None:
+        self._ambient_store = store
+
     # ── Lifecycle ──────────────────────────────────────────────────────
 
     def beginJob(self):
@@ -141,6 +153,16 @@ class EngineTestSourceModule(SourceModule):
             from open_alaqs.core.interfaces.EngineStore import EngineStore
 
             self._engine_store = EngineStore(db_path)
+
+        if self._ambient_store is None:
+            # AmbientConditionStore is a Singleton; if EmissionCalculation
+            # has already loaded it for the same db_path, this call
+            # returns the same instance rather than re-reading tbl_InvMeteo.
+            from open_alaqs.core.interfaces.AmbientCondition import (
+                AmbientConditionStore,
+            )
+
+            self._ambient_store = AmbientConditionStore(db_path)
 
     def endJob(self):
         # Nothing to release; stores are Singletons owned by the runtime.
@@ -305,12 +327,30 @@ class EngineTestSourceModule(SourceModule):
         mode_times = event.getModeTimes()  # {"TX": s, "AP": s, "CL": s, "TO": s}
         thrust_mode = event.getThrustMode() or self._default_thrust_mode
 
+        # BFFM2 needs ambient conditions at the event midpoint. Lazy: only
+        # look up when the thrust mode requires it, so snap/meem events
+        # don't pay the cost.
+        ambient_conditions = None
+        if thrust_mode == "bffm2":
+            ambient_conditions = self._resolve_event_ambient(event)
+            # None means the ambient store is empty AND diagnostic already
+            # emitted; fall back to snap-equivalent behaviour by returning
+            # None here so _resolve_ei drops to base EI (which is what an
+            # ISA-fallback would produce anyway when the store is empty —
+            # AmbientCondition() empty getters yield None).
+            # The BFFM2 wrapper (getEmissionIndexByModeWithBFFM2) already
+            # handles the "empty AmbientCondition → fall back to base" path
+            # via the existing bffm2.py ISA-defaults branch. So passing
+            # ambient_conditions even when the store was empty is safe;
+            # the diagnostic gets logged once and BFFM2 downcasts to ISA
+            # internally.
+
         any_mode_computed = False
         for mode, t_mode_s in mode_times.items():
             if t_mode_s <= 0:
                 continue
 
-            ei = _resolve_ei(engine, mode, thrust_mode)
+            ei = _resolve_ei(engine, mode, thrust_mode, ambient_conditions)
             if ei is None:
                 logger.warning(
                     "EngineTest event %s: no EI for engine %r mode %r; "
@@ -330,6 +370,56 @@ class EngineTestSourceModule(SourceModule):
             any_mode_computed = True
 
         return any_mode_computed
+
+    def _resolve_event_ambient(self, event):
+        """Look up ambient conditions at the event's midpoint via the
+        AmbientConditionStore.
+
+        Returns:
+          * The nearest ``AmbientCondition`` from ``tbl_InvMeteo``, OR
+          * An empty ``AmbientCondition()`` (whose getTemperature /
+            getPressure / getRelativeHumidity return None) if the store
+            is empty. A diagnostic is emitted once per module lifetime
+            in this case so the user learns their study is missing
+            meteo but log volume stays sane.
+
+        The empty case is handled downstream by ``bffm2.calculate_emission_index``
+        (existing behaviour): it silently substitutes ISA defaults with
+        its own logger.warning. So the ISA-fallback path is well-defined
+        and the diagnostic here explains WHY BFFM2 got ISA defaults for
+        callers who ask.
+        """
+        if self._ambient_store is None:
+            # Ambient store never loaded (e.g. beginJob not called).
+            # Return empty AmbientCondition; BFFM2 will fall back to ISA
+            # inside bffm2.py.
+            from open_alaqs.core.interfaces.AmbientCondition import AmbientCondition
+
+            return AmbientCondition()
+
+        start_dt = event.getStartDateTime()
+        end_dt = event.getEndDateTime()
+        if start_dt is None or end_dt is None:
+            # Degenerate event; the caller (process) already filtered
+            # these but be safe.
+            from open_alaqs.core.interfaces.AmbientCondition import AmbientCondition
+
+            return AmbientCondition()
+
+        midpoint_dt = start_dt + (end_dt - start_dt) / 2
+        midpoint_ts = midpoint_dt.timestamp()
+
+        ambient = self._ambient_store.getNearestByTime(midpoint_ts)
+        if ambient.getTemperature() is None and not self._bffm2_isa_fallback_logged:
+            logger.warning(
+                "EngineTestSource: tbl_InvMeteo has no ambient data; "
+                "BFFM2 events will fall back to ISA defaults "
+                "(T=288.15 K, P=101325 Pa, RH=0.6). Populate tbl_InvMeteo "
+                "to get real ambient corrections. This message is shown "
+                "once per run."
+            )
+            self._bffm2_isa_fallback_logged = True
+        return ambient
 
 
 # ── Free functions (unit-testable without instantiating the module) ────
@@ -361,7 +451,7 @@ def _period_window_fraction(
     return overlap_s / total_s
 
 
-def _resolve_ei(engine, mode: str, thrust_mode: str):
+def _resolve_ei(engine, mode: str, thrust_mode: str, ambient_conditions=None):
     """Return the ``EmissionIndex`` for ``mode`` on ``engine`` under the
     requested ``thrust_mode``.
 
@@ -369,6 +459,11 @@ def _resolve_ei(engine, mode: str, thrust_mode: str):
     ``'meem'`` → MEEM-corrected via ``getEmissionIndexByModeWithMEEM``
         at sea-level ambient, Mach 0 (correct for stationary run-ups at
         airport elevation).
+    ``'bffm2'`` → BFFM2-corrected gas-phase EIs (NOx, CO, HC) via
+        ``getEmissionIndexByModeWithBFFM2`` at the caller-supplied
+        ``ambient_conditions``, Mach 0. PM10 (and PM sub-classes), SOx,
+        and CO2 pass through unchanged from the base mode EI. Per
+        Design A: BFFM2 gas + EEDB PM composed together.
 
     Note on MEEM for engine-test events: MEEM V1 only corrects nvPM EIs,
     and its LTO branch (which applies here — engine test runs are at
@@ -383,20 +478,48 @@ def _resolve_ei(engine, mode: str, thrust_mode: str):
     room for future work (e.g. non-anchor thrust events with an
     explicit ``power_setting`` column).
 
-    Falls back to ``'snap'`` if MEEM is unavailable on the engine (older
-    EEDB entries without enough data for the correction). Returns None
-    if even the snap lookup fails.
+    Note on BFFM2: unlike MEEM, BFFM2 IS numerically different from snap
+    whenever the ambient is not ISA. Users choosing ``'bffm2'`` need a
+    populated ``tbl_InvMeteo``; the module emits a diagnostic if the
+    ambient store is empty and the underlying ``bffm2.py`` layer
+    substitutes ISA defaults with its own warning.
+
+    Falls back to ``'snap'`` if MEEM or BFFM2 is unavailable on the
+    engine (older EEDB entries without enough data for the correction).
+    Returns None if even the snap lookup fails.
     """
     try:
         if thrust_mode == "meem":
-            ei = engine.getEmissionIndexByModeWithMEEM(
-                mode,
-                p_amb_Pa=_MEEM_P_AMB_PA,
-                mach=_MEEM_MACH,
-            )
+            try:
+                ei = engine.getEmissionIndexByModeWithMEEM(
+                    mode,
+                    p_amb_Pa=_MEEM_P_AMB_PA,
+                    mach=_MEEM_MACH,
+                )
+            except AttributeError:
+                # Old engine lacking the MEEM wrapper method. Fall
+                # through to snap.
+                ei = None
             if ei is not None:
                 return ei
             # Fall through to snap on MEEM unavailability.
+        elif thrust_mode == "bffm2":
+            if ambient_conditions is None:
+                # Caller forgot to supply ambient. Fall back to snap.
+                return engine.getEmissionIndexByMode(mode)
+            try:
+                ei = engine.getEmissionIndexByModeWithBFFM2(
+                    mode,
+                    ambient_conditions=ambient_conditions,
+                    mach=0.0,
+                )
+            except AttributeError:
+                # Old engine lacking the BFFM2 wrapper method. Fall
+                # through to snap.
+                ei = None
+            if ei is not None:
+                return ei
+            # Fall through to snap on BFFM2 unavailability.
         return engine.getEmissionIndexByMode(mode)
     except Exception:  # pragma: no cover
         # Engine misconfigured (mode not in its table). Callers log

--- a/openalaqs_standalone/compute_engine_test.py
+++ b/openalaqs_standalone/compute_engine_test.py
@@ -33,6 +33,7 @@ Design (per phase 0 memo):
 
 from __future__ import annotations
 
+import sqlite3  # noqa: E402  (kept adjacent to the typing imports)
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
@@ -45,6 +46,25 @@ _MODE_TIME_COL = {
     "AP": "t_AP_s",
     "CL": "t_CL_s",
     "TO": "t_TO_s",
+}
+
+
+# BFFM2 mode-name mapping: our short mode keys → the name-form the
+# shared bffm2 module expects. Matches openalaqs_standalone.compute_aircraft.
+_BFFM2_MODE_NAMES = {
+    "TX": "Idle",
+    "AP": "Approach",
+    "CL": "Climbout",
+    "TO": "Takeoff",
+}
+
+# CAEP14 installation corrections. Same as compute_aircraft's; kept
+# adjacent for source-of-truth clarity.
+_BFFM2_INSTALLATION_CORRECTIONS = {
+    "Takeoff": 1.010,
+    "Climbout": 1.013,
+    "Approach": 1.020,
+    "Idle": 1.100,
 }
 
 
@@ -181,6 +201,133 @@ def _add_ei_to_totals(
         totals[pol] += float(v) * fuel_burned
 
 
+def _build_icao_eedb_for_engine(
+    engine_uid: str, ei_lookup: Dict[Tuple[str, str], Dict]
+) -> Optional[Dict]:
+    """Build the BFFM2-shaped icao_eedb dict for one engine.
+
+    Format expected by ``open_alaqs.core.tools.bffm2.calculate_emission_index``:
+      ``{pollutant: {mode_name: {ff_ref_kg_s: ei_g_kg}}}``
+
+    Where ``pollutant`` is ``PollutantType.NOx / .CO / .HC`` (or the
+    string variants they map from), ``mode_name`` is the BFFM2 name
+    (``"Idle" / "Approach" / "Climbout" / "Takeoff"``), and
+    ``ff_ref_kg_s`` is the mode's reference fuel flow.
+
+    Returns ``None`` if any of the four modes is missing from the
+    lookup, or if any missing has no ``fuel_kg_sec``. BFFM2 without a
+    complete 4-mode anchor set is undefined.
+    """
+    # Import lazily so snap-only callers don't pull it in.
+    from open_alaqs.core.interfaces.Emissions import PollutantType
+
+    eedb: Dict = {
+        p: {} for p in (PollutantType.NOx, PollutantType.CO, PollutantType.HC)
+    }
+    _POL_MAP = {
+        PollutantType.NOx: "nox_ei_g_kg_fuel",
+        PollutantType.CO: "co_ei_g_kg_fuel",
+        PollutantType.HC: "hc_ei_g_kg_fuel",
+    }
+    for mode, bffm2_name in _BFFM2_MODE_NAMES.items():
+        row = ei_lookup.get((engine_uid, mode))
+        if row is None:
+            return None
+        ff = row.get("fuel_kg_sec")
+        if ff is None:
+            return None
+        ff = float(ff)
+        for pol, ei_key in _POL_MAP.items():
+            v = row.get(ei_key)
+            if v is None:
+                return None
+            eedb[pol][bffm2_name] = {ff: float(v)}
+    return eedb
+
+
+def _add_bffm2_ei_to_totals(
+    totals: Dict[str, float],
+    ei_row: Dict,
+    icao_eedb: Dict,
+    meteo: Dict,
+    t_effective_s: float,
+) -> None:
+    """Add one segment's BFFM2-corrected gas emissions plus base PM/SOx
+    to the running totals dict.
+
+    Gas-phase EIs (NOx, CO, HC) come from ``bffm2.calculate_emission_index``
+    at the segment's ambient fuel flow. PM10, PM sub-classes, SOx, and
+    fuel burn come from the per-mode ``ei_row`` (same as snap). Matches
+    the plugin's Engine.getEmissionIndexByModeWithBFFM2 composition:
+    BFFM2 gas + EEDB PM (Design A per phase 5 memo).
+    """
+    # Ambient fuel flow conversion: FF_ref → FF_amb via θ/δ/Mach.
+    #   FF_amb = FF_ref * δ / θ^3.8 / exp(0.2*M²)
+    # Matches Engine.getEmissionIndexByEngineState's pre-conversion so the
+    # bffm2 module's internal inverse correction cancels the pre-conversion
+    # and lands on the correct EEDB interpolation position.
+    import math
+
+    from open_alaqs.core.interfaces.Emissions import PollutantType
+    from open_alaqs.core.tools.bffm2 import calculate_emission_index as _bffm2_ei
+
+    ff_ref = float(ei_row.get("fuel_kg_sec") or 0.0)
+    if ff_ref <= 0.0:
+        # Missing FF; can't do BFFM2. Fall through to snap for this mode
+        # by delegating to the standard _add_ei_to_totals-style math.
+        _add_ei_to_totals(totals, ei_row, t_effective_s)
+        return
+
+    T_K = meteo["T_K"]
+    P_Pa = meteo["P_Pa"]
+    RH = meteo["RH"]
+    mach = float(meteo.get("mach_number", 0.0))
+    theta = T_K / 288.15
+    delta = P_Pa / 101325.0
+    ff_amb = ff_ref * delta / (theta**3.8) / math.exp(0.2 * mach**2)
+
+    fuel_burned = ff_amb * t_effective_s
+    totals["fuel"] += fuel_burned
+
+    ambient_conditions = {
+        "temperature_in_Kelvin": T_K,
+        "pressure_in_Pa": P_Pa,
+        "relative_humidity": RH,
+        "mach_number": mach,
+    }
+
+    for pol_enum, dest_key in (
+        (PollutantType.NOx, "nox"),
+        (PollutantType.CO, "co"),
+        (PollutantType.HC, "hc"),
+    ):
+        ei = _bffm2_ei(
+            pol_enum,
+            ff_amb,
+            icao_eedb,
+            ambient_conditions=ambient_conditions,
+            installation_corrections=_BFFM2_INSTALLATION_CORRECTIONS,
+        )
+        totals[dest_key] += float(ei) * fuel_burned
+
+    # PM10, SOx, CO2, and PM sub-classes from the EEDB row unchanged.
+    _EEDB_PASSTHROUGH = {
+        "co2": "co2_ei_g_kg_fuel",
+        "sox": "sox_ei_g_kg_fuel",
+        "pm10": "pm10_ei_g_kg_fuel",
+        "p1": "p1_ei_g_kg_fuel",
+        "p2": "p2_ei_g_kg_fuel",
+        "pm10_nonvol": "pm10_nonvol_ei_g_kg_fuel",
+        "pm10_sul": "pm10_sul_ei_g_kg_fuel",
+        "pm10_organic": "pm10_organic_ei_g_kg_fuel",
+    }
+    for pol, ei_key in _EEDB_PASSTHROUGH.items():
+        v = ei_row.get(ei_key)
+        if v is None:
+            continue
+        totals[pol] += float(v) * fuel_burned
+
+
 def compute_engine_test_for_period(
     events: Iterable[Dict],
     period_start: datetime,
@@ -188,6 +335,7 @@ def compute_engine_test_for_period(
     ei_lookup: Dict[Tuple[str, str], Dict],
     aircraft_lookup: Dict,
     diagnostics: Optional[List[str]] = None,
+    conn: Optional[sqlite3.Connection] = None,
 ) -> Dict[str, Dict[str, float]]:
     """Compute per-source emission totals for one period.
 
@@ -205,6 +353,12 @@ def compute_engine_test_for_period(
         Used for engine-count and default-engine-uid fallback.
     diagnostics : optional list to append skip-warning strings to. If
         provided, callers can surface these in their run log.
+    conn : optional sqlite3 connection to the ``.alaqs`` project.
+        Required only for events with ``thrust_mode='bffm2'``: used to
+        look up ``tbl_InvMeteo`` at each event's midpoint. If not
+        supplied, BFFM2 events fall back to snap with a single
+        diagnostic. If supplied but the table is empty, BFFM2 events
+        fall back to ISA-with-diagnostic (once per call).
 
     Returns
     -------
@@ -214,6 +368,10 @@ def compute_engine_test_for_period(
     """
     if diagnostics is None:
         diagnostics = []
+
+    # Once-per-call flags for BFFM2 diagnostics.
+    _bffm2_isa_fallback_logged = False
+    _bffm2_no_conn_logged = False
 
     by_source: Dict[str, Dict[str, float]] = {}
 
@@ -244,7 +402,7 @@ def compute_engine_test_for_period(
             continue
 
         thrust_mode = str(event.get("thrust_mode") or "snap")
-        if thrust_mode not in ("snap", "meem"):
+        if thrust_mode not in ("snap", "meem", "bffm2"):
             diagnostics.append(
                 f"event {event.get('event_id')}: unknown thrust_mode "
                 f"{thrust_mode!r}; treating as 'snap'"
@@ -262,6 +420,86 @@ def compute_engine_test_for_period(
         # future-work note if non-anchor thrust events are ever added.
         if thrust_mode == "meem":
             thrust_mode = "snap"
+
+        # BFFM2 setup: pre-build the icao_eedb once per event (all four
+        # modes for the resolved engine) and resolve meteo at event
+        # midpoint. If any prerequisite is missing, fall back to snap
+        # with a diagnostic — matches the plugin's behaviour of falling
+        # through to base EI on BFFM2 failure.
+        bffm2_ready = False
+        bffm2_icao_eedb = None
+        bffm2_meteo = None
+        if thrust_mode == "bffm2":
+            if conn is None:
+                if not _bffm2_no_conn_logged:
+                    diagnostics.append(
+                        "bffm2 events present but conn=None; falling back "
+                        "to snap for all bffm2 events this call. Pass conn "
+                        "to compute_engine_test_for_period to enable BFFM2."
+                    )
+                    _bffm2_no_conn_logged = True
+                thrust_mode = "snap"
+            else:
+                bffm2_icao_eedb = _build_icao_eedb_for_engine(engine_uid, ei_lookup)
+                if bffm2_icao_eedb is None:
+                    diagnostics.append(
+                        f"event {event.get('event_id')}: bffm2 requested but "
+                        f"engine {engine_uid!r} lacks a complete 4-mode "
+                        "EI+FF anchor set; falling back to snap"
+                    )
+                    thrust_mode = "snap"
+                else:
+                    # Meteo lookup at event midpoint.
+                    mid_dt = e_start + (e_end - e_start) / 2
+                    mid_iso = mid_dt.strftime("%Y-%m-%d %H:%M:%S")
+                    # Delegate to movements.get_meteo_at which reads
+                    # tbl_InvMeteo with "<= runway_time" semantics and
+                    # falls back to ISA if the table has no matching
+                    # row. Import lazily to avoid the standalone runtime
+                    # dependency for snap-only callers.
+                    from openalaqs_standalone import movements as _mv
+
+                    row = conn.execute(
+                        "SELECT COUNT(*) FROM sqlite_master "
+                        "WHERE type='table' AND name='tbl_InvMeteo'"
+                    ).fetchone()
+                    if row[0] == 0 and not _bffm2_isa_fallback_logged:
+                        diagnostics.append(
+                            "bffm2 events present but tbl_InvMeteo not in "
+                            "the DB; BFFM2 will fall back to ISA defaults. "
+                            "Populate tbl_InvMeteo to get real ambient "
+                            "corrections. This message is shown once per "
+                            "call."
+                        )
+                        _bffm2_isa_fallback_logged = True
+                        bffm2_meteo = dict(_mv.ISA_AMBIENT)
+                    else:
+                        try:
+                            bffm2_meteo = _mv.get_meteo_at(conn, mid_iso, use_isa=False)
+                            # Warn once if the returned meteo is ISA
+                            # (meaning tbl_InvMeteo had no <= mid_iso
+                            # row, get_meteo_at recursively fell back).
+                            if (
+                                bffm2_meteo.get("T_K") == 288.15
+                                and bffm2_meteo.get("P_Pa") == 101325.0
+                                and not _bffm2_isa_fallback_logged
+                            ):
+                                diagnostics.append(
+                                    "bffm2 events present but tbl_InvMeteo "
+                                    "has no data at or before their midpoint; "
+                                    "BFFM2 will fall back to ISA defaults. "
+                                    "This message is shown once per call."
+                                )
+                                _bffm2_isa_fallback_logged = True
+                        except Exception as _exc:
+                            diagnostics.append(
+                                f"bffm2 meteo lookup failed ({_exc}); "
+                                "falling back to snap for this event"
+                            )
+                            thrust_mode = "snap"
+
+                    if thrust_mode == "bffm2":
+                        bffm2_ready = True
 
         source_id = event.get("source_id")
         if source_id is None:
@@ -285,7 +523,12 @@ def compute_engine_test_for_period(
                 )
                 continue
             t_effective = t_mode_s * engine_count * fraction
-            _add_ei_to_totals(totals, ei_row, t_effective)
+            if bffm2_ready:
+                _add_bffm2_ei_to_totals(
+                    totals, ei_row, bffm2_icao_eedb, bffm2_meteo, t_effective
+                )
+            else:
+                _add_ei_to_totals(totals, ei_row, t_effective)
             contributed = True
 
         if not contributed and source_id in by_source:

--- a/openalaqs_standalone/validation/tests/test_phase3_engine_test_standalone.py
+++ b/openalaqs_standalone/validation/tests/test_phase3_engine_test_standalone.py
@@ -478,3 +478,289 @@ def test_compute_engine_uid_falls_back_to_aircraft():
         events, _dt(1, 9), _dt(1, 10), ei_lookup, aircraft_lookup
     )
     assert abs(totals["N1"]["fuel"] - 100.0) < 1e-9
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 4: Phase 5b — BFFM2 thrust mode
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _build_engine_ei_lookup_all_modes(uid: str, nox_ei=20.0):
+    """Build a 4-mode ei_lookup for one engine with plausible FFs and
+    per-mode EIs, so BFFM2's icao_eedb builder can complete."""
+    return {
+        (uid, "TX"): _ei(fuel_kg_sec=0.05, nox=nox_ei, co=10.0, hc=5.0),
+        (uid, "AP"): _ei(fuel_kg_sec=0.20, nox=nox_ei, co=1.0, hc=0.1),
+        (uid, "CL"): _ei(fuel_kg_sec=0.60, nox=nox_ei, co=0.5, hc=0.05),
+        (uid, "TO"): _ei(fuel_kg_sec=0.80, nox=nox_ei, co=0.5, hc=0.05),
+    }
+
+
+def _prep_bffm2_conn_with_meteo(t_K=298.15, p_Pa=100000.0, rh=0.7):
+    """Create a scratch SQLite connection with a populated tbl_InvMeteo."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """CREATE TABLE tbl_InvMeteo (
+            DateTime TEXT,
+            Temperature REAL,
+            SeaLevelPressure REAL,
+            RelativeHumidity REAL,
+            Humidity REAL
+        )"""
+    )
+    conn.execute(
+        "INSERT INTO tbl_InvMeteo VALUES (?, ?, ?, ?, ?)",
+        ("2024-12-01 09:00:00", t_K, p_Pa, rh, 0.008),
+    )
+    conn.commit()
+    return conn
+
+
+def test_bffm2_without_conn_falls_back_to_snap_with_diagnostic():
+    """bffm2 events without conn → warn once, treat as snap."""
+    ei_lookup = _build_engine_ei_lookup_all_modes("B602")
+    aircraft_lookup = {"C56X": {"engine_count": 1, "engine_uid": "B602"}}
+    events = [_event_dict(t_CL_s=100, engine_count=1, thrust_mode="bffm2")]
+    diagnostics: list = []
+
+    snap_totals = compute_engine_test_for_period(
+        [_event_dict(t_CL_s=100, engine_count=1, thrust_mode="snap")],
+        _dt(1, 9),
+        _dt(1, 10),
+        ei_lookup,
+        aircraft_lookup,
+    )
+    bffm2_totals = compute_engine_test_for_period(
+        events,
+        _dt(1, 9),
+        _dt(1, 10),
+        ei_lookup,
+        aircraft_lookup,
+        diagnostics=diagnostics,
+        conn=None,
+    )
+
+    # Same numerical output as snap (fell back).
+    assert snap_totals == bffm2_totals
+    # Diagnostic emitted once.
+    n = sum(1 for msg in diagnostics if "conn=None" in msg)
+    assert n == 1
+
+
+def test_bffm2_no_conn_warning_logged_only_once():
+    """Multiple bffm2 events with conn=None → warning fires only once."""
+    ei_lookup = _build_engine_ei_lookup_all_modes("B602")
+    aircraft_lookup = {"C56X": {"engine_count": 1, "engine_uid": "B602"}}
+    events = [
+        _event_dict(event_id=1, t_CL_s=100, engine_count=1, thrust_mode="bffm2"),
+        _event_dict(
+            event_id=2,
+            t_CL_s=100,
+            engine_count=1,
+            thrust_mode="bffm2",
+            start_datetime="2024-12-01T09:45:00",
+            end_datetime="2024-12-01T09:55:00",
+        ),
+    ]
+    diagnostics: list = []
+    compute_engine_test_for_period(
+        events,
+        _dt(1, 9),
+        _dt(1, 10),
+        ei_lookup,
+        aircraft_lookup,
+        diagnostics=diagnostics,
+        conn=None,
+    )
+    n = sum(1 for msg in diagnostics if "conn=None" in msg)
+    assert n == 1
+
+
+def test_bffm2_incomplete_engine_ei_falls_back_to_snap():
+    """Engine missing one mode in ei_lookup → BFFM2 requires all 4 for
+    the icao_eedb; falls back to snap with a per-event diagnostic."""
+    # Only 3 modes present.
+    ei_lookup = {
+        ("B602", "TX"): _ei(fuel_kg_sec=0.05, nox=20.0, co=10.0, hc=5.0),
+        ("B602", "AP"): _ei(fuel_kg_sec=0.20, nox=20.0, co=1.0, hc=0.1),
+        ("B602", "CL"): _ei(fuel_kg_sec=0.60, nox=20.0, co=0.5, hc=0.05),
+        # "TO" missing
+    }
+    aircraft_lookup = {"C56X": {"engine_count": 1, "engine_uid": "B602"}}
+    events = [_event_dict(t_CL_s=100, engine_count=1, thrust_mode="bffm2")]
+    conn = _prep_bffm2_conn_with_meteo()
+    diagnostics: list = []
+
+    totals = compute_engine_test_for_period(
+        events,
+        _dt(1, 9),
+        _dt(1, 10),
+        ei_lookup,
+        aircraft_lookup,
+        diagnostics=diagnostics,
+        conn=conn,
+    )
+    # Fell back to snap. CL fuel = 100 * 1 * 1.0 * 0.6 = 60 kg.
+    assert abs(totals["N1"]["fuel"] - 60.0) < 1e-9
+    # Diagnostic emitted.
+    assert any("complete 4-mode" in msg for msg in diagnostics)
+
+
+def test_bffm2_missing_tbl_invmeteo_falls_back_to_isa_with_diagnostic():
+    """Conn provided but tbl_InvMeteo table doesn't exist → ISA
+    fallback with diagnostic."""
+    ei_lookup = _build_engine_ei_lookup_all_modes("B602")
+    aircraft_lookup = {"C56X": {"engine_count": 1, "engine_uid": "B602"}}
+    events = [_event_dict(t_CL_s=100, engine_count=1, thrust_mode="bffm2")]
+    conn = sqlite3.connect(":memory:")  # bare, no tbl_InvMeteo
+    diagnostics: list = []
+
+    totals = compute_engine_test_for_period(
+        events,
+        _dt(1, 9),
+        _dt(1, 10),
+        ei_lookup,
+        aircraft_lookup,
+        diagnostics=diagnostics,
+        conn=conn,
+    )
+    # BFFM2 with ISA ambient still produces numbers (not zero, not
+    # snap-equivalent — BFFM2 gas correction with humidity 0.6 differs
+    # from raw EEDB).
+    assert totals["N1"]["fuel"] > 0
+    # Diagnostic emitted.
+    assert any("tbl_InvMeteo not in the DB" in msg for msg in diagnostics)
+
+
+def test_bffm2_populated_meteo_produces_different_numbers_than_snap():
+    """The whole point of BFFM2: different ambient → different NOx.
+    High RH should REDUCE NOx compared to low RH (Boeing formula
+    humidity correction dominates)."""
+    ei_lookup = _build_engine_ei_lookup_all_modes("B602")
+    aircraft_lookup = {"C56X": {"engine_count": 1, "engine_uid": "B602"}}
+    events = [_event_dict(t_CL_s=100, engine_count=1, thrust_mode="bffm2")]
+
+    # High RH ambient
+    conn_high = _prep_bffm2_conn_with_meteo(rh=0.95)
+    totals_high = compute_engine_test_for_period(
+        events,
+        _dt(1, 9),
+        _dt(1, 10),
+        ei_lookup,
+        aircraft_lookup,
+        conn=conn_high,
+    )
+    # Low RH ambient
+    conn_low = _prep_bffm2_conn_with_meteo(rh=0.1)
+    totals_low = compute_engine_test_for_period(
+        events,
+        _dt(1, 9),
+        _dt(1, 10),
+        ei_lookup,
+        aircraft_lookup,
+        conn=conn_low,
+    )
+
+    # Different NOx between high and low RH.
+    assert abs(totals_high["N1"]["nox"] - totals_low["N1"]["nox"]) > 1.0
+
+
+def test_bffm2_uses_event_midpoint_for_meteo():
+    """Two events at same period but different midpoints → different
+    meteo lookups. Given a tbl_InvMeteo with time-varying data, results
+    should differ."""
+    ei_lookup = _build_engine_ei_lookup_all_modes("B602")
+    aircraft_lookup = {"C56X": {"engine_count": 1, "engine_uid": "B602"}}
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """CREATE TABLE tbl_InvMeteo (
+            DateTime TEXT, Temperature REAL, SeaLevelPressure REAL,
+            RelativeHumidity REAL, Humidity REAL
+        )"""
+    )
+    # Two meteo rows: 08:00 (cold, dry) and 09:20 (warm, humid).
+    conn.execute(
+        "INSERT INTO tbl_InvMeteo VALUES (?, ?, ?, ?, ?)",
+        ("2024-12-01 08:00:00", 278.15, 101325.0, 0.2, 0.001),
+    )
+    conn.execute(
+        "INSERT INTO tbl_InvMeteo VALUES (?, ?, ?, ?, ?)",
+        ("2024-12-01 09:20:00", 303.15, 100000.0, 0.9, 0.020),
+    )
+    conn.commit()
+
+    # Event A: 09:00-09:10 → midpoint 09:05 → uses 08:00 row (cold)
+    ev_a = _event_dict(
+        event_id=1,
+        t_CL_s=60,
+        engine_count=1,
+        thrust_mode="bffm2",
+        start_datetime="2024-12-01T09:00:00",
+        end_datetime="2024-12-01T09:10:00",
+    )
+    # Event B: 09:30-09:40 → midpoint 09:35 → uses 09:20 row (warm)
+    ev_b = _event_dict(
+        event_id=2,
+        t_CL_s=60,
+        engine_count=1,
+        thrust_mode="bffm2",
+        source_id="N2",
+        start_datetime="2024-12-01T09:30:00",
+        end_datetime="2024-12-01T09:40:00",
+    )
+
+    totals = compute_engine_test_for_period(
+        [ev_a, ev_b],
+        _dt(1, 9),
+        _dt(1, 10),
+        ei_lookup,
+        aircraft_lookup,
+        conn=conn,
+    )
+    # Different ambient → different NOx.
+    assert abs(totals["N1"]["nox"] - totals["N2"]["nox"]) > 1.0
+
+
+def test_bffm2_pm_and_sox_passthrough():
+    """PM10 and SOx should use base EEDB values (Design A: BFFM2 gas + EEDB PM/SOx)."""
+    # Give the engine distinct PM/SOx values so we can identify them
+    # in the output.
+    ei_lookup = _build_engine_ei_lookup_all_modes("B602")
+    for mode in ("TX", "AP", "CL", "TO"):
+        ei_lookup[("B602", mode)]["pm10_ei_g_kg_fuel"] = 0.5
+        ei_lookup[("B602", mode)]["sox_ei_g_kg_fuel"] = 1.0
+    aircraft_lookup = {"C56X": {"engine_count": 1, "engine_uid": "B602"}}
+    events = [_event_dict(t_CL_s=100, engine_count=1, thrust_mode="bffm2")]
+    conn = _prep_bffm2_conn_with_meteo()
+
+    totals = compute_engine_test_for_period(
+        events,
+        _dt(1, 9),
+        _dt(1, 10),
+        ei_lookup,
+        aircraft_lookup,
+        conn=conn,
+    )
+    # PM10 and SOx should be non-zero and proportional to fuel burn.
+    # We can't assert exact values without computing ff_amb ourselves,
+    # but we can check the ratio pm10/sox = 0.5/1.0 = 0.5.
+    ratio = totals["N1"]["pm10"] / totals["N1"]["sox"]
+    assert abs(ratio - 0.5) < 1e-6
+
+
+def test_bffm2_backward_compat_signature_without_conn():
+    """The function without conn keyword should still work (snap-only
+    callers)."""
+    ei_lookup = _build_engine_ei_lookup_all_modes("B602")
+    aircraft_lookup = {"C56X": {"engine_count": 1, "engine_uid": "B602"}}
+    events = [_event_dict(t_CL_s=100, engine_count=1, thrust_mode="snap")]
+    # Old-style call (no conn kwarg).
+    totals = compute_engine_test_for_period(
+        events,
+        _dt(1, 9),
+        _dt(1, 10),
+        ei_lookup,
+        aircraft_lookup,
+    )
+    assert totals["N1"]["fuel"] == 60.0  # CL: 100*1*1.0 * 0.6 kg/s = 60 kg

--- a/tests/test_phase3_engine_test_source_module_plugin.py
+++ b/tests/test_phase3_engine_test_source_module_plugin.py
@@ -637,3 +637,324 @@ def test_process_meem_thrust_mode_calls_meem_ei():
     # 10 g/kg * 900 kg = 9000.
     nox_g = e.get_value(PollutantType.NOx, PollutantUnit.GRAM)
     assert abs(nox_g - 27000.0) < 1e-6
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 6: Phase 5b — BFFM2 thrust mode
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class _FakeAmbientCondition:
+    """Stand-in for AmbientCondition. Real class provides
+    getTemperature (K), getPressure (Pa), getRelativeHumidity (0..1)."""
+
+    def __init__(self, T_K=None, P_Pa=None, RH=None):
+        self._T = T_K
+        self._P = P_Pa
+        self._RH = RH
+
+    def getTemperature(self):
+        return self._T
+
+    def getPressure(self):
+        return self._P
+
+    def getRelativeHumidity(self):
+        return self._RH
+
+
+class _FakeAmbientStore:
+    """Stand-in for AmbientConditionStore. ``objects`` = list of tuples
+    (timestamp_s, AmbientCondition). getNearestByTime returns nearest."""
+
+    def __init__(self, entries=None):
+        # entries: list of (timestamp_s, AmbientCondition)
+        self._entries = sorted(entries or [], key=lambda p: p[0])
+
+    def getNearestByTime(self, ts):
+        if not self._entries:
+            return _FakeAmbientCondition()  # empty
+        import bisect
+
+        times = [e[0] for e in self._entries]
+        idx = bisect.bisect_left(times, ts)
+        if idx == 0:
+            return self._entries[0][1]
+        if idx >= len(times):
+            return self._entries[-1][1]
+        before = self._entries[idx - 1]
+        after = self._entries[idx]
+        return before[1] if abs(ts - before[0]) <= abs(after[0] - ts) else after[1]
+
+    def getObjects(self):
+        # Truthiness of the store used by the module's _resolve_event_ambient
+        # code path (implicit via getTemperature() is None fallback).
+        return {i: e[1] for i, e in enumerate(self._entries)}
+
+
+def test_process_bffm2_calls_engine_bffm2_wrapper():
+    """thrust_mode='bffm2' routes through Engine.getEmissionIndexByModeWithBFFM2."""
+    from open_alaqs.core.interfaces.Emissions import PollutantType, PollutantUnit
+
+    bffm2_ei = _FakeEI(
+        fuel_kg_sec=1.0, pollutant_g_per_kg={PollutantType.NOx.name: 50.0}
+    )
+    snap_ei = _FakeEI(
+        fuel_kg_sec=1.0, pollutant_g_per_kg={PollutantType.NOx.name: 10.0}
+    )
+
+    captured = {}
+
+    class TripleEngine:
+        def getEmissionIndexByMode(self, mode):
+            return snap_ei
+
+        def getEmissionIndexByModeWithMEEM(self, mode, **kwargs):
+            return snap_ei
+
+        def getEmissionIndexByModeWithBFFM2(self, mode, ambient_conditions, mach=0.0):
+            captured["mode"] = mode
+            captured["ambient"] = ambient_conditions
+            captured["mach"] = mach
+            return bffm2_ei
+
+    event = _event(t_CL_s=900, engine_count=1, thrust_mode="bffm2")
+    m = _make_module_with_fakes(
+        events=[event],
+        aircraft_map={"C56X": _FakeAircraft()},
+        engine_map={"B602": TripleEngine()},
+    )
+    ambient = _FakeAmbientCondition(T_K=298.15, P_Pa=100000.0, RH=0.7)
+    # Event start=09:00 end=09:30 → midpoint 09:15
+    midpoint_ts = _dt(1, 9, 15).timestamp()
+    m.setAmbientStore(_FakeAmbientStore(entries=[(midpoint_ts, ambient)]))
+    m.setSource("N1", _make_test_site_source())
+
+    result = m.process(_dt(1, 9), _dt(1, 10))
+    assert result, "expected a non-empty result"
+
+    # Wrapper invoked with the ambient we injected.
+    assert captured.get("mode") == "CL"
+    assert captured.get("ambient") is ambient
+    assert captured.get("mach") == 0.0
+
+    # NOx computed with BFFM2 EI: 50 g/kg * 900 kg = 45000 g
+    e = result[0][2][0]
+    nox_g = e.get_value(PollutantType.NOx, PollutantUnit.GRAM)
+    assert abs(nox_g - 45000.0) < 1e-6
+
+
+def test_process_bffm2_uses_event_midpoint_for_meteo_lookup():
+    """Confirm ambient store is queried at ((start+end)/2).timestamp()."""
+
+    class Recorder:
+        queried_ts = None
+
+        def getNearestByTime(self, ts):
+            self.queried_ts = ts
+            return _FakeAmbientCondition(T_K=288.15, P_Pa=101325.0, RH=0.6)
+
+        def getObjects(self):
+            return {"x": self.getNearestByTime(0)}
+
+    recorder = Recorder()
+
+    # Event 09:00-09:30 → midpoint 09:15
+    event = _event(
+        t_CL_s=900,
+        engine_count=1,
+        thrust_mode="bffm2",
+        start="2024-12-01T09:00:00",
+        end="2024-12-01T09:30:00",
+    )
+    m = _make_module_with_fakes(
+        events=[event],
+        aircraft_map={"C56X": _FakeAircraft()},
+        engine_map={
+            "B602": type(
+                "E",
+                (),
+                {
+                    "getEmissionIndexByMode": lambda self, mode: _FakeEI(1.0, {}),
+                    "getEmissionIndexByModeWithBFFM2": lambda self, mode, ambient_conditions, mach=0.0: _FakeEI(
+                        1.0, {}
+                    ),
+                },
+            )()
+        },
+    )
+    m.setAmbientStore(recorder)
+    m.setSource("N1", _make_test_site_source())
+
+    m.process(_dt(1, 9), _dt(1, 10))
+
+    expected_ts = _dt(1, 9, 15).timestamp()
+    assert recorder.queried_ts == expected_ts
+
+
+def test_process_bffm2_with_empty_ambient_store_falls_through_and_logs(caplog):
+    """When AmbientConditionStore is empty, module logs ISA-fallback
+    warning once. BFFM2 wrapper still called with an empty ambient
+    (bffm2.py handles ISA substitution internally)."""
+    import logging
+
+    called_with_ambient = []
+
+    class DualEngine:
+        def getEmissionIndexByMode(self, mode):
+            return _FakeEI(1.0, {})
+
+        def getEmissionIndexByModeWithBFFM2(self, mode, ambient_conditions, mach=0.0):
+            called_with_ambient.append(ambient_conditions)
+            return _FakeEI(1.0, {})
+
+    event = _event(t_CL_s=900, engine_count=1, thrust_mode="bffm2")
+    m = _make_module_with_fakes(
+        events=[event],
+        aircraft_map={"C56X": _FakeAircraft()},
+        engine_map={"B602": DualEngine()},
+    )
+    m.setAmbientStore(_FakeAmbientStore(entries=[]))  # empty
+    m.setSource("N1", _make_test_site_source())
+
+    with caplog.at_level(logging.WARNING):
+        m.process(_dt(1, 9), _dt(1, 10))
+
+    # BFFM2 wrapper was called (with empty ambient); ISA fallback
+    # happens downstream in bffm2.py.
+    assert len(called_with_ambient) == 1
+    # ISA-fallback warning fired.
+    assert any(
+        "tbl_InvMeteo has no ambient data" in rec.message for rec in caplog.records
+    )
+
+
+def test_process_bffm2_isa_fallback_warning_logged_only_once(caplog):
+    """Multiple BFFM2 events with an empty store → warning fires once."""
+    import logging
+
+    class DualEngine:
+        def getEmissionIndexByMode(self, mode):
+            return _FakeEI(1.0, {})
+
+        def getEmissionIndexByModeWithBFFM2(self, mode, ambient_conditions, mach=0.0):
+            return _FakeEI(1.0, {})
+
+    e1 = _event(event_id=1, t_CL_s=600, engine_count=1, thrust_mode="bffm2")
+    e2 = _event(
+        event_id=2,
+        t_CL_s=300,
+        engine_count=1,
+        thrust_mode="bffm2",
+        start="2024-12-01T09:35:00",
+        end="2024-12-01T09:45:00",
+    )
+    m = _make_module_with_fakes(
+        events=[e1, e2],
+        aircraft_map={"C56X": _FakeAircraft()},
+        engine_map={"B602": DualEngine()},
+    )
+    m.setAmbientStore(_FakeAmbientStore(entries=[]))
+    m.setSource("N1", _make_test_site_source())
+
+    with caplog.at_level(logging.WARNING):
+        m.process(_dt(1, 9), _dt(1, 10))
+
+    n_warnings = sum(
+        1 for rec in caplog.records if "tbl_InvMeteo has no ambient data" in rec.message
+    )
+    assert n_warnings == 1
+
+
+def test_process_snap_and_meem_do_not_query_ambient_store():
+    """snap and meem thrust modes should NOT trigger meteo lookups."""
+
+    class Recorder:
+        queries = 0
+
+        def getNearestByTime(self, ts):
+            Recorder.queries += 1
+            return _FakeAmbientCondition()
+
+        def getObjects(self):
+            return {}
+
+    for tm in ("snap", "meem"):
+        Recorder.queries = 0
+        event = _event(t_CL_s=900, engine_count=1, thrust_mode=tm)
+        m = _make_module_with_fakes(
+            events=[event],
+            aircraft_map={"C56X": _FakeAircraft()},
+            engine_map={
+                "B602": type(
+                    "E",
+                    (),
+                    {
+                        "getEmissionIndexByMode": lambda self, mode: _FakeEI(1.0, {}),
+                        "getEmissionIndexByModeWithMEEM": lambda self, mode, **kw: _FakeEI(
+                            1.0, {}
+                        ),
+                    },
+                )()
+            },
+        )
+        m.setAmbientStore(Recorder())
+        m.setSource("N1", _make_test_site_source())
+        m.process(_dt(1, 9), _dt(1, 10))
+        assert Recorder.queries == 0, f"{tm} should not query ambient store"
+
+
+def test_process_bffm2_with_engine_that_lacks_wrapper_falls_back_to_snap():
+    """If Engine has no getEmissionIndexByModeWithBFFM2 method (older
+    engines), _resolve_ei catches the AttributeError and returns snap."""
+    from open_alaqs.core.interfaces.Emissions import PollutantType, PollutantUnit
+
+    snap_ei = _FakeEI(
+        fuel_kg_sec=1.0, pollutant_g_per_kg={PollutantType.NOx.name: 10.0}
+    )
+
+    class OldEngine:
+        def getEmissionIndexByMode(self, mode):
+            return snap_ei
+
+    event = _event(t_CL_s=900, engine_count=1, thrust_mode="bffm2")
+    m = _make_module_with_fakes(
+        events=[event],
+        aircraft_map={"C56X": _FakeAircraft()},
+        engine_map={"B602": OldEngine()},
+    )
+    ambient = _FakeAmbientCondition(T_K=298.15, P_Pa=100000.0, RH=0.7)
+    midpoint_ts = _dt(1, 9, 15).timestamp()
+    m.setAmbientStore(_FakeAmbientStore(entries=[(midpoint_ts, ambient)]))
+    m.setSource("N1", _make_test_site_source())
+
+    # Should not raise; falls back to snap.
+    result = m.process(_dt(1, 9), _dt(1, 10))
+    assert result, "expected result even with old engine"
+    e = result[0][2][0]
+    # snap: 10 g/kg * 900 kg = 9000
+    nox_g = e.get_value(PollutantType.NOx, PollutantUnit.GRAM)
+    assert abs(nox_g - 9000.0) < 1e-6
+
+
+def test_process_bffm2_no_ambient_passed_falls_back_to_snap():
+    """If ambient_conditions ends up None (which happens if the store
+    was never set at all), _resolve_ei falls back to snap without a
+    crash."""
+
+    class Engine:
+        def getEmissionIndexByMode(self, mode):
+            return _FakeEI(1.0, {})
+
+    event = _event(t_CL_s=900, engine_count=1, thrust_mode="bffm2")
+    m = _make_module_with_fakes(
+        events=[event],
+        aircraft_map={"C56X": _FakeAircraft()},
+        engine_map={"B602": Engine()},
+    )
+    # DON'T call setAmbientStore. _ambient_store is None.
+    m.setSource("N1", _make_test_site_source())
+
+    # Should not raise; falls back to snap-equivalent behaviour.
+    result = m.process(_dt(1, 9), _dt(1, 10))
+    assert result, "expected result even without ambient store"


### PR DESCRIPTION
Adds BFFM2 ambient-corrected gas-phase EIs (NOx, CO, HC) as a third
`thrust_mode` option (`'bffm2'`) alongside snap and meem. PM10, SOx,
and CO2 pass through from the base ICAO EEDB EI unchanged. Ambient
comes from `tbl_InvMeteo` at the event's midpoint, falling back to
ISA with a one-per-run diagnostic if no meteo is loaded.

## Design

Per Phase 5 memo:

- **Design A composition**: BFFM2 gas + EEDB PM. Consistent with the
  plugin's MovementSource behaviour.
- **Ambient lookup at event midpoint** (`start + (end-start)/2`).
- **Diagnostic + ISA fallback** when `tbl_InvMeteo` is empty or has
  no data at or before the event midpoint. Not silent; users can
  trace what happened. One diagnostic per run to keep log volume
  sane.
- **No schema change on `engine_test_events`**. The `thrust_mode`
  TEXT column already accepts `'bffm2'`; the DB default `'snap'`
  means users opt in per-event via SQL.

## Plugin side

* `open_alaqs/core/interfaces/AmbientCondition.py`
  * New `AmbientConditionStore.getNearestByTime(timestamp_s)`:
    bisect-based O(log n) lookup by Unix timestamp. Returns empty
    `AmbientCondition()` if the store is empty. Semantics match
    `EmissionCalculation.getAmbientCondition`.

* `open_alaqs/core/interfaces/Engine.py`
  * New `Engine.getEmissionIndexByModeWithBFFM2(mode,
    ambient_conditions, mach=0.0)`. Composes: base EI as starting
    point, overlays BFFM2 gas-phase (fuel_kg_sec, nox_g_kg, co_g_kg,
    hc_g_kg). Falls back to base EI on any BFFM2 exception, matching
    the existing MEEM fall-through pattern.

* `open_alaqs/core/modules/EngineTestSourceModule.py`
  * New `_ambient_store` field, setter, and `beginJob` wiring
    (loads `AmbientConditionStore` lazily, Singleton so it costs
    nothing if already loaded).
  * New `_resolve_event_ambient(event)`: computes event midpoint,
    calls `getNearestByTime`. If store empty, returns empty
    `AmbientCondition()` and logs the ISA-fallback warning once per
    run.
  * `_add_event_to_emission` passes the resolved ambient into
    `_resolve_ei` (only when `thrust_mode` is bffm2; snap/meem skip
    the lookup).
  * `_resolve_ei` extended with a bffm2 branch. AttributeError from
    older engines missing the method also falls through cleanly.

## Standalone side

* `openalaqs_standalone/compute_engine_test.py`
  * New optional `conn` parameter to `compute_engine_test_for_period`.
    Required only for events with `thrust_mode='bffm2'`; snap/meem
    workloads continue to work with no signature change (backward
    compatible).
  * `_build_icao_eedb_for_engine`: builds the BFFM2-shaped
    `{pollutant: {mode_name: {ff_ref: ei_g_kg}}}` dict from
    `ei_lookup`. Requires all 4 modes; returns None if any is missing.
  * `_add_bffm2_ei_to_totals`: gas-phase EIs from
    `bffm2.calculate_emission_index`, PM/SOx from `ei_row` (Design
    A). Ambient FF conversion applied exactly as in
    `Engine.getEmissionIndexByEngineState`.
  * Uses shared `open_alaqs.core.tools.bffm2.calculate_emission_index`
    — same code path as movements (`compute_aircraft.py`) and plugin.

## Fallback matrix

| Condition | Result |
|---|---|
| `conn=None` for a bffm2 event | snap + once-per-call diagnostic |
| Engine missing a mode in `ei_lookup` | snap + per-event diagnostic |
| `tbl_InvMeteo` table absent | ISA + once-per-call diagnostic |
| No `tbl_InvMeteo` row at/before mid_iso | ISA + once-per-call diagnostic |

## Tests

Plugin: 33 collected (26 + 7 new), Section 6:
* bffm2 routes through the engine wrapper
* meteo lookup at event midpoint (asserts exact timestamp)
* empty ambient store → ISA-fallback warning logged
* ISA-fallback warning logged only ONCE per run
* snap and meem do NOT query ambient store
* old engine lacking BFFM2 method falls back to snap
* bffm2 with no ambient store set falls back to snap

Standalone: 26 collected (18 + 8 new), Section 4:
* bffm2 without conn falls back to snap with diagnostic
* once-per-call warning (not per-event)
* incomplete engine falls back to snap
* missing `tbl_InvMeteo` falls back to ISA with diagnostic
* populated meteo produces DIFFERENT numbers than snap (RH varies)
* event midpoint used for meteo lookup (time-varying meteo test)
* PM10 and SOx pass through unchanged (Design A verification)
* backward-compat signature without conn kwarg

Full standalone regression on my sandbox: 976 passed.

## Not in this PR

- No CSV column for `thrust_mode` (Phase 4a decision; users set via
  SQL UPDATE). Kept unchanged.
- No documentation update. Deferred to end-of-Phase-5 doc pass along
  with the Helicopter S&S bug filing.

Depends on: all previously merged phases (1a–5a).