### PR TITLE
fix: Helicopter class missing getEmissionDynamicsByMode (issue #340)

### DIFF
--- a/open_alaqs/core/interfaces/Helicopter.py
+++ b/open_alaqs/core/interfaces/Helicopter.py
@@ -209,6 +209,26 @@ class Helicopter:
         """
         return "HELICOPTER"
 
+    def getEmissionDynamicsByMode(self):
+        """Helicopters do not participate in the smooth-and-shift plume model.
+
+        The S&S plume model represents thermal buoyancy of jet/turboprop
+        exhaust; helicopter rotor downwash is a different physics not
+        modelled here. Returning an empty mapping causes
+        ``GeoTransformation.create_polygon_3d`` to raise ``KeyError`` on
+        the ``[lto_mode]`` subscript, which is caught by the existing
+        ``except (KeyError, TypeError)`` block and falls through to
+        zero-extension defaults (the same behaviour as an aircraft with
+        no ``default_emission_dynamics`` entry). Emission masses are
+        preserved.
+
+        Without this method, ``[lto_mode]`` is attempted on the return
+        value of a missing method and Python raises ``AttributeError``,
+        which is NOT caught by the existing exception tuple, aborting
+        the inventory build. See issue #340.
+        """
+        return {}
+
     def __str__(self) -> str:
         return (
             f"\n Helicopter '{self._icao}' / variant '{self._variant_label}':"

--- a/tests/test_helicopter_dynamics_by_mode.py
+++ b/tests/test_helicopter_dynamics_by_mode.py
@@ -1,0 +1,145 @@
+"""Tests for the Helicopter.getEmissionDynamicsByMode fix (issue #340).
+
+The bug: ``Helicopter`` didn't implement ``getEmissionDynamicsByMode``,
+so ``GeoTransformation.create_polygon_3d`` raised ``AttributeError`` on
+any helicopter movement — the existing ``except (KeyError, TypeError)``
+tuple did not catch AttributeError.
+
+The fix: ``Helicopter.getEmissionDynamicsByMode()`` returns ``{}``. Then
+``{}[lto_mode]`` raises ``KeyError`` which IS caught, and zero-extension
+defaults are applied (matching the behaviour of a fixed-wing aircraft
+with no ``default_emission_dynamics`` entry).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+# ── Stub the qgis chain so Helicopter is importable without QGIS ──
+
+
+def _install_qgis_stubs():
+    """Install minimal qgis stubs so ``Helicopter`` is importable outside
+    a QGIS session (e.g. on a developer's sandbox running plain Python).
+
+    CRITICAL: only installs stubs when the real ``qgis`` package is NOT
+    already importable. On a real QGIS environment (e.g. CI), the real
+    modules are used and this function is a no-op. Without this guard,
+    stubs would shadow the real qgis modules for every other test that
+    pytest imports after this one (see failure of
+    ``test_contour_legend_zero_dedup_regression``,
+    ``test_layer_replacement_regression``, and ``test_spatial_tools`` on
+    the fix-helicopter-dynamics CI run before this fix).
+    """
+    try:
+        import qgis  # noqa: F401
+
+        # Real QGIS is available. Do nothing.
+        return
+    except ImportError:
+        pass
+
+    for name in (
+        "qgis",
+        "qgis.PyQt",
+        "qgis.PyQt.QtWidgets",
+        "qgis.PyQt.QtGui",
+        "qgis.PyQt.QtCore",
+        "qgis.core",
+        "qgis.utils",
+    ):
+        if name not in sys.modules:
+            sys.modules[name] = types.ModuleType(name)
+
+    sys.modules["qgis.utils"].spatialite_connect = lambda *a, **kw: None
+    sys.modules["qgis.utils"].iface = None
+    for sym in (
+        "QgsProject",
+        "QgsVectorLayer",
+        "QgsCoordinateReferenceSystem",
+        "QgsCoordinateTransform",
+        "QgsGeometry",
+        "QgsFeature",
+        "QgsField",
+        "QgsFields",
+        "QgsMessageLog",
+        "Qgis",
+        "QgsWkbTypes",
+        "QgsPointXY",
+    ):
+        setattr(sys.modules["qgis.core"], sym, type(sym, (), {}))
+
+
+_install_qgis_stubs()
+
+try:
+    from open_alaqs.core.interfaces.Helicopter import Helicopter
+
+    HAS_MODULE = True
+except Exception:  # pragma: no cover
+    HAS_MODULE = False
+
+
+pytestmark = pytest.mark.skipif(
+    not HAS_MODULE, reason="Helicopter class not importable"
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 1: the fix itself — method exists and returns {}
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _make_heli():
+    """Minimum Helicopter constructor call. Uses the dict-init form so
+    we don't depend on positional args that may change."""
+    return Helicopter(val={"icao": "AS50", "variant_label": "test", "name": "test"})
+
+
+def test_helicopter_has_getEmissionDynamicsByMode():
+    """Regression: the method must exist. Its absence was the root
+    cause of the AttributeError in issue #340."""
+    h = _make_heli()
+    assert hasattr(h, "getEmissionDynamicsByMode")
+    assert callable(h.getEmissionDynamicsByMode)
+
+
+def test_helicopter_getEmissionDynamicsByMode_returns_empty_dict():
+    """Contract: the method returns an empty dict so that subscript
+    access raises KeyError (which the caller catches) rather than
+    AttributeError (which the caller does not)."""
+    h = _make_heli()
+    result = h.getEmissionDynamicsByMode()
+    assert result == {}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 2: end-to-end — the crash site now falls through cleanly
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_helicopter_dynamics_subscript_raises_KeyError_not_AttributeError():
+    """The precise contract exercised by GeoTransformation.create_polygon_3d:
+    ``aircraft.getEmissionDynamicsByMode()[lto_mode]`` must raise KeyError
+    on helicopters, not AttributeError. KeyError is caught by the
+    existing exception tuple; AttributeError would abort the whole
+    inventory build."""
+    h = _make_heli()
+    with pytest.raises(KeyError):
+        h.getEmissionDynamicsByMode()["T/O"]
+    with pytest.raises(KeyError):
+        h.getEmissionDynamicsByMode()["Idle"]
+
+    # Explicitly assert it's NOT AttributeError.
+    try:
+        h.getEmissionDynamicsByMode()["T/O"]
+    except KeyError:
+        pass
+    except AttributeError as exc:  # pragma: no cover
+        pytest.fail(
+            f"Regression: helicopter dynamics subscript raised AttributeError, "
+            f"which would abort inventory builds. Got: {exc}"
+        )


### PR DESCRIPTION
Adds an empty-dict implementation of ``getEmissionDynamicsByMode`` on ``Helicopter``. Without it, any study with a helicopter movement aborted with ``AttributeError`` on the first S&S transformer call because ``aircraft.getEmissionDynamicsByMode()[lto_mode]`` raised AttributeError on the missing method, which the existing ``except (KeyError, TypeError)`` block at
``GeoTransformation.py:65`` did not catch.

With this fix:
1. ``heli.getEmissionDynamicsByMode()`` returns ``{}``.
2. ``{}[lto_mode]`` raises ``KeyError``.
3. The existing exception tuple catches it.
4. Zero-extension defaults are applied — the same behaviour as a fixed-wing aircraft with no ``default_emission_dynamics`` entry.
5. Emission masses are preserved.

Rationale for returning {} rather than adding AttributeError to the exception tuple at the call site: semantically, the S&S plume model represents thermal buoyancy of jet/turboprop exhaust, which is a different physics from helicopter rotor downwash. Helicopters legitimately should not participate in the same S&S model. Returning {} makes that explicit at the class boundary; adding AttributeError to the caller's exception tuple would leave the design gap in place and rely on the caller to defensively catch a bare programming error.

Files
-----

* open_alaqs/core/interfaces/Helicopter.py New method on the ``Helicopter`` class, 5 lines + docstring.

* tests/test_helicopter_dynamics_by_mode.py 3 tests, QGIS-free (uses the same qgis-stubs pattern as Phase 4b's test_ui_area_sources_toggle):
    * method exists and is callable
    * returns an empty dict
    * subscript access raises KeyError (not AttributeError), matching the contract the caller depends on

Affected releases: v5.2.4 and earlier. Not a regression; likely present since helicopters were introduced.

Closes #340.