### PR TITLE
docs: engine-test emissions add-on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ ISO 8601.
 
 ## [Unreleased]
 
+Engine-test emissions add-on. Adds a new mechanism for representing
+aircraft engine test runs (run-ups) as stationary emission sources
+with per-event fuel and per-pollutant computation matching the
+regular movement path.
+
+- **New schema on area sources.** `shapes_area_sources.is_test_site`
+  TEXT column marks an area source as an engine-test site. Legacy
+  studies migrate silently (NULL → not a test site). Fresh studies
+  from the template have the column present with no default value.
+- **New table `engine_test_events`.** One row per engine test run,
+  with fields: `source_id`, `test_id`, `start_datetime`,
+  `end_datetime`, `aircraft_type`, `engine_uid`, `engine_count`,
+  `t_TX_s`, `t_AP_s`, `t_CL_s`, `t_TO_s`, `thrust_mode` (`snap` /
+  `meem` / `bffm2`, default `snap`), and `instudy`. Migration via
+  `scripts/migrate_alaqs.py` handles the new table on existing
+  studies.
+- **UI toggle on the area-source form.** New "Engine test site"
+  checkbox in the QGIS area-source edit dialog. When enabled, the
+  source's `*_kg_unit` emission-rate fields are ignored at compute
+  time; per-mode emissions come from the event rows instead.
+- **CSV import tool.** `scripts/import_engine_test_events.py` bulk-
+  loads events from a CSV into the `engine_test_events` table. Dry
+  run is the default; `--apply` writes. Three modes (`append`,
+  `replace-for-source`, `replace-all`); safety flag `--i-mean-it`
+  required for `replace-all`. Eight row-level error codes and five
+  warning codes surface at once; `--tolerate-warnings` proceeds
+  despite warnings.
+- **Compute (plugin).** New `EngineTestSourceModule` computes each
+  event's fuel and per-pollutant emissions from
+  `Movement.defaultEmissions`, using
+  `t_effective = t_mode_s × engine_count × period_window_fraction`
+  seconds per mode. `AreaSourceWithTimeProfileModule` skips test-
+  site sources so the two paths don't double-count.
+- **Compute (standalone).** `openalaqs_standalone/compute_engine_test.py`
+  is the QGIS-free twin, matching the plugin math bit-for-bit. Also
+  ships `extract_engine_test_events.py` for the SQL side. Accepts
+  an optional `conn` kwarg for BFFM2 meteo lookups; snap-only
+  callers work with no signature change.
+- **Three thrust modes.** `snap` (raw ICAO EEDB), `meem` (nvPM
+  correction; numerically identical to `snap` for engine-test
+  events because mode = anchor thrust), and `bffm2` (gas-phase
+  ambient correction on NOx / CO / HC via `tbl_InvMeteo`, with
+  PM10 and SOx passed through from the EEDB per Design A). BFFM2
+  looks up meteo at each event's midpoint and falls back to ISA
+  with a one-per-run diagnostic if the table is empty.
+
+New public API on `Engine`: `getEmissionIndexByModeWithBFFM2(mode,
+ambient_conditions, mach=0.0)`. New public API on
+`AmbientConditionStore`: `getNearestByTime(timestamp_s)`.
+
 ## [5.2.4] - 2026-06-18
 
 Patch release. AUSTAL writer bug fix. Generating AUSTAL input files from

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open-ALAQS
 
-QGIS plugin for airport emissions inventory and dispersion. Builds an annual emissions inventory from runway, taxiway, gate, stationary, and movement sources, and exports AUSTAL-ready dispersion inputs.
+QGIS plugin for airport emissions inventory and dispersion. Builds an annual emissions inventory from runway, taxiway, gate, stationary, engine-test-run, and movement sources, and exports AUSTAL-ready dispersion inputs.
 
 <img src="./open_alaqs/assets/oa-logo.jpg" alt="Open-ALAQS logo" width="50%">
 
@@ -141,6 +141,8 @@ See [`scripts/README.md`](scripts/README.md) for the full inventory of QGIS-boun
 3. Run *Generate Emission Inventory* on the baked inventory to calculate emissions with the selected method.
 4. For dispersion runs, see [`documents/AUSTAL/AUSTAL_OPERATION.md`](documents/AUSTAL/AUSTAL_OPERATION.md).
 
