### PR TITLE
chore: include table name in SQLSerializable duplicate-key warning

### DIFF
--- a/open_alaqs/core/interfaces/SQLSerializable.py
+++ b/open_alaqs/core/interfaces/SQLSerializable.py
@@ -48,9 +48,17 @@ class SQLSerializable:
 
     def setEntry(self, key: Any, value_object: dict[str, Any]) -> None:
         if self.hasEntry(key):
+            # Include the table name so callers can trace which SQL
+            # source is producing duplicate/NULL keys. Without it the
+            # warning is undiagnosable: any SQLSerializable-derived
+            # class could be the culprit, and reference tables like
+            # tbl_InvMeteo can produce hundreds of these per calc run
+            # if their inferred primary key column is populated with
+            # NULL. The str(key) cast keeps None showing as 'None' in
+            # the log rather than raising a formatting error.
             logger.warning(
-                "Already found entry with key '%s'. Replacing existing entry."
-                % (str(key))
+                "Already found entry with key '%s' in table '%s'. "
+                "Replacing existing entry." % (str(key), self._table_name)
             )
 
         self._entries[key] = value_object


### PR DESCRIPTION
Reported during real-QGIS testing: an emission calc for EngineTestSource produced ~180 warnings all shaped like:

    Already found entry with key 'None'. Replacing existing entry.

The message doesn't say WHICH SQL-backed table is producing the duplicate keys, so tracing back to the culprit table requires running under a debugger or grepping every SQLSerializable subclass. Any of the reference tables loaded during a calc run (tbl_InvMeteo, default_aircraft, default_aircraft_engine_ei, engine_test_events, shapes_area_sources, etc.) could be the source.

Diagnostic upgrade: include self._table_name in the warning. New shape:

    Already found entry with key 'None' in table 'tbl_InvMeteo'.
    Replacing existing entry.

Now the offending table is named at each occurrence, so a follow-up audit of the schema for that specific table can proceed directly.

The str(key) cast is preserved as-is (already handled None properly).

Not touched
-----------

This is only a diagnostic upgrade. The underlying condition (some table having a nullable or non-unique inferred primary key) persists; each table where this fires still silently deduplicates its in-memory entries down to one representative row per repeated key. Fixing individual tables is separate follow-up work once the warning names them.

Tests
-----

No new tests. The change is a log-format tweak; no test asserts the old string (verified with grep). Existing test suite unaffected.