### PR TITLE
Redesign: move engine-test events import from toolbar to source form

### DIFF
--- a/open_alaqs/core/tools/engine_test_import.py
+++ b/open_alaqs/core/tools/engine_test_import.py
@@ -233,9 +233,19 @@ def _parse_mode_seconds(s: Optional[str]) -> tuple[bool, int, Optional[str]]:
 
 def validate_csv_rows(
     csv_rows: Iterable[dict[str, str]],
+    implicit_source_id: Optional[str] = None,
 ) -> ValidationResult:
     """Validate the CSV without touching the DB. DB cross-checks happen
     downstream in ``validate_against_db``.
+
+    If ``implicit_source_id`` is supplied, any row whose ``source_id``
+    is present but not equal to ``implicit_source_id`` yields a
+    ``mismatched_source_id`` error. This is used by the per-source UI
+    dialog to enforce that the CSV's rows all belong to the source
+    the user is editing. Typically the caller has already used
+    ``read_csv(..., implicit_source_id=X)`` to fill in ``source_id``
+    on rows where the column was absent, so this check only fires on
+    rows where the user explicitly put a mismatched value.
     """
     result = ValidationResult()
     seen_dupe_keys: dict[tuple, int] = {}
@@ -256,6 +266,22 @@ def validate_csv_rows(
 
         source_id = row["source_id"].strip()
         aircraft_type = row["aircraft_type"].strip()
+
+        # Scope enforcement: if the dialog supplied an implicit source,
+        # any row whose source_id differs is a hard error. Prevents a
+        # user from accidentally writing to another source's events via
+        # the per-source dialog.
+        if implicit_source_id is not None and source_id != implicit_source_id:
+            errs.append(
+                RowIssue(
+                    i,
+                    "mismatched_source_id",
+                    f"source_id {source_id!r} does not match the target "
+                    f"source {implicit_source_id!r}",
+                )
+            )
+            result.errors.extend(errs)
+            continue
 
         # Datetimes
         start_str = row["start_datetime"].strip()
@@ -393,15 +419,37 @@ def validate_csv_rows(
     return result
 
 
-def read_csv(csv_path: Path) -> tuple[list[dict[str, str]], Optional[str]]:
-    """Read the CSV. Return (rows, header_error). If the header is
-    missing a required column, ``header_error`` is set and ``rows`` is
-    empty.
+def read_csv(
+    csv_path: Path,
+    implicit_source_id: Optional[str] = None,
+) -> tuple[list[dict[str, str]], Optional[str]]:
+    """Read the CSV. Return (rows, header_error).
+
+    If ``implicit_source_id`` is provided:
+      * ``source_id`` is treated as optional in the CSV header.
+      * If the CSV header does NOT contain ``source_id``, the returned
+        rows have ``source_id`` filled with ``implicit_source_id`` on
+        every row.
+      * If the CSV header DOES contain ``source_id``, its values pass
+        through unchanged; the caller (typically
+        ``validate_csv_rows`` with the same ``implicit_source_id``)
+        surfaces any mismatch as a ``mismatched_source_id`` error.
+
+    If ``implicit_source_id`` is None, ``source_id`` is a required
+    column (the default CLI behaviour).
+
+    If the header is missing a required column, ``header_error`` is
+    set and ``rows`` is empty.
     """
     with csv_path.open("r", encoding="utf-8-sig", newline="") as f:
         reader = csv.DictReader(f)
         fieldnames = reader.fieldnames or []
-        missing = [c for c in REQUIRED_COLUMNS if c not in fieldnames]
+        if implicit_source_id is None:
+            required = REQUIRED_COLUMNS
+        else:
+            # source_id becomes optional when a scope is supplied.
+            required = tuple(c for c in REQUIRED_COLUMNS if c != "source_id")
+        missing = [c for c in required if c not in fieldnames]
         if missing:
             return [], (
                 "CSV header missing required column(s): "
@@ -410,6 +458,11 @@ def read_csv(csv_path: Path) -> tuple[list[dict[str, str]], Optional[str]]:
                 + f"\n  columns expected: {list(ALL_COLUMNS)}"
             )
         rows = list(reader)
+
+    # Fill in source_id on all rows if it was absent from the header.
+    if implicit_source_id is not None and "source_id" not in fieldnames:
+        for row in rows:
+            row["source_id"] = implicit_source_id
     return rows, None
 
 

--- a/open_alaqs/openalaqs.py
+++ b/open_alaqs/openalaqs.py
@@ -36,7 +36,6 @@ from open_alaqs.gui.DispersionAnalysis import OpenAlaqsDispersionAnalysis
 from open_alaqs.openalaqsdialog import (
     OpenAlaqsAbout,
     OpenAlaqsEnabledMacros,
-    OpenAlaqsImportEngineTestEvents,
     OpenAlaqsInventory,
     OpenAlaqsLogfile,
     OpenAlaqsOpenDatabase,
@@ -167,18 +166,6 @@ class OpenALAQS:
             self.run_taxi_routes,
         )
 
-        # Create action that will show the Import Engine Test Events dialog.
-        # Icon: reuse "profiles.png" as a placeholder — this action is
-        # conceptually similar (bulk-load a set of records for later
-        # emission calculation) and adding a dedicated icon is deferred
-        # until we have artwork.
-        self.actions["import_engine_test_events"] = self.create_connected_action(
-            QtGui.QIcon(str(icons_path / "profiles.png")),
-            "Import engine test events (CSV)",
-            self.iface.mainWindow(),
-            self.run_import_engine_test_events,
-        )
-
         # Create action that will show the Calculate Emissions Inventory dialog
         self.actions["build_inventory"] = self.create_connected_action(
             QtGui.QIcon(str(icons_path / "calculate.png")),
@@ -225,7 +212,6 @@ class OpenALAQS:
         self.open_alaqs_toolbar.addAction(self.actions["osm_import"])
         self.open_alaqs_toolbar.addAction(self.actions["profiles_edit"])
         self.open_alaqs_toolbar.addAction(self.actions["taxi_routes"])
-        self.open_alaqs_toolbar.addAction(self.actions["import_engine_test_events"])
         self.open_alaqs_toolbar.addAction(self.actions["build_inventory"])
 
         self.open_alaqs_toolbar.addSeparator()
@@ -241,7 +227,6 @@ class OpenALAQS:
         self.actions["osm_import"].setEnabled(False)
         self.actions["profiles_edit"].setEnabled(False)
         self.actions["taxi_routes"].setEnabled(False)
-        self.actions["import_engine_test_events"].setEnabled(False)
         self.actions["build_inventory"].setEnabled(False)
 
         self.macro_check()
@@ -328,7 +313,6 @@ class OpenALAQS:
         self.actions["osm_import"].setEnabled(True)
         self.actions["profiles_edit"].setEnabled(True)
         self.actions["taxi_routes"].setEnabled(True)
-        self.actions["import_engine_test_events"].setEnabled(True)
         self.actions["build_inventory"].setEnabled(True)
         self.actions["view_results_analysis"].setEnabled(True)
         self.actions["calculate_dispersion"].setEnabled(True)
@@ -361,7 +345,6 @@ class OpenALAQS:
                 self.actions["osm_import"].setEnabled(True)
                 self.actions["profiles_edit"].setEnabled(True)
                 self.actions["taxi_routes"].setEnabled(True)
-                self.actions["import_engine_test_events"].setEnabled(True)
                 self.actions["build_inventory"].setEnabled(True)
                 self.actions["view_results_analysis"].setEnabled(True)
                 self.actions["calculate_dispersion"].setEnabled(True)
@@ -390,8 +373,6 @@ class OpenALAQS:
             self.actions["profiles_edit"].setEnabled(False)
         if "taxi_routes" in self.actions:
             self.actions["taxi_routes"].setEnabled(False)
-        if "import_engine_test_events" in self.actions:
-            self.actions["import_engine_test_events"].setEnabled(False)
         if "build_inventory" in self.actions:
             self.actions["build_inventory"].setEnabled(False)
         if "calculate_dispersion" in self.actions:
@@ -465,36 +446,6 @@ class OpenALAQS:
         self.dialogs["taxi_routes"] = OpenAlaqsTaxiRoutes(self.iface)
         self.dialogs["taxi_routes"].show()
         self.dialogs["taxi_routes"].exec()
-
-    def run_import_engine_test_events(self):
-        """
-        Opens the widget dialog for importing engine-test events from a
-        CSV into the currently-loaded ALAQS project.
-        """
-        # Discover the currently-loaded project's DB path. Same pattern
-        # as OpenAlaqsInventory uses (ProjectDatabase is a Singleton
-        # holding the currently-open .alaqs path).
-        try:
-            from open_alaqs.core.alaqsdblite import ProjectDatabase
-
-            db_path = ProjectDatabase().path
-        except Exception:
-            db_path = None
-
-        if not db_path:
-            QtWidgets.QMessageBox.warning(
-                self.iface.mainWindow() if self.iface else None,
-                "No project loaded",
-                "Load an Open ALAQS project first before importing "
-                "engine-test events.",
-            )
-            return
-
-        self.dialogs["import_engine_test_events"] = OpenAlaqsImportEngineTestEvents(
-            self.iface, db_path
-        )
-        self.dialogs["import_engine_test_events"].show()
-        self.dialogs["import_engine_test_events"].exec()
 
     def run_build_inventory(self):
         """

--- a/open_alaqs/openalaqsdialog.py
+++ b/open_alaqs/openalaqsdialog.py
@@ -3231,7 +3231,7 @@ class OpenAlaqsOsmImport(QtWidgets.QDialog):
 class OpenAlaqsImportEngineTestEvents(QtWidgets.QDialog):
     """
     Dialog for importing engine-test event rows from a CSV into the
-    currently-loaded ALAQS project.
+    currently-loaded ALAQS project. Scoped to a single source.
 
     Thin UI wrapper around
     ``open_alaqs.core.tools.engine_test_import`` (the same core module
@@ -3241,13 +3241,27 @@ class OpenAlaqsImportEngineTestEvents(QtWidgets.QDialog):
     ``apply_insert`` on user confirmation. All CSV format and
     validation semantics live in the core module; changes there flow
     automatically into this dialog.
+
+    Launched from the area-source form's "Load engine test events CSV"
+    button. The current source's ``source_id`` is passed in and used to:
+      * label the dialog title so users know which source they're
+        loading events for,
+      * force the ``source_id`` column on all incoming rows (users
+        don't need to fill it in; if they do, mismatched values are
+        surfaced as errors, not silently accepted).
+
+    ``replace-all`` mode is intentionally omitted from the per-source
+    dialog — it would delete events for OTHER sources too, which is
+    surprising from within a form scoped to one source. Users with a
+    genuine need for global replacement fall back to the CLI.
     """
 
-    def __init__(self, iface, database_path):
+    def __init__(self, iface, database_path, source_id):
         main_window = iface.mainWindow() if iface is not None else None
         QtWidgets.QDialog.__init__(self, main_window)
         self.iface = iface
         self._database_path = database_path
+        self._source_id = source_id
 
         # Held per-run state.
         self._csv_path: Optional[Path] = None
@@ -3260,18 +3274,29 @@ class OpenAlaqsImportEngineTestEvents(QtWidgets.QDialog):
     # ── UI construction ───────────────────────────────────────────
 
     def _build_ui(self):
-        self.setWindowTitle("Import Engine Test Events")
+        self.setWindowTitle(f"Load engine test events for {self._source_id}")
         self.setMinimumWidth(700)
         self.setMinimumHeight(500)
 
         layout = QtWidgets.QVBoxLayout(self)
 
-        # DB path label (read-only, informational).
-        db_label = QtWidgets.QLabel(
-            f"<b>Target study:</b> {os.path.basename(self._database_path or '<none>')}"
+        # Scope header. Prominently show which source events are going
+        # to, so users don't confuse this dialog for a global import.
+        scope_label = QtWidgets.QLabel(
+            f"<b>Target source:</b> {self._source_id}<br>"
+            f"<b>Study:</b> {os.path.basename(self._database_path or '<none>')}"
         )
-        db_label.setWordWrap(True)
-        layout.addWidget(db_label)
+        scope_label.setWordWrap(True)
+        layout.addWidget(scope_label)
+
+        # Note about the source_id column.
+        note_label = QtWidgets.QLabel(
+            "<i>All rows in the CSV will be assigned to this source. "
+            "The <code>source_id</code> column in the CSV is optional; "
+            "if present it must match the target source above.</i>"
+        )
+        note_label.setWordWrap(True)
+        layout.addWidget(note_label)
 
         # File picker row.
         file_row = QtWidgets.QHBoxLayout()
@@ -3287,21 +3312,20 @@ class OpenAlaqsImportEngineTestEvents(QtWidgets.QDialog):
         file_row.addWidget(browse_btn)
         layout.addLayout(file_row)
 
-        # Insert-mode radio group.
+        # Insert-mode radio group. Replace-all deliberately omitted
+        # from the per-source dialog (would touch other sources); use
+        # the CLI for that.
         mode_box = QtWidgets.QGroupBox("Insert mode")
         mode_layout = QtWidgets.QVBoxLayout()
-        self._mode_append = QtWidgets.QRadioButton("Append (add to existing events)")
+        self._mode_append = QtWidgets.QRadioButton(
+            "Append (add to existing events for this source)"
+        )
         self._mode_append.setChecked(True)
         self._mode_replace_source = QtWidgets.QRadioButton(
-            "Replace for source (delete existing events for each source_id "
-            "in the CSV, then insert)"
-        )
-        self._mode_replace_all = QtWidgets.QRadioButton(
-            "Replace all (DELETE all rows in engine_test_events first — " "destructive)"
+            f"Replace (delete existing events for {self._source_id!r}, " "then insert)"
         )
         mode_layout.addWidget(self._mode_append)
         mode_layout.addWidget(self._mode_replace_source)
-        mode_layout.addWidget(self._mode_replace_all)
         mode_box.setLayout(mode_layout)
         layout.addWidget(mode_box)
 
@@ -3364,9 +3388,14 @@ class OpenAlaqsImportEngineTestEvents(QtWidgets.QDialog):
         if self._csv_path is None:
             return
 
-        # Read CSV.
+        # Read CSV — the current source_id acts as an implicit scope,
+        # so the source_id column becomes optional in the CSV. When
+        # absent, read_csv fills it in on every row with self._source_id.
+        # When present, validate_csv_rows below flags mismatches.
         try:
-            rows, header_error = read_csv(self._csv_path)
+            rows, header_error = read_csv(
+                self._csv_path, implicit_source_id=self._source_id
+            )
         except Exception as e:
             self._summary_text.setPlainText(f"ERROR: could not read CSV:\n{e}")
             self._apply_btn.setEnabled(False)
@@ -3377,8 +3406,11 @@ class OpenAlaqsImportEngineTestEvents(QtWidgets.QDialog):
             return
         self._csv_row_count = len(rows)
 
-        # Structural validation.
-        self._validation_result = validate_csv_rows(rows)
+        # Structural validation — scoped so mismatched source_id becomes
+        # a hard error.
+        self._validation_result = validate_csv_rows(
+            rows, implicit_source_id=self._source_id
+        )
 
         # DB cross-checks.
         try:
@@ -3432,14 +3464,12 @@ class OpenAlaqsImportEngineTestEvents(QtWidgets.QDialog):
     # ── Apply ─────────────────────────────────────────────────────
 
     def _selected_mode(self) -> str:
-        if self._mode_replace_all.isChecked():
-            return "replace-all"
         if self._mode_replace_source.isChecked():
             return "replace-for-source"
         return "append"
 
     def _on_apply(self):
-        """Confirm destructive modes, then INSERT into the DB."""
+        """Confirm destructive mode, then INSERT into the DB."""
         import sqlite3
 
         from open_alaqs.core.tools.engine_test_import import (
@@ -3449,34 +3479,16 @@ class OpenAlaqsImportEngineTestEvents(QtWidgets.QDialog):
 
         mode = self._selected_mode()
 
-        # Extra confirmation on replace-all (the CLI's --i-mean-it
-        # equivalent). replace-for-source is destructive too but scoped;
-        # a plain OK/Cancel is enough for it.
-        if mode == "replace-all":
+        # Confirmation on replace-for-source. Scoped to the current
+        # source, which is already prominent in the dialog title, so a
+        # simple confirmation suffices.
+        if mode == "replace-for-source":
             resp = QMessageBox.warning(
                 self,
-                "Delete ALL existing engine-test events?",
-                "This will DELETE every row in engine_test_events "
-                "before inserting the CSV rows. This cannot be undone.\n\n"
-                "Are you sure?",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No,
-            )
-            if resp != QMessageBox.Yes:
-                return
-        elif mode == "replace-for-source":
-            source_ids = sorted(
-                {r.source_id for r in self._validation_result.valid_rows}
-            )
-            preview = ", ".join(source_ids[:5])
-            if len(source_ids) > 5:
-                preview += f", ... ({len(source_ids)} total)"
-            resp = QMessageBox.warning(
-                self,
-                "Delete existing events for these sources?",
-                "This will DELETE existing engine_test_events rows for "
-                f"the following source_id(s) before inserting the new "
-                f"rows:\n\n{preview}\n\nAre you sure?",
+                f"Delete existing events for {self._source_id}?",
+                f"This will DELETE existing engine_test_events rows for "
+                f"source {self._source_id!r} before inserting the new "
+                "rows.\n\nAre you sure?",
                 QMessageBox.Yes | QMessageBox.No,
                 QMessageBox.No,
             )

--- a/open_alaqs/ui/ui_area_sources.py
+++ b/open_alaqs/ui/ui_area_sources.py
@@ -29,6 +29,55 @@ def catch_errors(f):
     return wrapper
 
 
+def _open_load_events_dialog(form, fields, feature):
+    """Launch OpenAlaqsImportEngineTestEvents scoped to the current source.
+
+    Called from the "Load engine test events CSV..." button on the area
+    source form. Discovers the currently-loaded project's DB path via
+    ``ProjectDatabase().path``, reads the source_id from the form's
+    ``name_field`` (which is the ``source_id`` line edit — the same value
+    that will be written to the feature on save), and passes both into
+    the dialog.
+
+    Refuses if:
+      * the source_id field is empty (nothing to scope to yet), or
+      * ProjectDatabase().path returns nothing (unlikely in the QGIS
+        flow, but defensive).
+    """
+    from qgis.PyQt.QtWidgets import QMessageBox
+
+    from open_alaqs.core.alaqsdblite import ProjectDatabase
+    from open_alaqs.openalaqsdialog import OpenAlaqsImportEngineTestEvents
+
+    source_id = (fields["name_field"].text() or "").strip()
+    if not source_id:
+        QMessageBox.warning(
+            form,
+            "Missing source name",
+            "Enter a Source Name before loading engine test events. "
+            "The events need to be tied to this source's identifier.",
+        )
+        return
+
+    try:
+        db_path = ProjectDatabase().path
+    except Exception:
+        db_path = None
+    if not db_path:
+        QMessageBox.warning(
+            form,
+            "No project loaded",
+            "The currently-loaded ALAQS project could not be found. "
+            "Save the study before loading engine test events.",
+        )
+        return
+
+    dialog = OpenAlaqsImportEngineTestEvents(
+        iface=None, database_path=db_path, source_id=source_id
+    )
+    dialog.exec()
+
+
 def form_open(form, layer, feature):
     logger.debug("This is the modified simple form")
     logger.debug(f"Layer {layer} and feature {feature}")
@@ -54,6 +103,7 @@ def form_open(form, layer, feature):
         button_box=form.findChild(QtWidgets.QDialogButtonBox, "buttonBox"),
         instudy=form.findChild(QtWidgets.QCheckBox, "instudy"),
         is_test_site=form.findChild(QtWidgets.QCheckBox, "is_test_site"),
+        load_events_csv=form.findChild(QtWidgets.QPushButton, "load_events_csv"),
     )
 
     # Hide the instudy field
@@ -64,6 +114,16 @@ def form_open(form, layer, feature):
     # on migrated projects), or absent entirely (pre-v1b schema — the
     # widget still exists on the form but has nothing to read).
     seed_is_test_site_from_feature(fields["is_test_site"], feature)
+
+    # Wire the "Load engine test events CSV..." button. It is enabled
+    # only when the source is flagged as a test site. Clicking it opens
+    # the OpenAlaqsImportEngineTestEvents dialog scoped to this source.
+    if fields["load_events_csv"] is not None:
+        fields["load_events_csv"].setEnabled(fields["is_test_site"].isChecked())
+        fields["is_test_site"].toggled.connect(fields["load_events_csv"].setEnabled)
+        fields["load_events_csv"].clicked.connect(
+            lambda: _open_load_events_dialog(form, fields, feature)
+        )
 
     # Disable heat flux fields
     fields["heat_flux_field"].setText("0")

--- a/open_alaqs/ui/ui_area_sources.ui
+++ b/open_alaqs/ui/ui_area_sources.ui
@@ -56,7 +56,7 @@
    <item row="4" column="1">
     <widget class="QCheckBox" name="is_test_site">
      <property name="toolTip">
-      <string>When enabled, this source's emissions come from engine_test_events records (loaded via scripts/import_engine_test_events.py) and the *_kg_unit rates on the Emissions tab are ignored.</string>
+      <string>When enabled, this source's emissions come from engine_test_events records (loaded via the "Load events CSV..." button below) and the *_kg_unit rates on the Emissions tab are ignored.</string>
      </property>
      <property name="text">
       <string/>
@@ -67,6 +67,19 @@
     </widget>
    </item>
    <item row="5" column="0" colspan="2">
+    <widget class="QPushButton" name="load_events_csv">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="toolTip">
+      <string>Bulk-load engine test event rows from a CSV. Enabled only when this source is an engine test site.</string>
+     </property>
+     <property name="text">
+      <string>Load engine test events CSV...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>

--- a/tests/test_import_engine_test_events.py
+++ b/tests/test_import_engine_test_events.py
@@ -739,3 +739,93 @@ def test_cli_missing_alaqs_returns_1(tmp_path, capsys):
     csv_path = _write_csv(tmp_path, "x.csv", _row(t_CL_s="900"))
     rc = importer.main([str(tmp_path / "no.alaqs"), csv_path])
     assert rc == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 7: implicit_source_id (per-source dialog scope)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_read_csv_source_id_optional_when_implicit_supplied(tmp_path):
+    """With implicit_source_id set, source_id column is not required
+    in the header. Rows get their source_id filled in."""
+    p = tmp_path / "no_source.csv"
+    p.write_text(
+        "start_datetime,end_datetime,aircraft_type,test_id,engine_uid,"
+        "engine_count,t_TX_s,t_AP_s,t_CL_s,t_TO_s,instudy\n"
+        "2024-12-01T09:00:00,2024-12-01T09:15:00,C56X,,,,600,0,300,0,1\n"
+    )
+    rows, err = importer.read_csv(p, implicit_source_id="TESTPAD_A")
+    assert err is None
+    assert len(rows) == 1
+    assert rows[0]["source_id"] == "TESTPAD_A"
+
+
+def test_read_csv_source_id_still_read_when_present_in_header(tmp_path):
+    """With implicit_source_id set AND source_id column in header, the
+    CSV values pass through unchanged. Validation catches mismatches."""
+    p = tmp_path / "with_source.csv"
+    p.write_text(_csv_text(_row(source_id="TESTPAD_B")))
+    rows, err = importer.read_csv(p, implicit_source_id="TESTPAD_A")
+    assert err is None
+    assert rows[0]["source_id"] == "TESTPAD_B"  # unchanged
+
+
+def test_validate_csv_rows_mismatched_source_id_errors_out():
+    """A row whose source_id doesn't match the implicit_source_id
+    should be rejected as an error, not a warning."""
+    rows = _rows_from_string(_csv_text(_row(source_id="TESTPAD_B", t_CL_s="900")))
+    result = importer.validate_csv_rows(rows, implicit_source_id="TESTPAD_A")
+    assert len(result.errors) == 1
+    assert result.errors[0].code == "mismatched_source_id"
+    assert "TESTPAD_A" in result.errors[0].message
+    assert "TESTPAD_B" in result.errors[0].message
+
+
+def test_validate_csv_rows_matching_source_id_passes():
+    """A row whose source_id matches the implicit_source_id should
+    validate normally."""
+    rows = _rows_from_string(_csv_text(_row(source_id="TESTPAD_A", t_CL_s="900")))
+    result = importer.validate_csv_rows(rows, implicit_source_id="TESTPAD_A")
+    assert result.errors == []
+    assert len(result.valid_rows) == 1
+
+
+def test_validate_csv_rows_no_implicit_source_id_backward_compat():
+    """When implicit_source_id is None (default, CLI path), any
+    source_id is accepted; no mismatched_source_id error possible."""
+    rows = _rows_from_string(_csv_text(_row(source_id="ANY_SOURCE", t_CL_s="900")))
+    result = importer.validate_csv_rows(rows)
+    assert result.errors == []
+    assert result.valid_rows[0].source_id == "ANY_SOURCE"
+
+
+def test_read_csv_still_requires_source_id_when_no_implicit(tmp_path):
+    """Backward compat: without implicit_source_id, source_id is still
+    a required column."""
+    p = tmp_path / "no_source.csv"
+    p.write_text(
+        "start_datetime,end_datetime,aircraft_type\n"
+        "2024-12-01T09:00:00,2024-12-01T09:15:00,C56X\n"
+    )
+    rows, err = importer.read_csv(p)
+    assert err is not None
+    assert "source_id" in err
+
+
+def test_end_to_end_dialog_flow_no_source_id_column(tmp_path):
+    """Simulate the dialog flow: CSV lacks source_id column, dialog
+    supplies TESTPAD_A. All rows get validated with source_id filled
+    in, no mismatch errors."""
+    p = tmp_path / "dialog_scenario.csv"
+    p.write_text(
+        "start_datetime,end_datetime,aircraft_type,t_CL_s\n"
+        "2024-12-01T09:00:00,2024-12-01T09:15:00,C56X,300\n"
+        "2024-12-02T10:00:00,2024-12-02T10:20:00,PC24,600\n"
+    )
+    rows, err = importer.read_csv(p, implicit_source_id="TESTPAD_A")
+    assert err is None
+    result = importer.validate_csv_rows(rows, implicit_source_id="TESTPAD_A")
+    assert result.errors == []
+    assert len(result.valid_rows) == 2
+    assert all(r.source_id == "TESTPAD_A" for r in result.valid_rows)


### PR DESCRIPTION
Fixing the workflow I got wrong in #343. The CSV import should be a
per-source action available FROM the area-source edit form, not a
global toolbar action. Users mark a source as an engine test site and
then load THIS SOURCE's events; loading events for multiple sources at
once from a top-level button was confusing and disconnected from the
source-creation flow.

## Changes

- Removed the toolbar action, its icon slot, and the run method in
  `open_alaqs/openalaqs.py`. Studies open now have one fewer icon in
  the OpenALAQS toolbar.

- Added a **"Load engine test events CSV..."** button to the area
  source form (`open_alaqs/ui/ui_area_sources.ui`). Sits between the
  "Engine test site" checkbox and the Parameters/Profiles/Emissions
  tab widget.

- The button is enabled ONLY when "Engine test site" is ticked.
  Toggling the checkbox live-updates the button's enable state.

- Clicking the button opens the
  `OpenAlaqsImportEngineTestEvents` dialog scoped to the CURRENT
  `source_id`, discovered from the form's `name_field` (Source Name).
  If the source hasn't been named yet, or the project DB isn't
  reachable, the button shows a message box instead.

- The dialog itself is now per-source:
    - Title reads *"Load engine test events for <source_id>"*.
    - Prominent scope header repeats the `source_id` and study
      filename.
    - Explanatory note: *"All rows will be assigned to this source.
      `source_id` column is optional; if present it must match."*
    - The "Replace for source" mode text now names the source
      explicitly.
    - The confirmation prompt on Replace names the source.
    - The **"Replace all" mode is REMOVED** — a per-source dialog
      shouldn't be able to touch other sources' events. CLI still
      has it for users who need it.

## Core module

`open_alaqs/core/tools/engine_test_import.py`:
- `read_csv` gains an `implicit_source_id` parameter. When set,
  `source_id` becomes optional in the header; rows without a
  `source_id` column get it filled in.
- `validate_csv_rows` gains the same parameter. Rows whose
  `source_id` doesn't match the implicit value are rejected with a
  new error code, `mismatched_source_id`.
- **Backward compatible**: `implicit_source_id` defaults to None, in
  which case `source_id` is still required (existing CLI behaviour
  and all 39 existing tests pass without modification).

## Tests

7 new tests in Section 7 of
`tests/test_import_engine_test_events.py`:
- `source_id` column is optional when implicit is set
- `source_id` in header passes through unchanged (mismatch caught by
  validation)
- `mismatched_source_id` error surfaces correctly
- matching `source_id` validates normally
- no `implicit_source_id` → backward-compat (any source accepted)
- `source_id` still required when no implicit supplied
- end-to-end dialog scenario (CSV lacks `source_id` column, dialog
  supplies `TESTPAD_A`, two rows validate as `TESTPAD_A`)

Full CLI test count: 46 (39 previous + 7 new). Full test suite
expected: **1828 passed** (1821 previous + 7 new).

## Docs follow-up

The USER_GUIDE and CHANGELOG entries from #344 still describe the
now-removed toolbar action. Will fix in a small follow-up PR after
this merges.