### PR TITLE
Fix + feat: is_test_site KeyError hotfix + in-QGIS CSV import dialog

### DIFF
--- a/open_alaqs/core/tools/engine_test_import.py
+++ b/open_alaqs/core/tools/engine_test_import.py
@@ -1,0 +1,633 @@
+"""Core logic for importing engine-test events from a CSV into an
+ALAQS project's ``engine_test_events`` table.
+
+This module is dependency-free (stdlib only) and is imported by:
+  * ``scripts/import_engine_test_events.py`` (CLI wrapper for
+    command-line users, tested by ``tests/test_import_engine_test_events.py``).
+  * ``open_alaqs.openalaqsdialog.OpenAlaqsImportEngineTestEvents`` (the
+    QGIS-plugin dialog for in-QGIS users).
+
+Both entry points share this validation and apply logic verbatim so
+the CLI and the UI never diverge.
+
+CSV format
+----------
+
+Header row required. Column order is flexible; the importer maps by
+header name. UTF-8 encoding, comma-delimited (RFC 4180). Empty cells
+take the column default (not the literal string ``""``).
+
+Columns (all names match the DB schema exactly):
+
+  Required:
+    source_id         Test-site area source identifier
+    start_datetime    ISO 8601 (e.g. 2024-12-01T09:00:00)
+    end_datetime      ISO 8601, strictly after start_datetime
+    aircraft_type     ICAO code (e.g. C56X, B738)
+
+  Optional:
+    test_id           Free-form user reference
+    engine_uid        Engine EI table key. Falls back to aircraft
+                      default at compute time if empty
+    engine_count      Positive integer. Falls back to aircraft default
+                      at compute time if empty
+    t_TX_s            Seconds in taxi/ground-idle. Default 0
+    t_AP_s            Seconds in approach. Default 0
+    t_CL_s            Seconds in climb-out. Default 0
+    t_TO_s            Seconds in take-off. Default 0
+    instudy           '0' or '1'. Default '1'
+
+Not accepted from CSV:
+    thrust_mode       DB column exists with default 'snap'. Users who
+                      need 'meem' or 'bffm2' UPDATE via SQL. Not in
+                      the CSV because misuse would be silent.
+
+Modes
+-----
+
+The caller (CLI or dialog) picks the insert mode:
+
+  append              Add rows to existing engine_test_events
+  replace-for-source  DELETE existing events for each source_id in the
+                      CSV, then insert. Useful for re-importing a
+                      corrected batch for one test site.
+  replace-all         DELETE every row in engine_test_events, then
+                      insert. Caller must confirm this destructive
+                      choice (CLI requires --i-mean-it; dialog shows a
+                      confirmation modal).
+
+Warnings vs errors
+------------------
+
+Row errors reject a row:
+  * missing_required
+  * unparseable_datetime
+  * end_before_start
+  * invalid_mode_time
+  * invalid_engine_count
+  * invalid_instudy
+  * duplicate_row  (same source_id + start_datetime + aircraft_type)
+
+Row warnings do NOT reject a row on their own; the caller decides
+whether to abort:
+  * unknown_source_id
+  * source_not_test_site
+  * unknown_aircraft_type
+  * unknown_engine_uid
+  * running_exceeds_window  (60 s tolerance, matching Phase 2's
+    EngineTestEvent.getConsistencyWarnings tolerance)
+
+Whole-CSV errors abort before any validation:
+  * Missing required column in header (returned as ``header_error``
+    from ``read_csv``).
+"""
+
+from __future__ import annotations
+
+import csv
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional
+
+# ── Column contract ────────────────────────────────────────────────────
+
+REQUIRED_COLUMNS = (
+    "source_id",
+    "start_datetime",
+    "end_datetime",
+    "aircraft_type",
+)
+
+OPTIONAL_COLUMNS = (
+    "test_id",
+    "engine_uid",
+    "engine_count",
+    "t_TX_s",
+    "t_AP_s",
+    "t_CL_s",
+    "t_TO_s",
+    "instudy",
+)
+
+ALL_COLUMNS = REQUIRED_COLUMNS + OPTIONAL_COLUMNS
+
+MODE_TIME_COLUMNS = ("t_TX_s", "t_AP_s", "t_CL_s", "t_TO_s")
+
+# Running-seconds tolerance for the running_exceeds_window warning.
+# Matches Phase 2's EngineTestEvent.getConsistencyWarnings tolerance.
+_RUNNING_EXCEEDS_WINDOW_TOLERANCE_S = 60
+
+
+# ── Result types ───────────────────────────────────────────────────────
+
+
+@dataclass
+class RowIssue:
+    """One error or warning against one CSV row."""
+
+    row_number: int  # 1-indexed, matching how spreadsheet software labels rows
+    code: str
+    message: str
+
+
+@dataclass
+class ValidatedRow:
+    """A row that passed all validation and is ready to insert."""
+
+    row_number: int
+    source_id: str
+    test_id: Optional[str]
+    start_datetime: str
+    end_datetime: str
+    aircraft_type: str
+    engine_uid: Optional[str]
+    engine_count: Optional[int]
+    t_TX_s: int
+    t_AP_s: int
+    t_CL_s: int
+    t_TO_s: int
+    instudy: str
+
+    def to_insert_tuple(self) -> tuple:
+        return (
+            self.source_id,
+            self.test_id,
+            self.start_datetime,
+            self.end_datetime,
+            self.aircraft_type,
+            self.engine_uid,
+            self.engine_count,
+            self.t_TX_s,
+            self.t_AP_s,
+            self.t_CL_s,
+            self.t_TO_s,
+            self.instudy,
+        )
+
+
+@dataclass
+class ValidationResult:
+    valid_rows: list[ValidatedRow] = field(default_factory=list)
+    errors: list[RowIssue] = field(default_factory=list)
+    warnings: list[RowIssue] = field(default_factory=list)
+    header_error: Optional[str] = None
+
+
+# ── Parsing helpers ────────────────────────────────────────────────────
+
+
+def _parse_iso_datetime(s: str) -> Optional[datetime]:
+    """Parse ISO 8601. Return None on failure so the caller emits a
+    single clear error rather than a raw ValueError."""
+    if s is None:
+        return None
+    s = s.strip()
+    if s == "":
+        return None
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(s)
+    except ValueError:
+        return None
+
+
+def _parse_optional_int(s: Optional[str]) -> tuple[bool, Optional[int]]:
+    """Return (ok, value). Empty string / None → (True, None). A digit
+    string that's non-negative → (True, int). Anything else → (False, None).
+    """
+    if s is None:
+        return True, None
+    s = s.strip()
+    if s == "":
+        return True, None
+    try:
+        v = int(s)
+        return True, v
+    except ValueError:
+        return False, None
+
+
+def _parse_mode_seconds(s: Optional[str]) -> tuple[bool, int, Optional[str]]:
+    """Parse a t_MODE_s column. Empty → (True, 0, None). Non-negative int
+    → (True, v, None). Negative → (False, 0, 'negative_running').
+    Malformed → (False, 0, 'not_an_integer')."""
+    if s is None:
+        return True, 0, None
+    s = s.strip()
+    if s == "":
+        return True, 0, None
+    try:
+        v = int(s)
+    except ValueError:
+        return False, 0, "not_an_integer"
+    if v < 0:
+        return False, 0, "negative_running"
+    return True, v, None
+
+
+# ── CSV → ValidationResult (no DB access) ──────────────────────────────
+
+
+def validate_csv_rows(
+    csv_rows: Iterable[dict[str, str]],
+) -> ValidationResult:
+    """Validate the CSV without touching the DB. DB cross-checks happen
+    downstream in ``validate_against_db``.
+    """
+    result = ValidationResult()
+    seen_dupe_keys: dict[tuple, int] = {}
+
+    for i, row in enumerate(csv_rows, start=2):  # header is line 1
+        errs: list[RowIssue] = []
+
+        # Required-value checks
+        for col in REQUIRED_COLUMNS:
+            val = (row.get(col) or "").strip()
+            if val == "":
+                errs.append(RowIssue(i, "missing_required", f"column {col!r} is empty"))
+
+        # If any required is missing, skip the rest; row is unusable.
+        if errs:
+            result.errors.extend(errs)
+            continue
+
+        source_id = row["source_id"].strip()
+        aircraft_type = row["aircraft_type"].strip()
+
+        # Datetimes
+        start_str = row["start_datetime"].strip()
+        end_str = row["end_datetime"].strip()
+        start_dt = _parse_iso_datetime(start_str)
+        end_dt = _parse_iso_datetime(end_str)
+        if start_dt is None:
+            errs.append(
+                RowIssue(
+                    i,
+                    "unparseable_datetime",
+                    f"start_datetime {start_str!r} is not ISO 8601",
+                )
+            )
+        if end_dt is None:
+            errs.append(
+                RowIssue(
+                    i,
+                    "unparseable_datetime",
+                    f"end_datetime {end_str!r} is not ISO 8601",
+                )
+            )
+        if start_dt is not None and end_dt is not None and end_dt <= start_dt:
+            errs.append(
+                RowIssue(
+                    i,
+                    "end_before_start",
+                    "end_datetime must be strictly after start_datetime",
+                )
+            )
+
+        # Duplicate detection: same (source_id, start_datetime, aircraft_type)
+        dupe_key = (source_id, start_str, aircraft_type)
+        if dupe_key in seen_dupe_keys:
+            errs.append(
+                RowIssue(
+                    i,
+                    "duplicate_row",
+                    f"same (source_id, start_datetime, aircraft_type) as row "
+                    f"{seen_dupe_keys[dupe_key]}",
+                )
+            )
+
+        # Optional-column parsing
+        test_id = (row.get("test_id") or "").strip() or None
+        engine_uid = (row.get("engine_uid") or "").strip() or None
+
+        ok_count, engine_count = _parse_optional_int(row.get("engine_count"))
+        if not ok_count:
+            errs.append(
+                RowIssue(
+                    i,
+                    "invalid_engine_count",
+                    f"engine_count {row.get('engine_count')!r} is not an integer",
+                )
+            )
+        elif engine_count is not None and engine_count <= 0:
+            errs.append(
+                RowIssue(
+                    i,
+                    "invalid_engine_count",
+                    f"engine_count must be a positive integer, got {engine_count}",
+                )
+            )
+
+        mode_times: dict[str, int] = {}
+        for col in MODE_TIME_COLUMNS:
+            ok_mt, v_mt, mt_err = _parse_mode_seconds(row.get(col))
+            if not ok_mt:
+                errs.append(
+                    RowIssue(
+                        i,
+                        "invalid_mode_time",
+                        f"{col}={row.get(col)!r}: {mt_err}",
+                    )
+                )
+            mode_times[col] = v_mt
+
+        instudy = (row.get("instudy") or "1").strip()
+        if instudy == "":
+            instudy = "1"
+        if instudy not in ("0", "1"):
+            errs.append(
+                RowIssue(
+                    i,
+                    "invalid_instudy",
+                    f"instudy {row.get('instudy')!r} must be '0' or '1'",
+                )
+            )
+
+        if errs:
+            result.errors.extend(errs)
+            continue
+
+        # Record dupe key only for successfully-validated (so-far) rows.
+        seen_dupe_keys[dupe_key] = i
+
+        # Running-seconds vs window warning (D from Phase 2).
+        running = sum(mode_times.values())
+        if engine_count is not None and engine_count > 0:
+            running_total = running * engine_count
+        else:
+            running_total = running
+        window_s = (end_dt - start_dt).total_seconds()
+        if running_total > window_s + _RUNNING_EXCEEDS_WINDOW_TOLERANCE_S:
+            result.warnings.append(
+                RowIssue(
+                    i,
+                    "running_exceeds_window",
+                    f"sum of mode times ({running_total}s across "
+                    f"{engine_count or 1} engine(s)) exceeds the "
+                    f"event window ({int(window_s)}s) by more than "
+                    f"{_RUNNING_EXCEEDS_WINDOW_TOLERANCE_S}s tolerance",
+                )
+            )
+
+        result.valid_rows.append(
+            ValidatedRow(
+                row_number=i,
+                source_id=source_id,
+                test_id=test_id,
+                start_datetime=start_str,
+                end_datetime=end_str,
+                aircraft_type=aircraft_type,
+                engine_uid=engine_uid,
+                engine_count=engine_count,
+                t_TX_s=mode_times["t_TX_s"],
+                t_AP_s=mode_times["t_AP_s"],
+                t_CL_s=mode_times["t_CL_s"],
+                t_TO_s=mode_times["t_TO_s"],
+                instudy=instudy,
+            )
+        )
+
+    return result
+
+
+def read_csv(csv_path: Path) -> tuple[list[dict[str, str]], Optional[str]]:
+    """Read the CSV. Return (rows, header_error). If the header is
+    missing a required column, ``header_error`` is set and ``rows`` is
+    empty.
+    """
+    with csv_path.open("r", encoding="utf-8-sig", newline="") as f:
+        reader = csv.DictReader(f)
+        fieldnames = reader.fieldnames or []
+        missing = [c for c in REQUIRED_COLUMNS if c not in fieldnames]
+        if missing:
+            return [], (
+                "CSV header missing required column(s): "
+                + ", ".join(missing)
+                + f"\n  header seen: {fieldnames}"
+                + f"\n  columns expected: {list(ALL_COLUMNS)}"
+            )
+        rows = list(reader)
+    return rows, None
+
+
+# ── DB cross-checks ────────────────────────────────────────────────────
+
+
+def _fetch_lookup_sets(conn: sqlite3.Connection) -> dict[str, set]:
+    """Read reference tables into sets for O(1) membership checks.
+    Missing tables return empty sets and yield no warnings on the
+    respective lookups (informative when the DB is un-migrated or
+    bare — the caller can still validate structural aspects of the
+    CSV even without reference data)."""
+    cur = conn.cursor()
+    sets: dict[str, set] = {
+        "shapes_area_sources": set(),
+        "test_site_source_ids": set(),
+        "default_aircraft": set(),
+        "default_aircraft_engine_ei": set(),
+    }
+
+    try:
+        for sid, is_test_site in cur.execute(
+            "SELECT source_id, is_test_site FROM shapes_area_sources"
+        ):
+            if sid is None:
+                continue
+            sets["shapes_area_sources"].add(str(sid))
+            if str(is_test_site or "0").strip() == "1":
+                sets["test_site_source_ids"].add(str(sid))
+    except sqlite3.OperationalError:
+        pass  # table absent or is_test_site column absent
+
+    try:
+        for (icao,) in cur.execute("SELECT icao FROM default_aircraft"):
+            if icao is not None:
+                sets["default_aircraft"].add(str(icao))
+    except sqlite3.OperationalError:
+        pass
+
+    try:
+        for (uid,) in cur.execute(
+            "SELECT engine_full_name FROM default_aircraft_engine_ei"
+        ):
+            if uid is not None:
+                sets["default_aircraft_engine_ei"].add(str(uid))
+    except sqlite3.OperationalError:
+        # Try alternate column name
+        try:
+            for (uid,) in cur.execute(
+                "SELECT engine_uid FROM default_aircraft_engine_ei"
+            ):
+                if uid is not None:
+                    sets["default_aircraft_engine_ei"].add(str(uid))
+        except sqlite3.OperationalError:
+            pass
+
+    return sets
+
+
+def validate_against_db(
+    valid_rows: list[ValidatedRow],
+    conn: sqlite3.Connection,
+) -> list[RowIssue]:
+    """Cross-check each already-CSV-valid row against reference tables
+    in the DB. Emits warnings (not errors) so the caller decides whether
+    to abort."""
+    lookups = _fetch_lookup_sets(conn)
+    warnings: list[RowIssue] = []
+
+    for r in valid_rows:
+        if r.source_id not in lookups["shapes_area_sources"]:
+            warnings.append(
+                RowIssue(
+                    r.row_number,
+                    "unknown_source_id",
+                    f"source_id {r.source_id!r} not found in shapes_area_sources",
+                )
+            )
+        elif r.source_id not in lookups["test_site_source_ids"]:
+            warnings.append(
+                RowIssue(
+                    r.row_number,
+                    "source_not_test_site",
+                    f"source_id {r.source_id!r} exists but is_test_site='0'; "
+                    "compute would ignore its events",
+                )
+            )
+
+        if (
+            lookups["default_aircraft"]
+            and r.aircraft_type not in lookups["default_aircraft"]
+        ):
+            warnings.append(
+                RowIssue(
+                    r.row_number,
+                    "unknown_aircraft_type",
+                    f"aircraft_type {r.aircraft_type!r} not in default_aircraft",
+                )
+            )
+
+        if (
+            r.engine_uid is not None
+            and lookups["default_aircraft_engine_ei"]
+            and r.engine_uid not in lookups["default_aircraft_engine_ei"]
+        ):
+            warnings.append(
+                RowIssue(
+                    r.row_number,
+                    "unknown_engine_uid",
+                    f"engine_uid {r.engine_uid!r} not in default_aircraft_engine_ei",
+                )
+            )
+
+    return warnings
+
+
+# ── Insert ─────────────────────────────────────────────────────────────
+
+
+_INSERT_SQL = (
+    "INSERT INTO engine_test_events ("
+    "source_id, test_id, start_datetime, end_datetime, aircraft_type, "
+    "engine_uid, engine_count, t_TX_s, t_AP_s, t_CL_s, t_TO_s, instudy"
+    ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+)
+
+
+def apply_insert(
+    conn: sqlite3.Connection,
+    rows: list[ValidatedRow],
+    mode: str,
+) -> dict:
+    """Insert rows into engine_test_events under one of the three modes.
+    All-or-nothing: uses a single transaction; on any SQLite error the
+    caller sees the exception and the DB is rolled back."""
+    cur = conn.cursor()
+
+    if mode == "replace-all":
+        cur.execute("DELETE FROM engine_test_events")
+    elif mode == "replace-for-source":
+        source_ids = sorted({r.source_id for r in rows})
+        # Chunk the IN() to keep parameter count sane on ancient sqlite
+        # builds; 500 is well under any known SQLITE_MAX_VARIABLE_NUMBER.
+        for i in range(0, len(source_ids), 500):
+            chunk = source_ids[i : i + 500]
+            placeholders = ",".join("?" * len(chunk))
+            cur.execute(
+                f"DELETE FROM engine_test_events WHERE source_id IN ({placeholders})",
+                chunk,
+            )
+
+    per_source: dict[str, int] = {}
+    for r in rows:
+        cur.execute(_INSERT_SQL, r.to_insert_tuple())
+        per_source[r.source_id] = per_source.get(r.source_id, 0) + 1
+
+    conn.commit()
+    return per_source
+
+
+# ── Reporting ──────────────────────────────────────────────────────────
+
+
+def format_summary(
+    result: ValidationResult,
+    db_warnings: list[RowIssue],
+    csv_row_count: int,
+) -> str:
+    """Format a validation summary as plain text. Used by both the CLI
+    (printed to stdout) and the dialog (shown in a read-only text
+    area).
+    """
+    lines = []
+    total_warnings = len(result.warnings) + len(db_warnings)
+    lines.append("Import summary")
+    lines.append(f"  CSV rows read:          {csv_row_count}")
+    lines.append(f"  Rows valid:             {len(result.valid_rows)}")
+    lines.append(f"  Rows rejected:          {len(result.errors)}")
+    lines.append(f"  Warnings:               {total_warnings}")
+
+    if result.errors:
+        lines.append("")
+        lines.append("Errors:")
+        for e in result.errors:
+            lines.append(f"  Row {e.row_number}: [{e.code}] {e.message}")
+
+    all_warnings = result.warnings + db_warnings
+    all_warnings.sort(key=lambda x: (x.row_number, x.code))
+    if all_warnings:
+        lines.append("")
+        lines.append("Warnings:")
+        for w in all_warnings:
+            lines.append(f"  Row {w.row_number}: [{w.code}] {w.message}")
+
+    return "\n".join(lines)
+
+
+def format_apply_summary(per_source: dict[str, int], mode: str) -> str:
+    lines = ["", f"Applied ({mode}):"]
+    total = sum(per_source.values())
+    for sid in sorted(per_source):
+        lines.append(f"  {sid}: {per_source[sid]} event(s)")
+    lines.append(f"  total: {total} event(s) inserted")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "REQUIRED_COLUMNS",
+    "OPTIONAL_COLUMNS",
+    "ALL_COLUMNS",
+    "MODE_TIME_COLUMNS",
+    "RowIssue",
+    "ValidatedRow",
+    "ValidationResult",
+    "read_csv",
+    "validate_csv_rows",
+    "validate_against_db",
+    "apply_insert",
+    "format_summary",
+    "format_apply_summary",
+]

