### PR TITLE
Fix: CSV import dialog UX bugs + area source form layout collision

### DIFF
--- a/open_alaqs/core/tools/engine_test_import.py
+++ b/open_alaqs/core/tools/engine_test_import.py
@@ -173,6 +173,13 @@ class ValidationResult:
     errors: list[RowIssue] = field(default_factory=list)
     warnings: list[RowIssue] = field(default_factory=list)
     header_error: Optional[str] = None
+    # Rows skipped because their source_id is for a different source
+    # than ``implicit_source_id``. Only populated when the caller
+    # supplies ``implicit_source_id`` (per-source dialog path). Not an
+    # error, not a warning — informational only. Purpose: the user
+    # keeps one master CSV with events for many sources, and each
+    # source's dialog picks its own subset.
+    skipped_other_source: int = 0
 
 
 # ── Parsing helpers ────────────────────────────────────────────────────
@@ -238,14 +245,15 @@ def validate_csv_rows(
     """Validate the CSV without touching the DB. DB cross-checks happen
     downstream in ``validate_against_db``.
 
-    If ``implicit_source_id`` is supplied, any row whose ``source_id``
-    is present but not equal to ``implicit_source_id`` yields a
-    ``mismatched_source_id`` error. This is used by the per-source UI
-    dialog to enforce that the CSV's rows all belong to the source
-    the user is editing. Typically the caller has already used
-    ``read_csv(..., implicit_source_id=X)`` to fill in ``source_id``
-    on rows where the column was absent, so this check only fires on
-    rows where the user explicitly put a mismatched value.
+    If ``implicit_source_id`` is supplied, rows whose ``source_id``
+    doesn't match are silently skipped and counted in
+    ``result.skipped_other_source``. This is used by the per-source
+    UI dialog: users can keep one master CSV of engine test events
+    across the airport and each source's dialog picks its own subset.
+    Typically the caller has already used ``read_csv(...,
+    implicit_source_id=X)`` to fill in ``source_id`` on rows where the
+    column was absent, so this skip only affects rows where the user
+    explicitly named a different source.
     """
     result = ValidationResult()
     seen_dupe_keys: dict[tuple, int] = {}
@@ -267,20 +275,14 @@ def validate_csv_rows(
         source_id = row["source_id"].strip()
         aircraft_type = row["aircraft_type"].strip()
 
-        # Scope enforcement: if the dialog supplied an implicit source,
-        # any row whose source_id differs is a hard error. Prevents a
-        # user from accidentally writing to another source's events via
-        # the per-source dialog.
+        # Scope filter: if the dialog supplied an implicit source, rows
+        # for OTHER sources are silently skipped (not errored). Purpose:
+        # the user keeps one master CSV with events for all sources at
+        # the airport, and each source's per-source dialog picks its
+        # own subset. The count is surfaced in the summary as
+        # informational so the user sees how many rows were skipped.
         if implicit_source_id is not None and source_id != implicit_source_id:
-            errs.append(
-                RowIssue(
-                    i,
-                    "mismatched_source_id",
-                    f"source_id {source_id!r} does not match the target "
-                    f"source {implicit_source_id!r}",
-                )
-            )
-            result.errors.extend(errs)
+            result.skipped_other_source += 1
             continue
 
         # Datetimes
@@ -379,21 +381,23 @@ def validate_csv_rows(
         # Record dupe key only for successfully-validated (so-far) rows.
         seen_dupe_keys[dupe_key] = i
 
-        # Running-seconds vs window warning (D from Phase 2).
+        # Running-seconds vs window warning (D from Phase 2). Engines
+        # run in parallel during a run-up: each engine runs for
+        # ``running`` seconds within the ``window_s`` duration. So the
+        # sanity check is per-engine, matching Phase 2's
+        # EngineTestEvent.getConsistencyWarnings. An earlier version
+        # (Phase 4a) multiplied by engine_count, which is wrong: it
+        # assumed serial engine running and produced spurious warnings
+        # on legitimate twin-engine test runs.
         running = sum(mode_times.values())
-        if engine_count is not None and engine_count > 0:
-            running_total = running * engine_count
-        else:
-            running_total = running
         window_s = (end_dt - start_dt).total_seconds()
-        if running_total > window_s + _RUNNING_EXCEEDS_WINDOW_TOLERANCE_S:
+        if running > window_s + _RUNNING_EXCEEDS_WINDOW_TOLERANCE_S:
             result.warnings.append(
                 RowIssue(
                     i,
                     "running_exceeds_window",
-                    f"sum of mode times ({running_total}s across "
-                    f"{engine_count or 1} engine(s)) exceeds the "
-                    f"event window ({int(window_s)}s) by more than "
+                    f"sum of mode times ({running}s per engine) exceeds "
+                    f"the event window ({int(window_s)}s) by more than "
                     f"{_RUNNING_EXCEEDS_WINDOW_TOLERANCE_S}s tolerance",
                 )
             )
@@ -525,31 +529,49 @@ def _fetch_lookup_sets(conn: sqlite3.Connection) -> dict[str, set]:
 def validate_against_db(
     valid_rows: list[ValidatedRow],
     conn: sqlite3.Connection,
+    implicit_source_id: Optional[str] = None,
 ) -> list[RowIssue]:
     """Cross-check each already-CSV-valid row against reference tables
     in the DB. Emits warnings (not errors) so the caller decides whether
-    to abort."""
+    to abort.
+
+    If ``implicit_source_id`` is supplied AND matches a row's
+    ``source_id``, the ``unknown_source_id`` and ``source_not_test_site``
+    warnings are suppressed for that row. Rationale: the per-source UI
+    dialog is opened while the user is CREATING the source, so the
+    source isn't in ``shapes_area_sources`` yet — flagging it as
+    unknown would be noise. The eventual save writes the source and
+    the events line up.
+    """
     lookups = _fetch_lookup_sets(conn)
     warnings: list[RowIssue] = []
 
     for r in valid_rows:
+        # Suppress unknown_source_id / source_not_test_site for the
+        # source the user is currently creating in the form.
+        is_source_being_created = (
+            implicit_source_id is not None and r.source_id == implicit_source_id
+        )
+
         if r.source_id not in lookups["shapes_area_sources"]:
-            warnings.append(
-                RowIssue(
-                    r.row_number,
-                    "unknown_source_id",
-                    f"source_id {r.source_id!r} not found in shapes_area_sources",
+            if not is_source_being_created:
+                warnings.append(
+                    RowIssue(
+                        r.row_number,
+                        "unknown_source_id",
+                        f"source_id {r.source_id!r} not found in shapes_area_sources",
+                    )
                 )
-            )
         elif r.source_id not in lookups["test_site_source_ids"]:
-            warnings.append(
-                RowIssue(
-                    r.row_number,
-                    "source_not_test_site",
-                    f"source_id {r.source_id!r} exists but is_test_site='0'; "
-                    "compute would ignore its events",
+            if not is_source_being_created:
+                warnings.append(
+                    RowIssue(
+                        r.row_number,
+                        "source_not_test_site",
+                        f"source_id {r.source_id!r} exists but is_test_site='0'; "
+                        "compute would ignore its events",
+                    )
                 )
-            )
 
         if (
             lookups["default_aircraft"]
@@ -641,6 +663,11 @@ def format_summary(
     lines.append(f"  CSV rows read:          {csv_row_count}")
     lines.append(f"  Rows valid:             {len(result.valid_rows)}")
     lines.append(f"  Rows rejected:          {len(result.errors)}")
+    if result.skipped_other_source > 0:
+        lines.append(
+            f"  Rows for other sources: {result.skipped_other_source} "
+            f"(skipped; not for this source)"
+        )
     lines.append(f"  Warnings:               {total_warnings}")
 
     if result.errors:

--- a/open_alaqs/openalaqsdialog.py
+++ b/open_alaqs/openalaqsdialog.py
@@ -3412,14 +3412,18 @@ class OpenAlaqsImportEngineTestEvents(QtWidgets.QDialog):
             rows, implicit_source_id=self._source_id
         )
 
-        # DB cross-checks.
+        # DB cross-checks. Pass implicit_source_id so warnings about
+        # the source-being-created are suppressed (it isn't in the DB
+        # yet because the form hasn't been saved).
         try:
             import sqlite3
 
             conn = sqlite3.connect(self._database_path)
             try:
                 self._db_warnings = validate_against_db(
-                    self._validation_result.valid_rows, conn
+                    self._validation_result.valid_rows,
+                    conn,
+                    implicit_source_id=self._source_id,
                 )
             finally:
                 conn.close()

--- a/open_alaqs/ui/ui_area_sources.ui
+++ b/open_alaqs/ui/ui_area_sources.ui
@@ -288,7 +288,7 @@
      </widget>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="8" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -298,7 +298,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="7" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/tests/test_import_engine_test_events.py
+++ b/tests/test_import_engine_test_events.py
@@ -771,15 +771,50 @@ def test_read_csv_source_id_still_read_when_present_in_header(tmp_path):
     assert rows[0]["source_id"] == "TESTPAD_B"  # unchanged
 
 
-def test_validate_csv_rows_mismatched_source_id_errors_out():
+def test_validate_csv_rows_other_source_rows_silently_skipped():
     """A row whose source_id doesn't match the implicit_source_id
-    should be rejected as an error, not a warning."""
+    should be silently skipped and counted in skipped_other_source.
+    Not an error, not a warning. Purpose: user keeps one master CSV
+    across all their sources; each source's dialog picks its own
+    subset."""
     rows = _rows_from_string(_csv_text(_row(source_id="TESTPAD_B", t_CL_s="900")))
     result = importer.validate_csv_rows(rows, implicit_source_id="TESTPAD_A")
-    assert len(result.errors) == 1
-    assert result.errors[0].code == "mismatched_source_id"
-    assert "TESTPAD_A" in result.errors[0].message
-    assert "TESTPAD_B" in result.errors[0].message
+    assert result.errors == []
+    assert result.warnings == []
+    assert result.valid_rows == []
+    assert result.skipped_other_source == 1
+
+
+def test_validate_csv_rows_mixed_sources_only_matching_rows_kept():
+    """Master CSV with rows for TESTPAD_A and TESTPAD_B: only TESTPAD_A
+    rows validate; TESTPAD_B rows are skipped."""
+    rows = _rows_from_string(
+        _csv_text(
+            _row(
+                source_id="TESTPAD_A",
+                start="2024-12-01T09:00:00",
+                end="2024-12-01T09:30:00",
+                t_CL_s="900",
+            ),
+            _row(
+                source_id="TESTPAD_B",
+                start="2024-12-01T10:00:00",
+                end="2024-12-01T10:30:00",
+                t_CL_s="900",
+            ),
+            _row(
+                source_id="TESTPAD_A",
+                start="2024-12-02T11:00:00",
+                end="2024-12-02T11:30:00",
+                t_CL_s="300",
+            ),
+        )
+    )
+    result = importer.validate_csv_rows(rows, implicit_source_id="TESTPAD_A")
+    assert result.errors == []
+    assert len(result.valid_rows) == 2
+    assert all(r.source_id == "TESTPAD_A" for r in result.valid_rows)
+    assert result.skipped_other_source == 1
 
 
 def test_validate_csv_rows_matching_source_id_passes():
@@ -793,11 +828,12 @@ def test_validate_csv_rows_matching_source_id_passes():
 
 def test_validate_csv_rows_no_implicit_source_id_backward_compat():
     """When implicit_source_id is None (default, CLI path), any
-    source_id is accepted; no mismatched_source_id error possible."""
+    source_id is accepted; no skipping happens."""
     rows = _rows_from_string(_csv_text(_row(source_id="ANY_SOURCE", t_CL_s="900")))
     result = importer.validate_csv_rows(rows)
     assert result.errors == []
     assert result.valid_rows[0].source_id == "ANY_SOURCE"
+    assert result.skipped_other_source == 0
 
 
 def test_read_csv_still_requires_source_id_when_no_implicit(tmp_path):
@@ -829,3 +865,145 @@ def test_end_to_end_dialog_flow_no_source_id_column(tmp_path):
     assert result.errors == []
     assert len(result.valid_rows) == 2
     assert all(r.source_id == "TESTPAD_A" for r in result.valid_rows)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 8: UX fixes reported after real QGIS testing
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_running_exceeds_window_uses_per_engine_time_not_multiplied():
+    """running_exceeds_window should compare per-engine mode times to
+    the event window, NOT multiply by engine_count. Engines run in
+    parallel during a run-up (Phase 3 compute is
+    t_mode_s × engine_count for total engine-seconds, but each engine
+    only runs for t_mode_s within the window). The Phase 4a check
+    incorrectly multiplied, producing spurious warnings on legitimate
+    twin-engine test runs."""
+    # 30-min window, 1800s of mode times per engine, 2 engines.
+    # Per-engine time = 1800s = window duration. No warning expected.
+    # Old buggy code: 1800 * 2 = 3600s vs 1800s window → warning fires.
+    rows = _rows_from_string(
+        _csv_text(_row(engine_count="2", t_TX_s="1200", t_AP_s="300", t_CL_s="300"))
+    )
+    result = importer.validate_csv_rows(rows)
+    assert result.errors == []
+    assert not any(w.code == "running_exceeds_window" for w in result.warnings)
+
+
+def test_running_exceeds_window_still_fires_when_actually_exceeds():
+    """Sanity check: the warning fires when per-engine time genuinely
+    exceeds the window."""
+    # 30-min window, but 3000s per engine (way over)
+    rows = _rows_from_string(
+        _csv_text(_row(engine_count="2", t_TX_s="2000", t_AP_s="500", t_CL_s="500"))
+    )
+    result = importer.validate_csv_rows(rows)
+    assert any(w.code == "running_exceeds_window" for w in result.warnings)
+
+
+def test_validate_against_db_suppresses_unknown_source_for_implicit():
+    """When implicit_source_id matches a row's source_id AND that
+    source is not yet in shapes_area_sources (because the user is
+    creating it in the form right now), the unknown_source_id warning
+    should NOT fire. This was the noise reported by real QGIS testing
+    after PR #345 merged."""
+    path, conn = _make_scratch_db(area_sources=[])  # empty
+    try:
+        rows = _rows_from_string(_csv_text(_row(source_id="TESTPAD_A", t_CL_s="900")))
+        result = importer.validate_csv_rows(rows)
+        db_warnings = importer.validate_against_db(
+            result.valid_rows, conn, implicit_source_id="TESTPAD_A"
+        )
+        assert not any(w.code == "unknown_source_id" for w in db_warnings)
+    finally:
+        conn.close()
+        os.unlink(path)
+
+
+def test_validate_against_db_still_warns_for_other_unknown_sources():
+    """Suppression is targeted: only the implicit source's warning is
+    suppressed. Other unknown source_ids in the CSV still warn (if any
+    slipped through the pre-DB skip). In practice the pre-DB filter
+    already handles them so this scenario is for callers who don't
+    use implicit_source_id at all."""
+    path, conn = _make_scratch_db(area_sources=[])
+    try:
+        # No implicit_source_id supplied — every unknown source_id
+        # should warn as before.
+        rows = _rows_from_string(_csv_text(_row(source_id="GHOST", t_CL_s="900")))
+        result = importer.validate_csv_rows(rows)
+        db_warnings = importer.validate_against_db(result.valid_rows, conn)
+        assert any(w.code == "unknown_source_id" for w in db_warnings)
+    finally:
+        conn.close()
+        os.unlink(path)
+
+
+def test_format_summary_shows_skipped_count_when_nonzero():
+    """When skipped_other_source > 0, the summary output should
+    include a line about it so the user sees how many rows were
+    filtered out."""
+    result = importer.ValidationResult(
+        valid_rows=[],
+        skipped_other_source=3,
+    )
+    summary = importer.format_summary(result, [], csv_row_count=5)
+    assert "Rows for other sources: 3" in summary
+
+
+def test_format_summary_hides_skipped_line_when_zero():
+    """No noise when nothing was skipped."""
+    result = importer.ValidationResult(valid_rows=[])
+    summary = importer.format_summary(result, [], csv_row_count=3)
+    assert "Rows for other sources" not in summary
+
+
+def test_end_to_end_master_csv_flow():
+    """Simulate the intended workflow: one master CSV with events for
+    multiple sources, opened per-source. Each source sees only its own
+    rows without any errors or warnings about the others."""
+    path, conn = _make_scratch_db(
+        area_sources=[
+            {"source_id": "TESTPAD_A", "is_test_site": "1"},
+            {"source_id": "TESTPAD_B", "is_test_site": "1"},
+        ]
+    )
+    try:
+        # Master CSV with mixed sources
+        rows = _rows_from_string(
+            _csv_text(
+                _row(
+                    source_id="TESTPAD_A",
+                    start="2024-12-01T09:00:00",
+                    end="2024-12-01T09:30:00",
+                    t_CL_s="600",
+                ),
+                _row(
+                    source_id="TESTPAD_B",
+                    start="2024-12-01T10:00:00",
+                    end="2024-12-01T10:30:00",
+                    t_CL_s="300",
+                ),
+                _row(
+                    source_id="TESTPAD_A",
+                    start="2024-12-02T11:00:00",
+                    end="2024-12-02T11:30:00",
+                    t_CL_s="900",
+                ),
+            )
+        )
+        # Open dialog scoped to TESTPAD_A
+        result = importer.validate_csv_rows(rows, implicit_source_id="TESTPAD_A")
+        db_warnings = importer.validate_against_db(
+            result.valid_rows, conn, implicit_source_id="TESTPAD_A"
+        )
+        assert result.errors == []
+        assert result.warnings == []
+        assert db_warnings == []
+        assert len(result.valid_rows) == 2
+        assert result.skipped_other_source == 1
+        assert all(r.source_id == "TESTPAD_A" for r in result.valid_rows)
+    finally:
+        conn.close()
+        os.unlink(path)


### PR DESCRIPTION
Two commits addressing four bugs surfaced by real QGIS testing of
PR #345.

## Bug A (parent commit): area source form layout collision

**Symptom:** OK/Cancel buttons floated to the top-left of the form,
overlapping the "Source Name" label (which was rendered truncated as
"Source N...").

**Cause:** In #345 I shifted `tabWidget` from row 5 to row 6 in the
outer `QFormLayout` to make room for the new "Load engine test
events CSV..." button. But `buttonBox` was already at row 6.
Collision.

**Fix:** shift `verticalSpacer` to row 7 and `buttonBox` to row 8.
Every widget in the outer layout now claims a unique cell.

## Bug B: unknown_source_id noise on source-being-created

**Symptom:** Creating a new source TESTPAD_A, ticking "Engine test
site", loading a CSV whose rows are for TESTPAD_A produced:

`Warnings:
Row 2: [unknown_source_id] source_id 'TESTPAD_A' not found in
shapes_area_sources
`

The warning is technically correct (TESTPAD_A isn't in the DB yet
because the form hasn't been saved) but useless — the user IS
creating that source.

**Fix:** `validate_against_db` grows an `implicit_source_id`
parameter. When supplied AND a row's source_id matches it, the
`unknown_source_id` and `source_not_test_site` warnings are
suppressed for that row. Suppression is targeted; other unknown
source_ids still warn.

## Bug C: one CSV, one source (bad UX)

**Symptom:** #345 made `mismatched_source_id` a hard error, meaning
loading a master CSV (one file with events for the whole airport)
from TESTPAD_A's form errored out on every TESTPAD_B row.

**Fix:** `mismatched_source_id` is no longer emitted. When
`implicit_source_id` is set and a row's source_id differs, the row
is silently SKIPPED and counted in a new `ValidationResult` field
`skipped_other_source`. The `format_summary` output shows the skip
count on a dedicated line:

`Rows for other sources: 2 (skipped; not for this source)`

Not an error, not a warning — informational. `format_summary` hides
the line when the count is zero.

Intended workflow: keep one master CSV with all engine test events
across the airport. Open TESTPAD_A's form → Load Events → each
source picks its own subset. Same file works for every source.

## Bug D: running_exceeds_window off by a factor of engine_count

**Symptom:** Importing an event for a twin-engine aircraft (C25C,
`engine_count=2`) with 1800s of mode times in an 1800s window
produced:

`Row 4: [running_exceeds_window] sum of mode times (3600s across
2 engine(s)) exceeds the event window (1800s) by more than
60s tolerance`

Wrong. Engines run in PARALLEL during a run-up. Phase 3's compute is
`t_effective_s = t_mode_s × engine_count`, correctly treating engines
as simultaneous. Phase 2's `getConsistencyWarnings` correctly compares
per-engine time to window duration.

My Phase 4a CSV importer diverged from Phase 2 by multiplying by
`engine_count` before the comparison.

**Fix:** `engine_test_import.py`'s `running_exceeds_window` check now
uses per-engine running time directly, matching Phase 2. Message text
updated to reflect the per-engine framing.

## Tests

- Removed `test_validate_csv_rows_mismatched_source_id_errors_out`
  (asserted the wrong behaviour); replaced with
  `test_validate_csv_rows_other_source_rows_silently_skipped`.
- Added `test_validate_csv_rows_mixed_sources_only_matching_rows_kept`.
- Backward-compat test now also asserts `skipped_other_source == 0`.
- New Section 8 with 7 tests for the three code bugs:
    - per-engine running window (fixed + regression)
    - `validate_against_db` unknown_source suppression (targeted)
    - summary shows skip count when non-zero, hides when zero
    - end-to-end master CSV flow across two sources

Total CLI tests: **54** (was 46; +8 new, −1 removed, +1 modified).
Full test suite expected: **1836 passed** (1828 + 8 net-new).

## Docs

The `USER_GUIDE` and `CHANGELOG` from earlier PRs still describe:
- the removed toolbar action
- the `--replace-all` mode in the per-source dialog (now CLI-only)
- CSV format as `source_id` required

I'll ship a docs follow-up PR after this and the earlier redesign
land, updating everything in one pass.