+For engine test runs (run-ups), an extra step between 1 and 2: mark the area source(s) that represent the run-up pad as engine test sites via the QGIS form ("Engine test site" checkbox), and bulk-load the events via [`scripts/import_engine_test_events.py`](scripts/README.md). Per-event masses are then included in the inventory automatically; the source's `*_kg_unit` rate columns are ignored.
+
 ## Emission calculation methods
 
 [(Back to top)](#table-of-contents)
@@ -155,6 +157,16 @@ Open-ALAQS ships three aircraft emission methods selectable at run time:
 PM is via MEEM V1 at LTO (EEDB nvPM anchors unchanged at LTO altitudes). The MEEM V2 base method (ICAO CAEP/13-WG3) is also implemented for non-LTO altitudes. The MDG4 / Staged Combustion update is not implemented.
 
 For BFFM2 implementation details see [`documents/BFFM2_validation/BFFM2.md`](documents/BFFM2_validation/BFFM2.md).
+
+### Engine test runs
+
+A separate calculation path handles engine test runs (run-ups) as stationary sources. An area source flagged as a test site (`is_test_site='1'`) has its emissions computed from per-event rows in the `engine_test_events` table rather than from the source's `*_kg_unit` rate columns. Each event carries a start/end datetime, an aircraft type and engine, a per-mode duration (`t_TX_s` / `t_AP_s` / `t_CL_s` / `t_TO_s`), and a `thrust_mode` (`snap` / `meem` / `bffm2`).
+
+- **`snap`** — plain ICAO EEDB EI for each mode. Default. No ambient corrections.
+- **`meem`** — nvPM correction (MEEM V1). Numerically identical to `snap` for engine-test events because engine test modes correspond to ICAO EEDB anchor thrust settings; interpolation at an anchor returns the anchor's own value.
+- **`bffm2`** — gas-phase EIs (NOx, CO, HC) corrected with ambient conditions from `tbl_InvMeteo` at each event's midpoint (SAE AIR-5715 / CAEP14). PM10 and SOx pass through from the EEDB per-mode. If `tbl_InvMeteo` is empty, `bffm2` falls back to ISA defaults with a one-per-run diagnostic.
+
+The default across every event is `snap`; users opt into `meem` or `bffm2` per-event via a SQL update on `engine_test_events.thrust_mode`. Both `EngineTestSourceModule` (plugin) and `openalaqs_standalone/compute_engine_test.py` (standalone) implement the same math bit-for-bit. See the *Engine test sites* subsection of [`documents/USER_GUIDE.md`](documents/USER_GUIDE.md) for the setup workflow.
 
 ## Meteorological data
 

--- a/documents/USER_GUIDE.md
+++ b/documents/USER_GUIDE.md
@@ -26,6 +26,7 @@
       - [Roadways](#roadways)
       - [Point sources](#point-sources)
       - [Area sources](#area-sources)
+      - [Engine test sites](#engine-test-sites)
       - [Buildings](#buildings)
   - [Activity Profiles](#activity-profiles)
     - [Worked example — defining and using named profiles](#worked-example--defining-and-using-named-profiles)
@@ -320,6 +321,41 @@ When adding an area source, the following information is required:
 The emission calculation is: `emission (kg) = EF (kg/unit) × units_per_year × (interval_hours / 8760)`.
 
 Beyond the standard pollutants, two additional pollutants **P1** and **P2** can be defined by the user. For aircraft movements, P1 and P2 are placeholders for PM1.0 and PM2.5 respectively, currently set equal to PM10 until dedicated emission indices become available in the EEDB (see [`PM10 output columns`](#pm10-output-columns)).
+
+The area-source form also has an **Engine test site** checkbox. When enabled, the source's `*_kg_unit` emission-rate fields above are ignored at compute time; per-mode emissions come from rows in the `engine_test_events` table instead. See the next subsection for the setup workflow.
+
+#### [Engine test sites](#engine-test-sites)
+
+An engine test site (run-up pad) is an area source flagged for special treatment. Rather than emitting a fixed per-unit rate multiplied by an activity profile, its emissions come from discrete engine-test events — each event specifies a start and end datetime, an aircraft type and engine, per-mode durations, and a thrust-computation mode.
+
+**Setup workflow:**
+
+1. Draw the area source in QGIS covering the extent of the run-up pad. Fill in name and height as for a regular area source.
+2. In the source's edit form, tick the **Engine test site** checkbox. The `*_kg_unit` rates on the Emissions tab are ignored for a test site; you can leave them at zero.
+3. Save the study.
+4. Prepare a CSV of events. Each row is one engine test run and needs a `source_id` (matching the area source you just flagged), `start_datetime`, `end_datetime`, `aircraft_type`, and per-mode running times in seconds (`t_TX_s`, `t_AP_s`, `t_CL_s`, `t_TO_s`). Optional columns: `test_id`, `engine_uid`, `engine_count`. See [`scripts/README.md`](../scripts/README.md#import_engine_test_eventspy) for the full CSV specification.
+5. Load the events with the importer script:
+   ```bash
+   python scripts/import_engine_test_events.py study.alaqs events.csv
+   ```
+   Run without `--apply` first to validate. Add `--apply` when the summary looks clean.
+6. Regenerate the emission inventory. Test-site emissions appear alongside regular sources with no further configuration.
+
+**Thrust computation modes.** Each event has an optional `thrust_mode` column (default `snap`), not exposed in the CSV — set it via SQL if you need a non-default:
+
+- `snap` — plain ICAO EEDB EI for each mode, no ambient corrections. This is the default.
+- `meem` — nvPM correction (MEEM V1). Accepted for consistency with the wider ALAQS methodology, but numerically identical to `snap` for engine-test events because engine test modes correspond to ICAO EEDB anchor thrust settings.
+- `bffm2` — gas-phase EIs (NOx, CO, HC) corrected with ambient conditions from `tbl_InvMeteo` at each event's midpoint (SAE AIR-5715 / CAEP14). PM10 and SOx pass through from the EEDB per-mode. If `tbl_InvMeteo` is empty or has no data at the event's midpoint, `bffm2` falls back to ISA defaults with a one-per-run warning in the run log.
+
+**Emission math.** For each event and each of the four ICAO modes with a non-zero running time,
+
+```
+t_effective_s = t_mode_s × engine_count × period_window_fraction
+fuel_burned_kg = fuel_flow_kg_s × t_effective_s
+mass_g[pollutant] = EI_g_per_kg[pollutant] × fuel_burned_kg
+```
+
+`period_window_fraction` handles events that straddle two inventory periods: the fraction of the event's duration falling inside each period. An event 09:30–10:30 with a 09:00–10:00 period contributes 50 % of its emissions to that period and 50 % to the next one.
 
 #### [Buildings](#buildings)
 

--- a/openalaqs_standalone/README.md
+++ b/openalaqs_standalone/README.md
@@ -109,6 +109,20 @@ compute_helicopter.py  FOCA helicopter per-movement emissions
 compute_gate_movements.py  per-movement gate (GSE + GPU) emissions,
                        driven by the movements and default_gate_profiles;
                        folded into each movement's total
+compute_engine_test.py per-event engine-test-run emissions from the
+                       `engine_test_events` table. QGIS-free twin of
+                       `EngineTestSourceModule`; same math bit-for-bit.
+                       Three thrust modes: `snap` (default), `meem`
+                       (numerically identical to snap for engine-test
+                       events at anchor thrust), `bffm2` (gas-phase
+                       ambient correction, PM10/SOx passthrough).
+                       BFFM2 requires an optional `conn` kwarg for
+                       `tbl_InvMeteo` lookups; snap-only workflows use
+                       the same signature as before.
+extract_engine_test_events.py  read engine_test_events joined against
+                       shapes_area_sources (test-site filter);
+                       produces the event-dict input that
+                       compute_engine_test.py consumes.
 compute_movements.py   dispatch + study-level driver
 parallel.py            multiprocessing driver for the movement
                        compute; results bit-identical to the serial
@@ -153,6 +167,7 @@ cli.py / __main__.py   `python -m openalaqs_standalone <command>`:
 | Gate | `shapes_gates` + `default_gate_profiles` | implemented (movement-driven calculator) |
 | Aircraft movement | `user_aircraft_movements` | implemented (calculator, 3 methods) |
 | Helicopter movement | `user_aircraft_movements` | implemented (FOCA calculator) |
+| Engine test site | `engine_test_events` + `shapes_area_sources` (`is_test_site='1'`) | implemented (calculator, 3 thrust modes) |
 
 ## Quick start
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,7 @@ the plugin reads.
 | `metar_to_alaqs_meteo.py` | Parse METAR observations into the `meteo.csv` format Open-ALAQS expects during *Create Output*. | Once per study, before inventory creation, to produce the hourly meteorology file. |
 | `migrate_alaqs.py` | Upgrade a legacy `.alaqs` file to the current schema. | Whenever a user brings a `.alaqs` produced by an older plugin version and needs to open it with the current one. |
 | `migrate_alaqs_gui.py` | Qt5 GUI wrapper around `migrate_alaqs.py`. Exposes every CLI flag plus a live log panel; useful for users uncomfortable with the command line. | Same situations as `migrate_alaqs.py`, when a GUI is preferred. Run with QGIS's bundled Python (e.g. `C:\PROGRA~1\QGIS34~1.13\bin\python.exe migrate_alaqs_gui.py`). |
+| `import_engine_test_events.py` | Bulk-load engine run-up events from a CSV into the `engine_test_events` table. | After creating test-site area sources (`is_test_site='1'`) but before generating the emission inventory. |
 | `austal_from_csv/` | [BETA] Standalone CLI that produces AUSTAL dispersion-model input files from pre-computed emissions and meteo CSVs (no `.alaqs` needed). See [`austal_from_csv/README.md`](austal_from_csv/README.md). | When you already have emissions/meteo CSVs and want AUSTAL inputs. |
 | `emissions_austal/` | [BETA] Standalone CLI that runs the full emissions calculation against a `.alaqs` inventory and optionally generates AUSTAL inputs in one pass. See [`emissions_austal/README.md`](emissions_austal/README.md). | When you want to run the calculator headlessly from an OSGeo4W shell. |
 | `update-strings.sh` | Run `pylupdate4` to refresh the `i18n/*.ts` Qt translation source files from `*.py` / `*.ui` changes. | Translation-maintenance workflow; only needed when the plugin UI strings change. |
@@ -216,6 +217,95 @@ python3 scripts/migrate_alaqs.py legacy.alaqs \
 | 0 | Migration applied or nothing to do. |
 | 1 | Migration failed; original restored from backup if available. |
 | 2 | Bad arguments / file not found. |
+
+## `import_engine_test_events.py`
+
+Bulk-loads engine-test event rows from a CSV into an ALAQS project's
+`engine_test_events` table. Consumed after users have created their
+test-site area sources (`is_test_site='1'` — see the "Engine test
+sites" subsection of `documents/USER_GUIDE.md`) and want to populate
+events without writing SQL by hand.
+
+### CSV format
+
+Wide format, one row per event. Header required. Column names match
+the DB schema exactly:
+
+- **Required:** `source_id`, `start_datetime`, `end_datetime`,
+  `aircraft_type`
+- **Optional:** `test_id`, `engine_uid`, `engine_count`, `t_TX_s`,
+  `t_AP_s`, `t_CL_s`, `t_TO_s`, `instudy`
+
+`thrust_mode` is intentionally NOT accepted from CSV: the DB column
+still exists and defaults to `snap`, so users who need `meem` or
+`bffm2` should `UPDATE` the row via SQL. This makes the choice
+explicit rather than silently mis-typed in a spreadsheet cell.
+
+Datetimes must be ISO 8601 (e.g. `2024-12-01T09:00:00`). `instudy`
+must be `0` or `1` (defaults to `1`). Mode times (`t_*_s`) are
+integer seconds, default 0. `engine_count` if given must be a
+positive integer; if blank, falls back to the aircraft's default at
+compute time.
+
+### Modes
+
+- **Dry run (default):** validates the CSV against the DB, prints
+  a summary, no writes.
+- `--apply` performs the INSERT.
+- `--mode append` (default) — add rows to existing events.
+- `--mode replace-for-source` — DELETE existing events for each
+  `source_id` in the CSV, then insert. Re-import a corrected batch
+  cleanly.
+- `--mode replace-all` — DELETE all events first. Requires
+  `--i-mean-it` as a safety flag against scripted mistakes.
+- `--tolerate-warnings` — proceed even with warnings (unknown
+  `source_id`, unknown `engine_uid`, running seconds exceed event
+  window, etc.). Default is to fail on any warning.
+
+### Validation
+
+Row errors reject the row: `missing_required`,
+`unparseable_datetime`, `end_before_start`, `invalid_mode_time`,
+`invalid_engine_count`, `invalid_instudy`, `duplicate_row`.
+
+Row warnings abort the whole import unless `--tolerate-warnings`:
+`unknown_source_id`, `source_not_test_site`, `unknown_aircraft_type`,
+`unknown_engine_uid`, `running_exceeds_window` (60 s tolerance).
+
+All errors and warnings surface at once so the whole CSV can be
+fixed in one pass rather than iteratively.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success (dry-run passed, or apply completed). |
+| 1 | Fatal error (CSV parse failure, DB error, invalid arguments). |
+| 2 | Validation failed (row errors, or warnings without `--tolerate-warnings`). |
+
+### Examples
+
+Dry-run a batch:
+
+```bash
+python scripts/import_engine_test_events.py \
+    /path/to/study.alaqs /path/to/logbook.csv
+```
+
+Apply after review:
+
+```bash
+python scripts/import_engine_test_events.py \
+    /path/to/study.alaqs /path/to/logbook.csv --apply
+```
+
+Re-import a corrected batch for one source:
+
+```bash
+python scripts/import_engine_test_events.py \
+    /path/to/study.alaqs /path/to/N1_fix.csv \
+    --apply --mode replace-for-source
+```
 
 ## `migrate_alaqs_gui.py`
 


### PR DESCRIPTION
Rounds off phase 5 with a documentation pass covering the engine-test-emissions add-on across five doc files. No code changes.

Files
-----

* CHANGELOG.md Unreleased entry summarising the whole add-on: schema (is_test_site, engine_test_events), UI toggle, CSV import tool, plugin and standalone compute modules, three thrust modes, and the two new public APIs (Engine.getEmissionIndexByModeWithBFFM2 and AmbientConditionStore.getNearestByTime).

* README.md
  - Top-level description now mentions engine-test-run sources.
  - New "Engine test runs" subsection under Emission calculation methods, explaining the three thrust modes and pointing to the user guide.
  - Workflow section extended with a note on the engine-test path (mark the source, load via importer, regenerate inventory).

* documents/USER_GUIDE.md
  - New "Engine test sites" subsection between Area sources and Buildings, with setup workflow, thrust-mode explanation, and the emission math (t_effective, fuel_burned, per-pollutant mass, period_window_fraction).
  - Added TOC entry and a cross-reference note in the Area sources subsection pointing to the new section.

* scripts/README.md
  - New row in the inventory table for import_engine_test_events.py.
  - New detailed section covering CSV format, modes (dry run, --apply, three insert modes with --i-mean-it, --tolerate-warnings), error/warning codes, exit codes, and three worked examples (dry run, apply, re-import for one source).

* openalaqs_standalone/README.md
  - Added compute_engine_test.py and extract_engine_test_events.py to the Aircraft modules list with the same three-thrust-mode note as the plugin section, noting that BFFM2 requires an optional conn kwarg for tbl_InvMeteo lookups but snap-only workflows have no signature change.
  - New row in Source coverage table for engine test sites.

Sanity
------

All markdown code fences are balanced (10 / 6 / 16 / 10 / 24 across the five files). No links to non-existent anchors. Cross-references between README, USER_GUIDE, and scripts README use consistent anchor names.

Not in this commit
------------------

- No CLI examples for BFFM2 configuration in USER_GUIDE.md's "Generate Emissions Inventory" section. Left out because the thrust_mode setting is per-event (in the DB) rather than a global inventory setting; users who need bffm2 set it via SQL update after import.
- No new content in documents/BFFM2_validation/BFFM2.md. That document describes the BFFM2 formula and its validation against CAEP14; the engine-test wiring reuses the same shared formula module so nothing new to describe there.
- No changes to documents/AUSTAL/*.md. Engine-test emissions flow into the standard AUSTAL export path unchanged.