--- a/open_alaqs/openalaqs.py
+++ b/open_alaqs/openalaqs.py
@@ -36,6 +36,7 @@ from open_alaqs.gui.DispersionAnalysis import OpenAlaqsDispersionAnalysis
 from open_alaqs.openalaqsdialog import (
     OpenAlaqsAbout,
     OpenAlaqsEnabledMacros,
+    OpenAlaqsImportEngineTestEvents,
     OpenAlaqsInventory,
     OpenAlaqsLogfile,
     OpenAlaqsOpenDatabase,
@@ -166,6 +167,18 @@ class OpenALAQS:
             self.run_taxi_routes,
         )
 
+        # Create action that will show the Import Engine Test Events dialog.
+        # Icon: reuse "profiles.png" as a placeholder — this action is
+        # conceptually similar (bulk-load a set of records for later
+        # emission calculation) and adding a dedicated icon is deferred
+        # until we have artwork.
+        self.actions["import_engine_test_events"] = self.create_connected_action(
+            QtGui.QIcon(str(icons_path / "profiles.png")),
+            "Import engine test events (CSV)",
+            self.iface.mainWindow(),
+            self.run_import_engine_test_events,
+        )
+
         # Create action that will show the Calculate Emissions Inventory dialog
         self.actions["build_inventory"] = self.create_connected_action(
             QtGui.QIcon(str(icons_path / "calculate.png")),
@@ -212,6 +225,7 @@ class OpenALAQS:
         self.open_alaqs_toolbar.addAction(self.actions["osm_import"])
         self.open_alaqs_toolbar.addAction(self.actions["profiles_edit"])
         self.open_alaqs_toolbar.addAction(self.actions["taxi_routes"])
+        self.open_alaqs_toolbar.addAction(self.actions["import_engine_test_events"])
         self.open_alaqs_toolbar.addAction(self.actions["build_inventory"])
 
         self.open_alaqs_toolbar.addSeparator()
@@ -227,6 +241,7 @@ class OpenALAQS:
         self.actions["osm_import"].setEnabled(False)
         self.actions["profiles_edit"].setEnabled(False)
         self.actions["taxi_routes"].setEnabled(False)
+        self.actions["import_engine_test_events"].setEnabled(False)
         self.actions["build_inventory"].setEnabled(False)
 
         self.macro_check()
@@ -313,6 +328,7 @@ class OpenALAQS:
         self.actions["osm_import"].setEnabled(True)
         self.actions["profiles_edit"].setEnabled(True)
         self.actions["taxi_routes"].setEnabled(True)
+        self.actions["import_engine_test_events"].setEnabled(True)
         self.actions["build_inventory"].setEnabled(True)
         self.actions["view_results_analysis"].setEnabled(True)
         self.actions["calculate_dispersion"].setEnabled(True)
@@ -345,6 +361,7 @@ class OpenALAQS:
                 self.actions["osm_import"].setEnabled(True)
                 self.actions["profiles_edit"].setEnabled(True)
                 self.actions["taxi_routes"].setEnabled(True)
+                self.actions["import_engine_test_events"].setEnabled(True)
                 self.actions["build_inventory"].setEnabled(True)
                 self.actions["view_results_analysis"].setEnabled(True)
                 self.actions["calculate_dispersion"].setEnabled(True)
@@ -373,6 +390,8 @@ class OpenALAQS:
             self.actions["profiles_edit"].setEnabled(False)
         if "taxi_routes" in self.actions:
             self.actions["taxi_routes"].setEnabled(False)
+        if "import_engine_test_events" in self.actions:
+            self.actions["import_engine_test_events"].setEnabled(False)
         if "build_inventory" in self.actions:
             self.actions["build_inventory"].setEnabled(False)
         if "calculate_dispersion" in self.actions:
@@ -446,6 +465,36 @@ class OpenALAQS:
         self.dialogs["taxi_routes"] = OpenAlaqsTaxiRoutes(self.iface)
         self.dialogs["taxi_routes"].show()
         self.dialogs["taxi_routes"].exec()
+
+    def run_import_engine_test_events(self):
+        """
+        Opens the widget dialog for importing engine-test events from a
+        CSV into the currently-loaded ALAQS project.
+        """
+        # Discover the currently-loaded project's DB path. Same pattern
+        # as OpenAlaqsInventory uses (ProjectDatabase is a Singleton
+        # holding the currently-open .alaqs path).
+        try:
+            from open_alaqs.core.alaqsdblite import ProjectDatabase
+
+            db_path = ProjectDatabase().path
+        except Exception:
+            db_path = None
+
+        if not db_path:
+            QtWidgets.QMessageBox.warning(
+                self.iface.mainWindow() if self.iface else None,
+                "No project loaded",
+                "Load an Open ALAQS project first before importing "
+                "engine-test events.",
+            )
+            return
+
+        self.dialogs["import_engine_test_events"] = OpenAlaqsImportEngineTestEvents(
+            self.iface, db_path
+        )
+        self.dialogs["import_engine_test_events"].show()
+        self.dialogs["import_engine_test_events"].exec()
 
     def run_build_inventory(self):
         """

--- a/open_alaqs/openalaqsdialog.py
+++ b/open_alaqs/openalaqsdialog.py
@@ -3226,3 +3226,308 @@ class OpenAlaqsOsmImport(QtWidgets.QDialog):
             layer_types = list(LAYERS_CONFIG.keys())
 
         return layer_types
+
+
+class OpenAlaqsImportEngineTestEvents(QtWidgets.QDialog):
+    """
+    Dialog for importing engine-test event rows from a CSV into the
+    currently-loaded ALAQS project.
+
+    Thin UI wrapper around
+    ``open_alaqs.core.tools.engine_test_import`` (the same core module
+    used by the ``scripts/import_engine_test_events.py`` CLI). The
+    dialog handles: file picker, validation summary display, mode
+    selection, confirmation on destructive modes, and calling
+    ``apply_insert`` on user confirmation. All CSV format and
+    validation semantics live in the core module; changes there flow
+    automatically into this dialog.
+    """
+
+    def __init__(self, iface, database_path):
+        main_window = iface.mainWindow() if iface is not None else None
+        QtWidgets.QDialog.__init__(self, main_window)
+        self.iface = iface
+        self._database_path = database_path
+
+        # Held per-run state.
+        self._csv_path: Optional[Path] = None
+        self._validation_result = None  # ValidationResult after last validation
+        self._db_warnings = []  # list[RowIssue] from validate_against_db
+        self._csv_row_count = 0
+
+        self._build_ui()
+
+    # ── UI construction ───────────────────────────────────────────
+
+    def _build_ui(self):
+        self.setWindowTitle("Import Engine Test Events")
+        self.setMinimumWidth(700)
+        self.setMinimumHeight(500)
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        # DB path label (read-only, informational).
+        db_label = QtWidgets.QLabel(
+            f"<b>Target study:</b> {os.path.basename(self._database_path or '<none>')}"
+        )
+        db_label.setWordWrap(True)
+        layout.addWidget(db_label)
+
+        # File picker row.
+        file_row = QtWidgets.QHBoxLayout()
+        file_row.addWidget(QtWidgets.QLabel("CSV file:"))
+        self._csv_path_edit = QtWidgets.QLineEdit()
+        self._csv_path_edit.setPlaceholderText(
+            "Choose a CSV with engine-test event rows..."
+        )
+        self._csv_path_edit.setReadOnly(True)
+        file_row.addWidget(self._csv_path_edit)
+        browse_btn = QtWidgets.QPushButton("Browse...")
+        browse_btn.clicked.connect(self._on_browse)
+        file_row.addWidget(browse_btn)
+        layout.addLayout(file_row)
+
+        # Insert-mode radio group.
+        mode_box = QtWidgets.QGroupBox("Insert mode")
+        mode_layout = QtWidgets.QVBoxLayout()
+        self._mode_append = QtWidgets.QRadioButton("Append (add to existing events)")
+        self._mode_append.setChecked(True)
+        self._mode_replace_source = QtWidgets.QRadioButton(
+            "Replace for source (delete existing events for each source_id "
+            "in the CSV, then insert)"
+        )
+        self._mode_replace_all = QtWidgets.QRadioButton(
+            "Replace all (DELETE all rows in engine_test_events first — " "destructive)"
+        )
+        mode_layout.addWidget(self._mode_append)
+        mode_layout.addWidget(self._mode_replace_source)
+        mode_layout.addWidget(self._mode_replace_all)
+        mode_box.setLayout(mode_layout)
+        layout.addWidget(mode_box)
+
+        # Warnings toggle.
+        self._tolerate_warnings = QtWidgets.QCheckBox(
+            "Tolerate warnings (proceed even if the CSV has warnings)"
+        )
+        layout.addWidget(self._tolerate_warnings)
+
+        # Summary text area (read-only).
+        layout.addWidget(QtWidgets.QLabel("Validation summary:"))
+        self._summary_text = QtWidgets.QTextEdit()
+        self._summary_text.setReadOnly(True)
+        self._summary_text.setFontFamily("monospace")
+        self._summary_text.setPlaceholderText(
+            "Pick a CSV file above; the validation summary will appear here."
+        )
+        layout.addWidget(self._summary_text, 1)  # stretch=1
+
+        # Buttons row.
+        button_row = QtWidgets.QHBoxLayout()
+        button_row.addStretch(1)
+        self._apply_btn = QtWidgets.QPushButton("Apply")
+        self._apply_btn.setEnabled(False)
+        self._apply_btn.clicked.connect(self._on_apply)
+        button_row.addWidget(self._apply_btn)
+        close_btn = QtWidgets.QPushButton("Close")
+        close_btn.clicked.connect(self.reject)
+        button_row.addWidget(close_btn)
+        layout.addLayout(button_row)
+
+        # React to toggle changes: re-check apply-button enablement.
+        self._tolerate_warnings.toggled.connect(self._update_apply_enabled)
+
+    # ── File choice → validate ────────────────────────────────────
+
+    def _on_browse(self):
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            "Choose engine-test events CSV",
+            "",
+            "CSV files (*.csv);;All files (*)",
+        )
+        if not path:
+            return
+        self._csv_path = Path(path)
+        self._csv_path_edit.setText(str(self._csv_path))
+        self._run_validation()
+
+    def _run_validation(self):
+        """Read the CSV, run structural + DB-level validation, and
+        show the summary. Never mutates the DB."""
+        from open_alaqs.core.tools.engine_test_import import (
+            format_summary,
+            read_csv,
+            validate_against_db,
+            validate_csv_rows,
+        )
+
+        if self._csv_path is None:
+            return
+
+        # Read CSV.
+        try:
+            rows, header_error = read_csv(self._csv_path)
+        except Exception as e:
+            self._summary_text.setPlainText(f"ERROR: could not read CSV:\n{e}")
+            self._apply_btn.setEnabled(False)
+            return
+        if header_error is not None:
+            self._summary_text.setPlainText(f"ERROR: {header_error}")
+            self._apply_btn.setEnabled(False)
+            return
+        self._csv_row_count = len(rows)
+
+        # Structural validation.
+        self._validation_result = validate_csv_rows(rows)
+
+        # DB cross-checks.
+        try:
+            import sqlite3
+
+            conn = sqlite3.connect(self._database_path)
+            try:
+                self._db_warnings = validate_against_db(
+                    self._validation_result.valid_rows, conn
+                )
+            finally:
+                conn.close()
+        except Exception as e:
+            self._summary_text.setPlainText(
+                f"ERROR: DB cross-checks failed:\n{e}\n\n"
+                "Structural validation still completed; see partial "
+                "summary below.\n\n"
+                + format_summary(self._validation_result, [], self._csv_row_count)
+            )
+            self._apply_btn.setEnabled(False)
+            return
+
+        # Display combined summary.
+        self._summary_text.setPlainText(
+            format_summary(
+                self._validation_result, self._db_warnings, self._csv_row_count
+            )
+        )
+        self._update_apply_enabled()
+
+    def _update_apply_enabled(self):
+        """Recompute whether Apply should be enabled given current state."""
+        if self._validation_result is None:
+            self._apply_btn.setEnabled(False)
+            return
+        # Errors are always disqualifying.
+        if self._validation_result.errors:
+            self._apply_btn.setEnabled(False)
+            return
+        # No valid rows → nothing to insert.
+        if not self._validation_result.valid_rows:
+            self._apply_btn.setEnabled(False)
+            return
+        # Warnings block unless the user opted in.
+        total_warnings = len(self._validation_result.warnings) + len(self._db_warnings)
+        if total_warnings > 0 and not self._tolerate_warnings.isChecked():
+            self._apply_btn.setEnabled(False)
+            return
+        self._apply_btn.setEnabled(True)
+
+    # ── Apply ─────────────────────────────────────────────────────
+
+    def _selected_mode(self) -> str:
+        if self._mode_replace_all.isChecked():
+            return "replace-all"
+        if self._mode_replace_source.isChecked():
+            return "replace-for-source"
+        return "append"
+
+    def _on_apply(self):
+        """Confirm destructive modes, then INSERT into the DB."""
+        import sqlite3
+
+        from open_alaqs.core.tools.engine_test_import import (
+            apply_insert,
+            format_apply_summary,
+        )
+
+        mode = self._selected_mode()
+
+        # Extra confirmation on replace-all (the CLI's --i-mean-it
+        # equivalent). replace-for-source is destructive too but scoped;
+        # a plain OK/Cancel is enough for it.
+        if mode == "replace-all":
+            resp = QMessageBox.warning(
+                self,
+                "Delete ALL existing engine-test events?",
+                "This will DELETE every row in engine_test_events "
+                "before inserting the CSV rows. This cannot be undone.\n\n"
+                "Are you sure?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if resp != QMessageBox.Yes:
+                return
+        elif mode == "replace-for-source":
+            source_ids = sorted(
+                {r.source_id for r in self._validation_result.valid_rows}
+            )
+            preview = ", ".join(source_ids[:5])
+            if len(source_ids) > 5:
+                preview += f", ... ({len(source_ids)} total)"
+            resp = QMessageBox.warning(
+                self,
+                "Delete existing events for these sources?",
+                "This will DELETE existing engine_test_events rows for "
+                f"the following source_id(s) before inserting the new "
+                f"rows:\n\n{preview}\n\nAre you sure?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if resp != QMessageBox.Yes:
+                return
+
+        # Run the insert.
+        try:
+            conn = sqlite3.connect(self._database_path)
+        except sqlite3.Error as e:
+            QMessageBox.critical(
+                self,
+                "Import failed",
+                f"Could not open the study database:\n{e}",
+            )
+            return
+
+        try:
+            per_source = apply_insert(conn, self._validation_result.valid_rows, mode)
+        except sqlite3.Error as e:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            conn.close()
+            QMessageBox.critical(
+                self,
+                "Import failed",
+                f"DB write failed; changes rolled back.\n\n{e}",
+            )
+            return
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+        # Show apply summary appended to the existing validation summary.
+        self._summary_text.setPlainText(
+            self._summary_text.toPlainText()
+            + "\n\n"
+            + format_apply_summary(per_source, mode)
+        )
+        self._apply_btn.setEnabled(False)  # prevent double-apply
+
+        QMessageBox.information(
+            self,
+            "Import complete",
+            f"Inserted {sum(per_source.values())} event(s) across "
+            f"{len(per_source)} source(s).\n\n"
+            "Reopen the study (or reload it) if you want to see the new "
+            "events in any layer view. Regenerate the emission inventory "
+            "to include the new events in the totals.",
+        )

--- a/open_alaqs/ui/_area_sources_helpers.py
+++ b/open_alaqs/ui/_area_sources_helpers.py
@@ -6,6 +6,10 @@ exercise them without a QGIS session or the full plugin import chain.
 
 from __future__ import annotations
 
+import logging
+
+_logger = logging.getLogger(__name__)
+
 
 def seed_is_test_site_from_feature(checkbox, feature) -> None:
     """Read ``feature["is_test_site"]`` and set the checkbox state.
@@ -30,14 +34,44 @@ def seed_is_test_site_from_feature(checkbox, feature) -> None:
     checkbox.setChecked(str(raw).strip() == "1")
 
 
-def write_is_test_site_to_feature(checkbox, feature) -> None:
+def write_is_test_site_to_feature(checkbox, feature) -> bool:
     """Write the checkbox state back to ``feature["is_test_site"]`` as
     the TEXT ``'1'`` or ``'0'`` matching the DB column type.
 
     ``AreaSources.isTestSite()`` reads by string comparison so the
     integer/text distinction matters for round-trip consistency.
+
+    Returns True if the write succeeded, False if the feature layer
+    doesn't have the ``is_test_site`` field. The False case happens
+    when the ``.alaqs`` study was created (or last opened by) a plugin
+    version older than v1b, before ``is_test_site`` was added to
+    ``shapes_area_sources``. In that case the write is silently skipped
+    (rather than raising KeyError and crashing the save), and a WARNING
+    is logged pointing at ``scripts/migrate_alaqs.py``.
+
+    Real ``QgsFeature`` objects only accept assignment to fields that
+    are declared on their layer's schema; assignment to a missing field
+    raises KeyError. This is different from a plain dict, which was the
+    stand-in used in the Phase 4b unit tests — hence the original tests
+    passed but a real QGIS session with a legacy ``.alaqs`` raised
+    KeyError on save (see hotfix branch fix-is-test-site-write-keyerror).
     """
-    feature["is_test_site"] = str(int(checkbox.isChecked()))
+    try:
+        feature["is_test_site"] = str(int(checkbox.isChecked()))
+        return True
+    except KeyError:
+        _logger.warning(
+            "Cannot persist 'is_test_site' checkbox: the feature layer "
+            "has no 'is_test_site' field. This means your .alaqs study "
+            "was created by a plugin version older than the one that "
+            "added engine-test-site support. Migrate the study to gain "
+            "the new column:\n"
+            "  python scripts/migrate_alaqs.py /path/to/study.alaqs\n"
+            "Then close and reopen the project in QGIS. Other edits on "
+            "this feature are being saved normally; only the checkbox "
+            "state is dropped."
+        )
+        return False
 
 
 __all__ = [

--- a/scripts/import_engine_test_events.py
+++ b/scripts/import_engine_test_events.py
@@ -1,40 +1,15 @@
-"""Import engine-test events from a CSV into an ALAQS project.
+"""Import engine-test events from a CSV into an ALAQS project (CLI).
 
 Consumed by users after they have created their test-site area sources
 (``shapes_area_sources.is_test_site='1'``) and want to bulk-load event
 rows into ``engine_test_events``.
 
-CSV format
-----------
-
-Header row required. Column order is flexible; the importer maps by
-header name. UTF-8 encoding, comma-delimited (RFC 4180). Empty cells
-take the column default (not the literal string ``""``).
-
-Columns (all names match the DB schema exactly):
-
-  Required:
-    source_id         Test-site area source identifier
-    start_datetime    ISO 8601 (e.g. 2024-12-01T09:00:00)
-    end_datetime      ISO 8601, strictly after start_datetime
-    aircraft_type     ICAO code (e.g. C56X, B738)
-
-  Optional:
-    test_id           Free-form user reference
-    engine_uid        Engine EI table key. Falls back to aircraft
-                      default at compute time if empty
-    engine_count      Positive integer. Falls back to aircraft default
-                      at compute time if empty
-    t_TX_s            Seconds in taxi/ground-idle. Default 0
-    t_AP_s            Seconds in approach. Default 0
-    t_CL_s            Seconds in climb-out. Default 0
-    t_TO_s            Seconds in take-off. Default 0
-    instudy           '0' or '1'. Default '1'
-
-Not accepted from CSV:
-    thrust_mode       DB column exists with default 'snap'. Users who
-                      need 'meem' can UPDATE the row via SQL. Not in
-                      the CSV because misuse would be silent.
+The importer's core logic lives in
+``open_alaqs.core.tools.engine_test_import`` so it can be shared with the
+QGIS-plugin dialog (``open_alaqs.openalaqsdialog.OpenAlaqsImportEngineTestEvents``).
+This file is only the CLI wrapper: argument parsing, stdout printing,
+exit-code mapping. See the core module for CSV-format documentation,
+validation semantics, and the full list of error / warning codes.
 
 Modes
 -----
@@ -46,35 +21,13 @@ change nothing. Pass ``--apply`` to actually INSERT.
 
   append              Add rows to existing engine_test_events (default)
   replace-for-source  DELETE existing events for each source_id in the
-                      CSV, then insert. Useful for re-importing a
-                      corrected batch for one test site.
+                      CSV, then insert.
   replace-all         DELETE every row in engine_test_events, then
-                      insert. Requires --i-mean-it as a safety flag.
+                      insert. Requires ``--i-mean-it`` as a safety
+                      flag.
 
-Warnings vs errors
-------------------
-
-Errors reject a row. Reasons:
-  * Missing required column value
-  * Unparseable datetime
-  * end_datetime <= start_datetime
-  * Negative t_*_s
-  * engine_count present but not a positive integer
-  * instudy present but not '0'/'1'
-
-Warnings do NOT reject a row on their own; they abort the whole import
-unless ``--tolerate-warnings`` is passed. Reasons:
-  * source_id not found in shapes_area_sources
-  * source_id found but is_test_site='0' (event would be ignored by
-    compute)
-  * aircraft_type not found in default_aircraft
-  * engine_uid not found in default_aircraft_engine_ei
-  * Running seconds sum exceeds event-window duration by more than
-    the tolerance (60 s, matching Phase 2's EngineTestEvent tolerance)
-
-Whole-CSV errors abort before any validation:
-  * Missing required column in header
-  * Duplicate rows (same source_id + start_datetime + aircraft_type)
+Warnings do NOT reject rows on their own; they abort the whole import
+unless ``--tolerate-warnings`` is passed.
 
 Exit codes:
   0  Success (dry-run passed, or apply completed)
@@ -86,551 +39,52 @@ Example
 -------
 
   # Dry-run a batch
-  python scripts/import_engine_test_events.py \
+  python scripts/import_engine_test_events.py \\
       /path/to/study.alaqs /path/to/logbook.csv
 
   # Apply after review
-  python scripts/import_engine_test_events.py \
+  python scripts/import_engine_test_events.py \\
       /path/to/study.alaqs /path/to/logbook.csv --apply
 
   # Re-import a corrected batch for source N1
-  python scripts/import_engine_test_events.py \
-      /path/to/study.alaqs /path/to/N1_fix.csv \
+  python scripts/import_engine_test_events.py \\
+      /path/to/study.alaqs /path/to/N1_fix.csv \\
       --apply --mode replace-for-source
 """
 
 from __future__ import annotations
 
 import argparse
-import csv
 import sqlite3
 import sys
-from dataclasses import dataclass, field
-from datetime import datetime
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Optional
 
-# ── Column contract ────────────────────────────────────────────────────
+# Add the repo root to sys.path so ``open_alaqs.core.tools`` imports
+# work when this script is run directly (``python scripts/import_...``).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
-REQUIRED_COLUMNS = (
-    "source_id",
-    "start_datetime",
-    "end_datetime",
-    "aircraft_type",
+# Re-export for backward compatibility with any external code that
+# imported these names from the CLI module (e.g. the CLI's own test
+# file). The core module is the source of truth; these names are only
+# aliases.
+from open_alaqs.core.tools.engine_test_import import (  # noqa: E402; noqa: E402, F401
+    ALL_COLUMNS,
+    MODE_TIME_COLUMNS,
+    OPTIONAL_COLUMNS,
+    REQUIRED_COLUMNS,
+    RowIssue,
+    ValidatedRow,
+    ValidationResult,
+    apply_insert,
+    format_apply_summary,
+    format_summary,
+    read_csv,
+    validate_against_db,
+    validate_csv_rows,
 )
-
-OPTIONAL_COLUMNS = (
-    "test_id",
-    "engine_uid",
-    "engine_count",
-    "t_TX_s",
-    "t_AP_s",
-    "t_CL_s",
-    "t_TO_s",
-    "instudy",
-)
-
-ALL_COLUMNS = REQUIRED_COLUMNS + OPTIONAL_COLUMNS
-
-MODE_TIME_COLUMNS = ("t_TX_s", "t_AP_s", "t_CL_s", "t_TO_s")
-
-# Running-seconds tolerance for the running_exceeds_window warning.
-# Matches Phase 2's EngineTestEvent.getConsistencyWarnings tolerance.
-_RUNNING_EXCEEDS_WINDOW_TOLERANCE_S = 60
-
-
-# ── Result types ───────────────────────────────────────────────────────
-
-
-@dataclass
-class RowIssue:
-    """One error or warning against one CSV row."""
-
-    row_number: int  # 1-indexed, matching how spreadsheet software labels rows
-    code: str
-    message: str
-
-
-@dataclass
-class ValidatedRow:
-    """A row that passed all validation and is ready to insert."""
-
-    row_number: int
-    source_id: str
-    test_id: Optional[str]
-    start_datetime: str
-    end_datetime: str
-    aircraft_type: str
-    engine_uid: Optional[str]
-    engine_count: Optional[int]
-    t_TX_s: int
-    t_AP_s: int
-    t_CL_s: int
-    t_TO_s: int
-    instudy: str
-
-    def to_insert_tuple(self) -> tuple:
-        return (
-            self.source_id,
-            self.test_id,
-            self.start_datetime,
-            self.end_datetime,
-            self.aircraft_type,
-            self.engine_uid,
-            self.engine_count,
-            self.t_TX_s,
-            self.t_AP_s,
-            self.t_CL_s,
-            self.t_TO_s,
-            self.instudy,
-        )
-
-
-@dataclass
-class ValidationResult:
-    valid_rows: list[ValidatedRow] = field(default_factory=list)
-    errors: list[RowIssue] = field(default_factory=list)
-    warnings: list[RowIssue] = field(default_factory=list)
-    header_error: Optional[str] = None
-
-
-# ── Parsing helpers ────────────────────────────────────────────────────
-
-
-def _parse_iso_datetime(s: str) -> Optional[datetime]:
-    """Parse ISO 8601. Return None on failure so the caller emits a
-    single clear error rather than a raw ValueError."""
-    if s is None:
-        return None
-    s = s.strip()
-    if s == "":
-        return None
-    if s.endswith("Z"):
-        s = s[:-1] + "+00:00"
-    try:
-        return datetime.fromisoformat(s)
-    except ValueError:
-        return None
-
-
-def _parse_optional_int(s: Optional[str]) -> tuple[bool, Optional[int]]:
-    """Return (ok, value). Empty string / None → (True, None). A digit
-    string that's non-negative → (True, int). Anything else → (False, None).
-    """
-    if s is None:
-        return True, None
-    s = s.strip()
-    if s == "":
-        return True, None
-    try:
-        v = int(s)
-        return True, v
-    except ValueError:
-        return False, None
-
-
-def _parse_mode_seconds(s: Optional[str]) -> tuple[bool, int, Optional[str]]:
-    """Parse a t_MODE_s column. Empty → (True, 0, None). Non-negative int
-    → (True, v, None). Negative → (False, 0, 'negative_running').
-    Malformed → (False, 0, 'not_an_integer')."""
-    if s is None:
-        return True, 0, None
-    s = s.strip()
-    if s == "":
-        return True, 0, None
-    try:
-        v = int(s)
-    except ValueError:
-        return False, 0, "not_an_integer"
-    if v < 0:
-        return False, 0, "negative_running"
-    return True, v, None
-
-
-# ── CSV → ValidationResult (no DB access) ──────────────────────────────
-
-
-def validate_csv_rows(
-    csv_rows: Iterable[dict[str, str]],
-) -> ValidationResult:
-    """Validate the CSV without touching the DB. DB cross-checks happen
-    downstream in ``validate_against_db``.
-    """
-    result = ValidationResult()
-    seen_dupe_keys: dict[tuple, int] = {}
-
-    for i, row in enumerate(csv_rows, start=2):  # header is line 1
-        errs: list[RowIssue] = []
-
-        # Required-value checks
-        for col in REQUIRED_COLUMNS:
-            val = (row.get(col) or "").strip()
-            if val == "":
-                errs.append(RowIssue(i, "missing_required", f"column {col!r} is empty"))
-
-        # If any required is missing, skip the rest; row is unusable.
-        if errs:
-            result.errors.extend(errs)
-            continue
-
-        source_id = row["source_id"].strip()
-        aircraft_type = row["aircraft_type"].strip()
-
-        # Datetimes
-        start_str = row["start_datetime"].strip()
-        end_str = row["end_datetime"].strip()
-        start_dt = _parse_iso_datetime(start_str)
-        end_dt = _parse_iso_datetime(end_str)
-        if start_dt is None:
-            errs.append(
-                RowIssue(
-                    i,
-                    "unparseable_datetime",
-                    f"start_datetime {start_str!r} is not ISO 8601",
-                )
-            )
-        if end_dt is None:
-            errs.append(
-                RowIssue(
-                    i,
-                    "unparseable_datetime",
-                    f"end_datetime {end_str!r} is not ISO 8601",
-                )
-            )
-        if start_dt is not None and end_dt is not None and end_dt <= start_dt:
-            errs.append(
-                RowIssue(
-                    i,
-                    "end_before_start",
-                    "end_datetime must be strictly after start_datetime",
-                )
-            )
-
-        # Duplicate detection: same (source_id, start_datetime, aircraft_type)
-        dupe_key = (source_id, start_str, aircraft_type)
-        if dupe_key in seen_dupe_keys:
-            errs.append(
-                RowIssue(
-                    i,
-                    "duplicate_row",
-                    f"same (source_id, start_datetime, aircraft_type) as row "
-                    f"{seen_dupe_keys[dupe_key]}",
-                )
-            )
-
-        # Optional-column parsing
-        test_id = (row.get("test_id") or "").strip() or None
-
-        engine_uid = (row.get("engine_uid") or "").strip() or None
-
-        ok_count, engine_count = _parse_optional_int(row.get("engine_count"))
-        if not ok_count:
-            errs.append(
-                RowIssue(
-                    i,
-                    "invalid_engine_count",
-                    f"engine_count {row.get('engine_count')!r} is not an integer",
-                )
-            )
-        elif engine_count is not None and engine_count <= 0:
-            errs.append(
-                RowIssue(
-                    i,
-                    "invalid_engine_count",
-                    f"engine_count must be a positive integer, got {engine_count}",
-                )
-            )
-
-        mode_times: dict[str, int] = {}
-        for col in MODE_TIME_COLUMNS:
-            ok_mt, v_mt, mt_err = _parse_mode_seconds(row.get(col))
-            if not ok_mt:
-                errs.append(
-                    RowIssue(
-                        i,
-                        "invalid_mode_time",
-                        f"{col}={row.get(col)!r}: {mt_err}",
-                    )
-                )
-            mode_times[col] = v_mt
-
-        instudy = (row.get("instudy") or "1").strip()
-        if instudy == "":
-            instudy = "1"
-        if instudy not in ("0", "1"):
-            errs.append(
-                RowIssue(
-                    i,
-                    "invalid_instudy",
-                    f"instudy {row.get('instudy')!r} must be '0' or '1'",
-                )
-            )
-
-        if errs:
-            result.errors.extend(errs)
-            continue
-
-        # Record dupe key only for successfully-validated (so-far) rows.
-        seen_dupe_keys[dupe_key] = i
-
-        # Running-seconds vs window warning (D from Phase 2).
-        running = sum(mode_times.values())
-        if engine_count is not None and engine_count > 0:
-            running_total = running * engine_count
-        else:
-            running_total = running
-        window_s = (end_dt - start_dt).total_seconds()
-        if running_total > window_s + _RUNNING_EXCEEDS_WINDOW_TOLERANCE_S:
-            result.warnings.append(
-                RowIssue(
-                    i,
-                    "running_exceeds_window",
-                    f"sum of mode times ({running_total}s across "
-                    f"{engine_count or 1} engine(s)) exceeds the "
-                    f"event window ({int(window_s)}s) by more than "
-                    f"{_RUNNING_EXCEEDS_WINDOW_TOLERANCE_S}s tolerance",
-                )
-            )
-
-        result.valid_rows.append(
-            ValidatedRow(
-                row_number=i,
-                source_id=source_id,
-                test_id=test_id,
-                start_datetime=start_str,
-                end_datetime=end_str,
-                aircraft_type=aircraft_type,
-                engine_uid=engine_uid,
-                engine_count=engine_count,
-                t_TX_s=mode_times["t_TX_s"],
-                t_AP_s=mode_times["t_AP_s"],
-                t_CL_s=mode_times["t_CL_s"],
-                t_TO_s=mode_times["t_TO_s"],
-                instudy=instudy,
-            )
-        )
-
-    return result
-
-
-def read_csv(csv_path: Path) -> tuple[list[dict[str, str]], Optional[str]]:
-    """Read the CSV. Return (rows, header_error). If the header is
-    missing a required column, ``header_error`` is set and ``rows`` is
-    empty.
-    """
-    with csv_path.open("r", encoding="utf-8-sig", newline="") as f:
-        reader = csv.DictReader(f)
-        fieldnames = reader.fieldnames or []
-        missing = [c for c in REQUIRED_COLUMNS if c not in fieldnames]
-        if missing:
-            return [], (
-                "CSV header missing required column(s): "
-                + ", ".join(missing)
-                + f"\n  header seen: {fieldnames}"
-                + f"\n  columns expected: {list(ALL_COLUMNS)}"
-            )
-        rows = list(reader)
-    return rows, None
-
-
-# ── DB cross-checks ────────────────────────────────────────────────────
-
-
-def _fetch_lookup_sets(conn: sqlite3.Connection) -> dict[str, set]:
-    """Read reference tables into sets for O(1) membership checks.
-    Missing tables return empty sets and yield warnings on all lookups
-    (informative when the DB is un-migrated or bare)."""
-    cur = conn.cursor()
-    sets: dict[str, set] = {
-        "shapes_area_sources": set(),
-        "test_site_source_ids": set(),
-        "default_aircraft": set(),
-        "default_aircraft_engine_ei": set(),
-    }
-
-    try:
-        for sid, is_test_site in cur.execute(
-            "SELECT source_id, is_test_site FROM shapes_area_sources"
-        ):
-            if sid is None:
-                continue
-            sets["shapes_area_sources"].add(str(sid))
-            if str(is_test_site or "0").strip() == "1":
-                sets["test_site_source_ids"].add(str(sid))
-    except sqlite3.OperationalError:
-        pass  # table absent or is_test_site column absent
-
-    try:
-        for (icao,) in cur.execute("SELECT icao FROM default_aircraft"):
-            if icao is not None:
-                sets["default_aircraft"].add(str(icao))
-    except sqlite3.OperationalError:
-        pass
-
-    try:
-        for (uid,) in cur.execute(
-            "SELECT engine_full_name FROM default_aircraft_engine_ei"
-        ):
-            if uid is not None:
-                sets["default_aircraft_engine_ei"].add(str(uid))
-    except sqlite3.OperationalError:
-        # Try alternate column name
-        try:
-            for (uid,) in cur.execute(
-                "SELECT engine_uid FROM default_aircraft_engine_ei"
-            ):
-                if uid is not None:
-                    sets["default_aircraft_engine_ei"].add(str(uid))
-        except sqlite3.OperationalError:
-            pass
-
-    return sets
-
-
-def validate_against_db(
-    valid_rows: list[ValidatedRow],
-    conn: sqlite3.Connection,
-) -> list[RowIssue]:
-    """Cross-check each already-CSV-valid row against reference tables
-    in the DB. Emits warnings (not errors) so the caller decides whether
-    to abort."""
-    lookups = _fetch_lookup_sets(conn)
-    warnings: list[RowIssue] = []
-
-    for r in valid_rows:
-        if r.source_id not in lookups["shapes_area_sources"]:
-            warnings.append(
-                RowIssue(
-                    r.row_number,
-                    "unknown_source_id",
-                    f"source_id {r.source_id!r} not found in shapes_area_sources",
-                )
-            )
-        elif r.source_id not in lookups["test_site_source_ids"]:
-            warnings.append(
-                RowIssue(
-                    r.row_number,
-                    "source_not_test_site",
-                    f"source_id {r.source_id!r} exists but is_test_site='0'; "
-                    "compute would ignore its events",
-                )
-            )
-
-        if (
-            lookups["default_aircraft"]
-            and r.aircraft_type not in lookups["default_aircraft"]
-        ):
-            warnings.append(
-                RowIssue(
-                    r.row_number,
-                    "unknown_aircraft_type",
-                    f"aircraft_type {r.aircraft_type!r} not in default_aircraft",
-                )
-            )
-
-        if (
-            r.engine_uid is not None
-            and lookups["default_aircraft_engine_ei"]
-            and r.engine_uid not in lookups["default_aircraft_engine_ei"]
-        ):
-            warnings.append(
-                RowIssue(
-                    r.row_number,
-                    "unknown_engine_uid",
-                    f"engine_uid {r.engine_uid!r} not in default_aircraft_engine_ei",
-                )
-            )
-
-    return warnings
-
-
-# ── Insert ─────────────────────────────────────────────────────────────
-
-
-_INSERT_SQL = (
-    "INSERT INTO engine_test_events ("
-    "source_id, test_id, start_datetime, end_datetime, aircraft_type, "
-    "engine_uid, engine_count, t_TX_s, t_AP_s, t_CL_s, t_TO_s, instudy"
-    ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-)
-
-
-def apply_insert(
-    conn: sqlite3.Connection,
-    rows: list[ValidatedRow],
-    mode: str,
-) -> dict:
-    """Insert rows into engine_test_events under one of the three modes.
-    All-or-nothing: uses a single transaction; on any SQLite error the
-    caller sees the exception and the DB is rolled back."""
-    cur = conn.cursor()
-
-    if mode == "replace-all":
-        cur.execute("DELETE FROM engine_test_events")
-    elif mode == "replace-for-source":
-        source_ids = sorted({r.source_id for r in rows})
-        # Chunk the IN() to keep parameter count sane on ancient sqlite
-        # builds; 500 is well under any known SQLITE_MAX_VARIABLE_NUMBER.
-        for i in range(0, len(source_ids), 500):
-            chunk = source_ids[i : i + 500]
-            placeholders = ",".join("?" * len(chunk))
-            cur.execute(
-                f"DELETE FROM engine_test_events WHERE source_id IN ({placeholders})",
-                chunk,
-            )
-
-    per_source: dict[str, int] = {}
-    for r in rows:
-        cur.execute(_INSERT_SQL, r.to_insert_tuple())
-        per_source[r.source_id] = per_source.get(r.source_id, 0) + 1
-
-    conn.commit()
-    return per_source
-
-
-# ── Reporting ──────────────────────────────────────────────────────────
-
-
-def format_summary(
-    result: ValidationResult,
-    db_warnings: list[RowIssue],
-    csv_row_count: int,
-) -> str:
-    lines = []
-    total_warnings = len(result.warnings) + len(db_warnings)
-    lines.append("Import summary")
-    lines.append(f"  CSV rows read:          {csv_row_count}")
-    lines.append(f"  Rows valid:             {len(result.valid_rows)}")
-    lines.append(f"  Rows rejected:          {len(result.errors)}")
-    lines.append(f"  Warnings:               {total_warnings}")
-
-    if result.errors:
-        lines.append("")
-        lines.append("Errors:")
-        for e in result.errors:
-            lines.append(f"  Row {e.row_number}: [{e.code}] {e.message}")
-
-    all_warnings = result.warnings + db_warnings
-    all_warnings.sort(key=lambda x: (x.row_number, x.code))
-    if all_warnings:
-        lines.append("")
-        lines.append("Warnings:")
-        for w in all_warnings:
-            lines.append(f"  Row {w.row_number}: [{w.code}] {w.message}")
-
-    return "\n".join(lines)
-
-
-def format_apply_summary(per_source: dict[str, int], mode: str) -> str:
-    lines = ["", f"Applied ({mode}):"]
-    total = sum(per_source.values())
-    for sid in sorted(per_source):
-        lines.append(f"  {sid}: {per_source[sid]} event(s)")
-    lines.append(f"  total: {total} event(s) inserted")
-    return "\n".join(lines)
-
-
-# ── CLI ────────────────────────────────────────────────────────────────
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
@@ -710,7 +164,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     try:
         db_warnings = validate_against_db(result.valid_rows, conn)
     finally:
-        # Close before any apply, since apply reopens with the right
+        # Close before any apply; apply reopens with the right
         # transaction semantics.
         pass
 

--- a/tests/test_ui_area_sources_toggle.py
+++ b/tests/test_ui_area_sources_toggle.py
@@ -37,7 +37,40 @@ class _FakeCheckbox:
 
 class _FakeFeature:
     """QgsFeature stand-in supporting ``feature['key']`` reads/writes
-    and KeyError on missing keys."""
+    and KeyError on missing keys.
+
+    IMPORTANT: assignment to a key not present at construction time
+    raises KeyError, mirroring the real QgsFeature behaviour (fields
+    must be declared on the layer's schema). This is stricter than a
+    plain dict — the original Phase 4b tests used a dict-based fake
+    that silently accepted new keys, which masked the bug fixed on
+    the fix-is-test-site-write-keyerror branch (KeyError on save
+    against a pre-v1b .alaqs whose shapes_area_sources layer has no
+    is_test_site field).
+    """
+
+    def __init__(self, data: dict = None):
+        self._data = dict(data or {})
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __setitem__(self, key, value):
+        if key not in self._data:
+            raise KeyError(key)
+        self._data[key] = value
+
+    def __contains__(self, key):
+        return key in self._data
+
+
+class _FakeFeatureLegacyDict:
+    """Loose dict-like fake, kept for the ONE test that intentionally
+    exercises a feature whose field set is unknown at construction time
+    (e.g. a study created on the current schema where every field is
+    present). Real QgsFeature would allow the assignment in that case
+    because the field is declared on the layer.
+    """
 
     def __init__(self, data: dict = None):
         self._data = dict(data or {})
@@ -123,23 +156,51 @@ def test_seed_from_feature_integer_zero_leaves_unchecked():
 def test_write_writes_1_when_checked():
     feature = _FakeFeature({"is_test_site": "0"})
     cb = _FakeCheckbox(checked=True)
-    write_is_test_site_to_feature(cb, feature)
+    result = write_is_test_site_to_feature(cb, feature)
     assert feature["is_test_site"] == "1"
+    assert result is True
 
 
 def test_write_writes_0_when_unchecked():
     feature = _FakeFeature({"is_test_site": "1"})
     cb = _FakeCheckbox(checked=False)
-    write_is_test_site_to_feature(cb, feature)
+    result = write_is_test_site_to_feature(cb, feature)
     assert feature["is_test_site"] == "0"
+    assert result is True
 
 
-def test_write_creates_key_when_absent():
-    """A pre-v1b feature layer that gained is_test_site during the
-    edit session; the write should still work."""
-    feature = _FakeFeature({})  # key missing
+def test_write_returns_false_when_field_absent_no_crash(caplog):
+    """A pre-v1b .alaqs whose shapes_area_sources layer has no
+    is_test_site field: assignment raises KeyError. The helper must
+    catch it, log a WARNING pointing at migrate_alaqs.py, and return
+    False so callers know the state wasn't persisted.
+
+    This test would have caught the KeyError-on-save bug reported
+    against Phase 4b if the original tests hadn't used a dict-based
+    fake that permissively accepted new keys.
+    """
+    import logging
+
+    feature = _FakeFeature({})  # NO is_test_site field
     cb = _FakeCheckbox(checked=True)
-    write_is_test_site_to_feature(cb, feature)
+
+    with caplog.at_level(logging.WARNING):
+        result = write_is_test_site_to_feature(cb, feature)
+
+    assert result is False
+    # The field is NOT added; the feature is unchanged.
+    assert "is_test_site" not in feature
+    # The WARNING mentions the migration command.
+    assert any("migrate_alaqs" in rec.message for rec in caplog.records)
+
+
+def test_write_still_works_on_a_present_but_null_field():
+    """After migrate_alaqs.py runs, the field exists with NULL. The
+    write should succeed (setting the string value replaces the NULL)."""
+    feature = _FakeFeature({"is_test_site": None})
+    cb = _FakeCheckbox(checked=True)
+    result = write_is_test_site_to_feature(cb, feature)
+    assert result is True
     assert feature["is_test_site"] == "1"
 
 


### PR DESCRIPTION
Two commits shipping together: a hotfix for a save-time crash reported
against Phase 4b, plus a new toolbar action that replaces the CLI as
the primary way to load engine-test events (the CLI stays, but the UI
is the default now).

## Hotfix: `write_is_test_site_to_feature` raises `KeyError` on pre-v1b `.alaqs`

Reported by the first real-QGIS test after Phase 4b merged: opening
an area source in a study created by an older plugin version and
toggling the "Engine test site" checkbox crashed the save with:

```
KeyError: 'is_test_site'
in ui/_area_sources_helpers.py line 40
```

### Root cause

Real `QgsFeature` only accepts assignment to fields declared on the
layer's schema. Legacy `.alaqs` files were opened before Phase 1b
added `is_test_site` to `shapes_area_sources`, so the QGIS layer's
field set still lacks it. The write path did:

```python
feature["is_test_site"] = str(int(checkbox.isChecked()))
```

which raises `KeyError` instead of silently succeeding.

The read path was already defensive (try/except in
`seed_is_test_site_from_feature`) but the write was not — an
asymmetry introduced in Phase 4b.

Test failure to catch it: the Phase 4b unit tests used a dict-based
`_FakeFeature` stand-in that permissively accepted new keys, so
`test_write_creates_key_when_absent` passed against fake behaviour
that does not match real `QgsFeature`. The test asserted wrong
behaviour.

### Fix

- `open_alaqs/ui/_area_sources_helpers.py`:
  `write_is_test_site_to_feature` now catches `KeyError`, logs a
  WARNING pointing at `scripts/migrate_alaqs.py`, and returns False
  so callers know the state wasn't persisted. Returns bool now.
- `tests/test_ui_area_sources_toggle.py`:
  `_FakeFeature` made stricter (assignment to unknown key raises
  KeyError, matching real QgsFeature). Removed the misleading
  `test_write_creates_key_when_absent`; added
  `test_write_returns_false_when_field_absent_no_crash` and
  `test_write_still_works_on_a_present_but_null_field`.

Users with a pre-v1b `.alaqs` still need to migrate to gain the
column (`python scripts/migrate_alaqs.py /path/to/study.alaqs`).

## New: import dialog

Adds an "Import engine test events (CSV)" toolbar action that opens
a dialog for bulk-loading engine-test event rows into the
currently-open ALAQS project. Rest of the engine-test workflow is
UI-driven; forcing users to a terminal for the CSV load was
inconsistent.

### Refactor to share code between CLI and UI

The QGIS-plugin ZIP only contains files under `open_alaqs/`
(`.qgis-plugin-ci: plugin_path: open_alaqs`). `scripts/` is NOT
packaged, so the dialog can't import from the CLI script at runtime.

Moved the importer's core logic to a plugin module at
`open_alaqs/core/tools/engine_test_import.py`. The CLI script is now
a thin argparse + stdout wrapper (~180 lines from ~500). Both entry
points import from the shared core module.

The CLI script re-exports the moved names, so the 39-test CLI test
file works unchanged.

### Files

- `open_alaqs/core/tools/engine_test_import.py` (new): full importer
  core. Dependency-free (stdlib only). Public API via `__all__`.
- `scripts/import_engine_test_events.py`: thin CLI wrapper.
- `open_alaqs/openalaqsdialog.py`: new
  `OpenAlaqsImportEngineTestEvents` class. Programmatic Qt widgets:
  file picker, insert-mode radio group, tolerate-warnings checkbox,
  monospace summary text area, Apply/Close buttons. File choice
  triggers validation; Apply enabled only when clean (or warnings
  are tolerated). `_on_apply` prompts with `QMessageBox` on
  destructive modes matching the CLI's `--i-mean-it` protection.
- `open_alaqs/openalaqs.py`: new `import_engine_test_events` action
  registered next to `taxi_routes`. Reuses `profiles.png` as
  placeholder icon; dedicated icon is a follow-up. Discovers the
  currently-loaded DB via `ProjectDatabase().path`.

## Tests

Existing tests all pass: 39 (CLI) + 14 (Phase 4b, updated) + 3
(Helicopter) = 56 in the QGIS-free set. Total across the plugin
should be **1821** (1818 previous + 2 net-new from the hotfix; the
dialog adds no tests, and the refactor keeps the existing CLI test
count unchanged via re-exports).

## Not in this PR

- No dedicated icon for the new action.
- No `.ui` file for the dialog (widgets built programmatically since
  the dialog is small; consistent with `OpenAlaqsAbout`).
- No CSV column for `thrust_mode` (Phase 4a decision retained).