### PR TITLE
docs: update for the in-QGIS CSV import dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,28 @@ regular movement path.
   checkbox in the QGIS area-source edit dialog. When enabled, the
   source's `*_kg_unit` emission-rate fields are ignored at compute
   time; per-mode emissions come from the event rows instead.
-- **CSV import tool.** `scripts/import_engine_test_events.py` bulk-
-  loads events from a CSV into the `engine_test_events` table. Dry
-  run is the default; `--apply` writes. Three modes (`append`,
-  `replace-for-source`, `replace-all`); safety flag `--i-mean-it`
-  required for `replace-all`. Eight row-level error codes and five
-  warning codes surface at once; `--tolerate-warnings` proceeds
-  despite warnings.
+- **CSV import tool.** Two entry points share one core
+  implementation in `open_alaqs.core.tools.engine_test_import`:
+    - **Toolbar action** *"Import engine test events (CSV)"* opens a
+      dialog with a file picker, validation summary, insert-mode
+      radio group (`append` / `replace-for-source` / `replace-all`
+      with confirmation on the destructive modes), and a
+      "Tolerate warnings" checkbox. This is the primary path.
+    - **CLI** `scripts/import_engine_test_events.py` provides the
+      same functionality from a terminal, for scripting. Dry run
+      is the default; `--apply` writes. `--i-mean-it` required for
+      `replace-all`. `--tolerate-warnings` for the non-strict path.
+  Eight row-level error codes and five warning codes surface at
+  once from either entry point; both produce byte-identical
+  INSERTs.
+- **`is_test_site` UI toggle write guarded on pre-v1b studies.**
+  Toggling the "Engine test site" checkbox on a study created by
+  an older plugin version raised `KeyError` on save because the
+  layer's schema had no `is_test_site` field. The write now catches
+  the KeyError, logs a WARNING pointing at `scripts/migrate_alaqs.py`,
+  and returns False. Other fields on the same feature are still
+  saved normally. Users need to run the migration to gain the
+  column.
 - **Compute (plugin).** New `EngineTestSourceModule` computes each
   event's fuel and per-pollutant emissions from
   `Movement.defaultEmissions`, using

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ See [`scripts/README.md`](scripts/README.md) for the full inventory of QGIS-boun
 3. Run *Generate Emission Inventory* on the baked inventory to calculate emissions with the selected method.
 4. For dispersion runs, see [`documents/AUSTAL/AUSTAL_OPERATION.md`](documents/AUSTAL/AUSTAL_OPERATION.md).
 
-For engine test runs (run-ups), an extra step between 1 and 2: mark the area source(s) that represent the run-up pad as engine test sites via the QGIS form ("Engine test site" checkbox), and bulk-load the events via [`scripts/import_engine_test_events.py`](scripts/README.md). Per-event masses are then included in the inventory automatically; the source's `*_kg_unit` rate columns are ignored.
+For engine test runs (run-ups), an extra step between 1 and 2: mark the area source(s) that represent the run-up pad as engine test sites via the QGIS form ("Engine test site" checkbox), and bulk-load the events via the toolbar's *"Import engine test events (CSV)"* action (or, for scripting workflows, [`scripts/import_engine_test_events.py`](scripts/README.md)). Per-event masses are then included in the inventory automatically; the source's `*_kg_unit` rate columns are ignored.
 
 ## Emission calculation methods
 

--- a/documents/USER_GUIDE.md
+++ b/documents/USER_GUIDE.md
@@ -334,12 +334,20 @@ An engine test site (run-up pad) is an area source flagged for special treatment
 2. In the source's edit form, tick the **Engine test site** checkbox. The `*_kg_unit` rates on the Emissions tab are ignored for a test site; you can leave them at zero.
 3. Save the study.
 4. Prepare a CSV of events. Each row is one engine test run and needs a `source_id` (matching the area source you just flagged), `start_datetime`, `end_datetime`, `aircraft_type`, and per-mode running times in seconds (`t_TX_s`, `t_AP_s`, `t_CL_s`, `t_TO_s`). Optional columns: `test_id`, `engine_uid`, `engine_count`. See [`scripts/README.md`](../scripts/README.md#import_engine_test_eventspy) for the full CSV specification.
-5. Load the events with the importer script:
-   ```bash
-   python scripts/import_engine_test_events.py study.alaqs events.csv
-   ```
-   Run without `--apply` first to validate. Add `--apply` when the summary looks clean.
+5. Load the events. Two ways, functionally identical:
+   * **From QGIS (default):** click *"Import engine test events (CSV)"* in the OpenALAQS toolbar. In the dialog: browse to the CSV, review the validation summary, pick the insert mode (`Append` / `Replace for source` / `Replace all`), tick "Tolerate warnings" if you want to accept them, and click Apply. Destructive modes prompt for extra confirmation.
+   * **From the terminal (for scripting):**
+     ```bash
+     python scripts/import_engine_test_events.py study.alaqs events.csv
+     ```
+     Run without `--apply` first to validate. Add `--apply` when the summary looks clean.
 6. Regenerate the emission inventory. Test-site emissions appear alongside regular sources with no further configuration.
+
+**Note on pre-existing `.alaqs` files:** if your study was created by a plugin version older than the one that added engine-test-site support, running the migration is required before step 2 works — the checkbox has no place to write to otherwise. Run:
+```bash
+python scripts/migrate_alaqs.py study.alaqs
+```
+Then close and reopen the project in QGIS.
 
 **Thrust computation modes.** Each event has an optional `thrust_mode` column (default `snap`), not exposed in the CSV — set it via SQL if you need a non-default:
 


### PR DESCRIPTION
Follow-up to the "in-QGIS dialog for importing engine test events" PR that shipped with the KeyError hotfix. The three user-facing docs still described the CLI as the only way to load engine-test events. This updates them to prioritise the toolbar action and mention the KeyError hotfix.

Files
-----

* CHANGELOG.md Unreleased entry: replaced the "CSV import tool" bullet with a more accurate one describing two entry points (toolbar action and CLI) sharing a single core implementation in open_alaqs.core.tools.engine_test_import. Added a new bullet for the is_test_site UI toggle KeyError-guard hotfix.

* README.md Workflow section: mention the toolbar action as the primary way to load events, CLI as the scripting alternative.

* documents/USER_GUIDE.md Engine test sites setup workflow step 5: replaced the single bash-only path with two sub-bullets — QGIS toolbar action (default) and terminal CLI (scripting). Added a "Note on pre-existing .alaqs files" paragraph describing the migration step required to gain the is_test_site column and referencing scripts/migrate_alaqs.py.

Not updated
-----------

- scripts/README.md — this is the scripts README, CLI-focused makes sense.
- documents/BFFM2_validation/*.md — the CSV import is orthogonal to the BFFM2 methodology; no cross-reference needed.

Sanity
------

Markdown fences balanced (10 / 6 / 12 across the three files). No new links to non-existent anchors.