### PR TITLE
Fix: skip validation of irrelevant fields on engine-test-site area sources

### DIFF
--- a/open_alaqs/ui/ui_area_sources.py
+++ b/open_alaqs/ui/ui_area_sources.py
@@ -125,6 +125,10 @@ def form_open(form, layer, feature):
             lambda: _open_load_events_dialog(form, fields, feature)
         )
 
+    # Re-run validation whenever the test-site toggle changes: the set
+    # of required fields differs between test-site and regular modes.
+    fields["is_test_site"].toggled.connect(lambda _checked: validate(fields))
+
     # Disable heat flux fields
     fields["heat_flux_field"].setText("0")
     fields["heat_flux_field"].setEnabled(False)
@@ -160,6 +164,28 @@ def form_open(form, layer, feature):
         # (see EngineTestEvents.py schema). AreaSources.isTestSite()
         # reads by string comparison.
         write_is_test_site_to_feature(fields["is_test_site"], feature)
+
+        # For test sites, the compute path ignores unit_year and the
+        # *_kg_unit rate columns. Auto-fill "0" on any that the user
+        # left blank so the DB stores a valid numeric rather than NULL
+        # (which some downstream code doesn't handle). Users who care
+        # can override these values, but there's no reason to force
+        # them to.
+        if fields["is_test_site"].isChecked():
+            fields_to_zero_fill = [
+                "unit_field",
+                "co_kg_unit_field",
+                "hc_kg_unit_field",
+                "nox_kg_unit_field",
+                "sox_kg_unit_field",
+                "pm10_kg_unit_field",
+                "p1_kg_unit_field",
+                "p2_kg_unit_field",
+            ]
+            for f_name in fields_to_zero_fill:
+                widget = fields.get(f_name)
+                if widget is not None and not widget.text().strip():
+                    widget.setText("0")
 
     fields["button_box"].accepted.connect(on_save)
 
@@ -245,24 +271,47 @@ def validate(fields: dict):
     correctly. If they have, the attributes are committed to the feature.
     Otherwise an error message is displayed and the incorrect field is
     highlighted in red.
+
+    When the "Engine test site" checkbox is ticked, the emissions and
+    unit-rate fields are irrelevant (the compute path reads events from
+    ``engine_test_events`` and ignores the ``*_kg_unit`` columns). Those
+    fields are skipped in validation so the user can save the source
+    without filling in numbers that will never be used. ``on_save()``
+    auto-fills them with ``"0"`` so the DB stores something valid.
+
+    Source name, height, and heat flux are validated regardless — they
+    matter for both regular area sources AND test sites (height for
+    dispersion positioning, name for the source_id, heat flux is
+    already 0 and disabled).
     """
 
     # Get the button box
     button_box = fields["button_box"]
 
-    # Validate all fields
+    # Fields validated for every area source.
     results = [
         validate_field(fields["name_field"], "str"),
         validate_field(fields["height_field"], "float"),
         validate_field(fields["heat_flux_field"], "float"),
-        validate_field(fields["co_kg_unit_field"], "float"),
-        validate_field(fields["hc_kg_unit_field"], "float"),
-        validate_field(fields["nox_kg_unit_field"], "float"),
-        validate_field(fields["sox_kg_unit_field"], "float"),
-        validate_field(fields["pm10_kg_unit_field"], "float"),
-        validate_field(fields["p1_kg_unit_field"], "float"),
-        validate_field(fields["p2_kg_unit_field"], "float"),
     ]
+
+    # Fields validated only for regular area sources. Skipped when the
+    # source is a test site.
+    is_test_site = (
+        fields.get("is_test_site") is not None and fields["is_test_site"].isChecked()
+    )
+    if not is_test_site:
+        results.extend(
+            [
+                validate_field(fields["co_kg_unit_field"], "float"),
+                validate_field(fields["hc_kg_unit_field"], "float"),
+                validate_field(fields["nox_kg_unit_field"], "float"),
+                validate_field(fields["sox_kg_unit_field"], "float"),
+                validate_field(fields["pm10_kg_unit_field"], "float"),
+                validate_field(fields["p1_kg_unit_field"], "float"),
+                validate_field(fields["p2_kg_unit_field"], "float"),
+            ]
+        )
 
     # Block signals if any of the fields is invalid
     button_box.button(button_box.StandardButton.Ok).blockSignals(


### PR DESCRIPTION
Reported after `fix-csv-import-ux` merged: the area source form
still refuses to save an engine-test-site source because the
emissions (`*_kg_unit`) and Units per Year fields are empty and
`validate()` flags them as invalid — even though those fields are
completely ignored at compute time when `is_test_site='1'` (compute
reads events from the `engine_test_events` table instead).

The user had to fill in fake values for CO/HC/NOx/SOx/PM10/P1/P2 kg
per unit and Units per Year just to be allowed to save. Bad UX.

## Changes

- `validate()` now skips validation of `unit_year` and the seven
  `*_kg_unit` fields when the "Engine test site" checkbox is ticked.
  Source name, height, and heat flux are still validated for both
  modes (height matters for dispersion; heat flux is already 0 and
  disabled).
- `on_save()` auto-fills `"0"` into `unit_year` and any of the seven
  `*_kg_unit` fields the user left blank when the source is a test
  site. Purpose: the DB column types are numeric (TEXT for
  `unit_year`, DECIMAL for `*_kg_unit`), and "0" is safe and
  semantically meaningful (this source contributes no
  rate-per-unit emissions; its emissions come from events).
- The `is_test_site` checkbox's `toggled` signal is connected to
  re-run `validate()` so ticking or unticking the checkbox
  immediately updates the OK button's enabled state without waiting
  for another field's text-change signal.
## Audit

Traced through every downstream code path that reads
`shapes_area_sources.unit_year` or `*_kg_unit`:

- `AreaSourceModule.process()` explicitly skips test sites at
  line 84 (Phase 4b decision). Auto-filled zero values are never
  read for test sites.
- `EngineTestSourceModule.process()` reads events from
  `engine_test_events`, not from area source fields. Independent.
- `AreaSources.__init__` uses `_ctf(val.get("unit_year", 0),
  default=0.0)`. Same for `*_kg_unit`. Handles empty/NULL/missing
  gracefully by defaulting to 0.0.
- `build_sources_df()` puts area sources (including test sites)
  into a `pd.DataFrame`. Currently built but not consumed by any
  live output module (only debug-log reads it). Zero-emission test
  sites would appear as no-op rows if it were consumed.
- No double-counting risk. No downstream crash risk.

## Not in this commit

- No `.ui` change (no widget was added or removed; only Python
  behaviour changed).
- The Emissions tab is still visible when the checkbox is ticked;
  users who care can still set values on it, and those values pass
  through to the DB. Hiding the tab is a separate UX decision.
- Height stays required. It's the one `*_kg_unit`-adjacent field
  that matters for dispersion positioning regardless of source
  type.

## Tests

No new unit tests. The logic is pure Qt-widget wiring (a
`QCheckBox`, eight `QLineEdit`s, and one signal connection) and
`validate()` runs on every `textChanged`. Testing meaningfully
requires a QGIS session with the real form. Manual verification:
create an area source, tick "Engine test site", leave the emissions
fields empty, click OK — should save. Untick, click OK — should
refuse until emissions fields are filled in.