### PR TITLE
feat: engine-test integration in standalone orchestrate + AUSTAL export

### DIFF
--- a/open_alaqs/core/modules/AUSTALOutputModule.py
+++ b/open_alaqs/core/modules/AUSTALOutputModule.py
@@ -1634,8 +1634,29 @@ class AUSTALDispersionModule(DispersionModule):
         attribute. Unknown classes return an empty string; the caller
         treats that as "do not prefix" so the source falls into its
         own bucket at aggregation time.
+
+        Engine-test sites are AreaSources instances (they share the
+        DB table and Python class with regular area sources) but they
+        get their own label ``engine_test`` so the AUSTAL by-type
+        aggregation doesn't merge their per-hour g/s rates with
+        regular area sources' constant rates. Merging would smear the
+        sparse test-event spikes into the ambient area emission and
+        both dispersion signatures would be lost. The
+        ``isTestSite()`` accessor is defined on AreaSources; any
+        older Source subclass without that method falls back to the
+        class-name map unchanged.
         """
         cls_name = type(source_).__name__
+
+        if cls_name == "AreaSources":
+            try:
+                if hasattr(source_, "isTestSite") and source_.isTestSite():
+                    return "engine_test"
+            except Exception:
+                # Defensive: an accessor raising should not derail the
+                # aggregation. Fall through to the standard 'area' label.
+                pass
+
         return {
             "RoadwaySources": "road",
             "ParkingSources": "parking",

--- a/openalaqs_standalone/compute_area.py
+++ b/openalaqs_standalone/compute_area.py
@@ -84,7 +84,24 @@ def compute_area_emissions(
     try:
         profiles = load_profiles(conn)
         cur = conn.cursor()
-        cur.execute("SELECT * FROM shapes_area_sources WHERE instudy = '1'")
+        # Skip engine-test sites (is_test_site='1'). Their emissions come
+        # from engine_test_events via compute_engine_test_emissions, not
+        # from the *_kg_unit rates on the row. Pre-v1b DBs lack the
+        # column entirely, so we probe with PRAGMA and pick a WHERE
+        # clause that works either way. Column-absent means no test
+        # sites exist and every row goes through the area path.
+        area_cols = [
+            r[1] for r in cur.execute("PRAGMA table_info(shapes_area_sources)")
+        ]
+        has_test_site_col = "is_test_site" in area_cols
+        if has_test_site_col:
+            cur.execute(
+                "SELECT * FROM shapes_area_sources "
+                "WHERE instudy = '1' "
+                "AND (is_test_site IS NULL OR is_test_site = '' OR is_test_site = '0')"
+            )
+        else:
+            cur.execute("SELECT * FROM shapes_area_sources WHERE instudy = '1'")
         cols = [d[0] for d in cur.description]
         rows = [dict(zip(cols, row)) for row in cur.fetchall()]
     finally:

--- a/openalaqs_standalone/compute_engine_test.py
+++ b/openalaqs_standalone/compute_engine_test.py
@@ -34,7 +34,8 @@ Design (per phase 0 memo):
 from __future__ import annotations
 
 import sqlite3  # noqa: E402  (kept adjacent to the typing imports)
-from datetime import datetime
+from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 # Mode-keys shared with the plugin. Order preserved so downstream tables
@@ -554,9 +555,228 @@ def compute_engine_test_for_period(
     return by_source
 
 
+# ══════════════════════════════════════════════════════════════════════
+# Orchestration wrapper — matches the compute_area_emissions signature
+# so orchestrate.py can dispatch to it uniformly.
+# ══════════════════════════════════════════════════════════════════════
+
+# Pollutant name mapping: internal keys from compute_engine_test_for_period
+# vs the standard `pollutant` column in emissions.parquet used by all
+# other computes. "pm25" in the standard schema is the p2 sub-fraction
+# (matches AREA_POLLUTANT_COLS in compute_area).
+_POLLUTANT_INTERNAL_TO_STANDARD = {
+    "co": "co",
+    "hc": "hc",
+    "nox": "nox",
+    "sox": "sox",
+    "pm10": "pm10",
+    "p2": "pm25",
+}
+
+
+def _load_ei_lookup(conn: sqlite3.Connection) -> Dict[Tuple[str, str], Dict[str, Any]]:
+    """Load default_aircraft_engine_ei into (engine_name, mode) → row-dict.
+
+    Mirrors what the plugin's EngineStore does internally, but as a
+    plain dict for the standalone path. Only the columns needed by
+    _add_ei_to_totals are read; the SELECT explicitly lists them so
+    a schema drift on unrelated columns doesn't break this.
+    """
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT engine_name, mode, thrust, fuel_kg_sec, "
+        "co_ei, hc_ei, nox_ei, sox_ei, pm10_ei, p1_ei, p2_ei, "
+        "pm10_nonvol, pm10_sul, pm10_organic "
+        "FROM default_aircraft_engine_ei"
+    )
+    out: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    for row in cur.fetchall():
+        if row[0] is None or row[1] is None:
+            # NULL engine_name or mode: unusable. The plugin's
+            # SQLSerializable loader also drops these (they collide
+            # on key='None' in its in-memory dict).
+            continue
+        out[(row[0], row[1])] = {
+            "thrust": row[2],
+            "fuel_kg_sec": row[3],
+            "co_ei": row[4],
+            "hc_ei": row[5],
+            "nox_ei": row[6],
+            "sox_ei": row[7],
+            "pm10_ei": row[8],
+            "p1_ei": row[9],
+            "p2_ei": row[10],
+            "pm10_nonvol": row[11],
+            "pm10_sul": row[12],
+            "pm10_organic": row[13],
+        }
+    return out
+
+
+def _load_aircraft_lookup(conn: sqlite3.Connection) -> Dict[str, Dict[str, Any]]:
+    """Load default_aircraft into icao → row-dict."""
+    cur = conn.cursor()
+    cur.execute("SELECT icao, engine_count, engine FROM default_aircraft")
+    return {
+        icao: {"engine_count": ec, "engine_uid": eng}
+        for icao, ec, eng in cur.fetchall()
+    }
+
+
+def compute_engine_test_emissions(
+    alaqs_path: "Path",
+    year: int,
+    pollutants: Optional[list] = None,
+    time_window: Optional[Tuple[Any, Any]] = None,
+):
+    """Compute hourly engine-test emissions for all in-study test sites.
+
+    Signature mirrors ``compute_area_emissions`` so ``orchestrate.py``
+    can dispatch to it uniformly alongside road / parking / point /
+    area. Returns a long-form DataFrame with columns
+    ``[timestamp, source_id, pollutant, kg_in_hour]``.
+
+    Only hours where an event actually overlaps produce rows. Zero-
+    emission hours are omitted to keep the parquet compact, matching
+    the convention of the other stationary computes (which also skip
+    zero-emission source-pollutant-hour combinations).
+
+    ``pollutants`` filters the output; unknown pollutants are silently
+    dropped. Passing ``None`` uses the standard set (STATIONARY_POLLUTANTS
+    intersected with the pollutants engine-test emits: co, hc, nox,
+    sox, pm10, pm25).
+
+    ``time_window = (start, end)`` restricts emissions to the half-open
+    interval [start, end). Any event whose overlap window falls fully
+    outside is skipped; partial overlaps are clipped hour-by-hour by
+    the per-period compute (which already handles this via
+    ``_period_window_fraction``).
+
+    The ``year`` argument is only used to bracket a full-year scan when
+    ``time_window`` is None; it doesn't force events to be re-dated.
+    """
+    import pandas as pd
+
+    if pollutants is None:
+        pollutants = ["co", "hc", "nox", "sox", "pm10", "pm25"]
+
+    # Load DB pieces once
+    conn = sqlite3.connect(str(alaqs_path))
+    try:
+        # Import lazily to avoid a hard dependency at module import time
+        # (the plugin path never needs extract_engine_test_events).
+        from openalaqs_standalone.extract_engine_test_events import (
+            extract_engine_test_events,
+        )
+
+        events = extract_engine_test_events(conn)
+        ei_lookup = _load_ei_lookup(conn)
+        aircraft_lookup = _load_aircraft_lookup(conn)
+    finally:
+        conn.close()
+
+    if not events:
+        return pd.DataFrame(
+            columns=["timestamp", "source_id", "pollutant", "kg_in_hour"]
+        )
+
+    # Determine the hour range to scan. If a time_window is given, use
+    # it directly. Otherwise bracket the union of event windows AND
+    # clamp to the inventory year — passing an event dated outside
+    # `year` still emits its own overlapping hours (the compute doesn't
+    # gate on year), but this keeps the scan bounded.
+    if time_window is not None:
+        scan_start, scan_end = time_window
+        if isinstance(scan_start, str):
+            scan_start = datetime.fromisoformat(scan_start)
+        if isinstance(scan_end, str):
+            scan_end = datetime.fromisoformat(scan_end)
+    else:
+        year_start = datetime(year, 1, 1)
+        year_end = datetime(year + 1, 1, 1)
+        scan_start, scan_end = year_start, year_end
+
+    # Which hours actually have overlapping events? For each event,
+    # compute the set of hour-buckets it touches; take the union.
+    # Cheaper than looping 8760 empty hours.
+    touched_hours: set = set()
+    for ev in events:
+        try:
+            e_start = datetime.fromisoformat(ev["start_datetime"])
+            e_end = datetime.fromisoformat(ev["end_datetime"])
+        except (KeyError, ValueError, TypeError):
+            continue
+        # Clip to scan window
+        e_start_clip = max(e_start, scan_start)
+        e_end_clip = min(e_end, scan_end)
+        if e_start_clip >= e_end_clip:
+            continue
+        # Enumerate the hour buckets [floor(start_hour), ceil(end_hour))
+        h = e_start_clip.replace(minute=0, second=0, microsecond=0)
+        while h < e_end_clip:
+            touched_hours.add(h)
+            h = h + timedelta(hours=1)
+
+    if not touched_hours:
+        return pd.DataFrame(
+            columns=["timestamp", "source_id", "pollutant", "kg_in_hour"]
+        )
+
+    # Compute per-hour, per-source per-pollutant totals in grams,
+    # convert to kg, emit long-form rows. Only hours with non-zero
+    # contribution produce rows.
+    ts_out: list = []
+    sid_out: list = []
+    pol_out: list = []
+    kg_out: list = []
+
+    pollutants_set = set(pollutants)
+    # Filter the internal-to-standard map to only requested pollutants.
+    active_map = {
+        k: v for k, v in _POLLUTANT_INTERNAL_TO_STANDARD.items() if v in pollutants_set
+    }
+
+    for hour in sorted(touched_hours):
+        by_source = compute_engine_test_for_period(
+            events=events,
+            period_start=hour,
+            period_end=hour + timedelta(hours=1),
+            ei_lookup=ei_lookup,
+            aircraft_lookup=aircraft_lookup,
+            conn=None,
+        )
+        for raw_source_id, totals in by_source.items():
+            # Prefix with "engine_test:" to match extract_sources.py's
+            # source_id convention (its rows in sources.parquet use
+            # the same prefix).
+            source_id = f"engine_test:{raw_source_id}"
+            for internal_key, standard_key in active_map.items():
+                grams = totals.get(internal_key, 0.0)
+                if grams <= 0.0:
+                    continue
+                kg = grams / 1000.0
+                ts_out.append(hour)
+                sid_out.append(source_id)
+                pol_out.append(standard_key)
+                kg_out.append(kg)
+
+    df = pd.DataFrame(
+        {
+            "timestamp": ts_out,
+            "source_id": sid_out,
+            "pollutant": pol_out,
+            "kg_in_hour": kg_out,
+        }
+    )
+    if not df.empty:
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+    return df
+
+
 __all__ = [
     "_period_window_fraction",
     "_resolve_engine_count",
     "_resolve_engine_uid",
     "compute_engine_test_for_period",
+    "compute_engine_test_emissions",
 ]

--- a/openalaqs_standalone/extract_sources.py
+++ b/openalaqs_standalone/extract_sources.py
@@ -332,28 +332,33 @@ def _extract_area_sources(conn: sqlite3.Connection) -> list[dict]:
         return []
     cols = [d[0] for d in cur.description]
     rows = []
-    n_test_sites_skipped = 0
     for raw in cur.fetchall():
         rec = dict(zip(cols, raw))
 
-        # Skip engine-test sites (is_test_site='1'). Their emissions come
-        # from the engine_test_events table, not from the *_kg_unit fixed
-        # rates on this row, and the compute module for engine tests is
-        # introduced in a later phase. The IS NULL / '' fallbacks preserve
-        # backward compatibility with pre-v1b projects that lack the
-        # column entirely (SQLite's SELECT * still returns their rows,
-        # just without the column, so rec.get returns None).
+        # Engine-test sites (is_test_site='1') get emitted with
+        # source_id "engine_test:<oid>" and source_type "engine_test"
+        # instead of "area:<oid>" / "area". This lets `orchestrate.py`
+        # dispatch to `compute_engine_test_emissions` for them and keeps
+        # their emissions out of the regular area-source compute (which
+        # would produce zero anyway since test sites carry no *_kg_unit
+        # rates). Downstream `austal_prep` doesn't dispatch on
+        # source_type — it uses geometry_kind (polygon) — so the AUSTAL
+        # writer treats these the same as regular area sources. The
+        # source_id prefix guarantees uniqueness against area sources
+        # with the same numeric oid. Pre-v1b projects lacking the
+        # column entirely still work: rec.get returns None, str(None) =
+        # "None", .strip() = "None", not "1", so those rows fall
+        # through to the area path unchanged.
         is_test_site = str(rec.get("is_test_site") or "0").strip()
-        if is_test_site == "1":
-            n_test_sites_skipped += 1
-            continue
+        source_type = "engine_test" if is_test_site == "1" else "area"
+        source_prefix = "engine_test" if is_test_site == "1" else "area"
 
         wkt, kind, length_m, area_m2 = _wkb_to_wkt_via_shapely(rec.get("geometry"))
         raw_id = rec.get("source_id") or rec.get("oid")
         rows.append(
             {
-                "source_id": f"area:{raw_id}",
-                "source_type": "area",
+                "source_id": f"{source_prefix}:{raw_id}",
+                "source_type": source_type,
                 "label": str(raw_id),
                 "geometry_wkt": wkt,
                 "geometry_kind": kind,
@@ -375,15 +380,11 @@ def _extract_area_sources(conn: sqlite3.Connection) -> list[dict]:
                         "pm10_kg_unit": rec.get("pm10_kg_unit"),
                         "p1_kg_unit": rec.get("p1_kg_unit"),
                         "p2_kg_unit": rec.get("p2_kg_unit"),
+                        "is_test_site": is_test_site,
                     },
                     default=str,
                 ),
             }
-        )
-    if n_test_sites_skipped:
-        print(
-            f"  [extract_sources] {n_test_sites_skipped} engine-test site(s) "
-            "skipped: engine-test emissions module not yet available"
         )
     return rows
 
@@ -394,11 +395,12 @@ def extract_sources(alaqs_path: Path, out_path: Optional[Path] = None) -> pd.Dat
     If `out_path` is given, write the DataFrame to a parquet file.
 
     Source types extracted:
-        road     from shapes_roadways
-        parking  from shapes_parking
-        gate     from shapes_gates           (no EFs; movement-driven)
-        point    from shapes_point_sources
-        area     from shapes_area_sources
+        road         from shapes_roadways
+        parking      from shapes_parking
+        gate         from shapes_gates           (no EFs; movement-driven)
+        point        from shapes_point_sources
+        area         from shapes_area_sources    (is_test_site='0')
+        engine_test  from shapes_area_sources    (is_test_site='1')
 
     Aircraft tracks (shapes_aircraft_tracks, shapes_tracks,
     cache_runway_trajectories) are not extracted: they are intermediate

--- a/openalaqs_standalone/orchestrate.py
+++ b/openalaqs_standalone/orchestrate.py
@@ -47,6 +47,7 @@ from openalaqs_standalone._profiles import STATIONARY_POLLUTANTS
 from openalaqs_standalone.adapt_meteo import adapt_meteo
 from openalaqs_standalone.adapt_receptors import adapt_receptors
 from openalaqs_standalone.compute_area import compute_area_emissions
+from openalaqs_standalone.compute_engine_test import compute_engine_test_emissions
 from openalaqs_standalone.compute_parking import compute_parking_emissions
 from openalaqs_standalone.compute_point import compute_point_emissions
 from openalaqs_standalone.compute_road import compute_road_emissions
@@ -321,6 +322,14 @@ def orchestrate(
         (compute_parking_emissions, "parking"),
         (compute_point_emissions, "point"),
         (compute_area_emissions, "area"),
+        # Engine-test sites are area-source polygons in the DB but their
+        # emissions come from per-event records in engine_test_events,
+        # not from the *_kg_unit rates. compute_engine_test_emissions
+        # produces the same long-form (timestamp, source_id, pollutant,
+        # kg_in_hour) schema and emits only hours with actual event
+        # overlap, so a study with zero test sites or no events adds
+        # zero rows here.
+        (compute_engine_test_emissions, "engine_test"),
     ]
 
     em_chunks: list[pd.DataFrame] = []

--- a/openalaqs_standalone/validation/tests/test_phase1b_extract_sources_standalone.py
+++ b/openalaqs_standalone/validation/tests/test_phase1b_extract_sources_standalone.py
@@ -101,9 +101,10 @@ def _make_scratch_db_pre_v1b(rows):
 # ---------------------------------------------------------------------------
 
 
-def test_extract_skips_test_sites_and_logs():
-    """A row with is_test_site='1' is filtered out; the diagnostic log
-    line reports how many were skipped."""
+def test_extract_test_sites_emitted_as_engine_test_type():
+    """A row with is_test_site='1' is emitted as source_type
+    'engine_test' with source_id prefixed 'engine_test:' — not skipped.
+    Regular area rows still come through as 'area'."""
     path, conn = _make_scratch_db_with_column(
         [
             {"source_id": "A1", "is_test_site": "0", "geometry": None},
@@ -112,24 +113,33 @@ def test_extract_skips_test_sites_and_logs():
         ]
     )
     try:
-        buf = io.StringIO()
-        with redirect_stdout(buf):
-            rows = _extract_area_sources(conn)
+        rows = _extract_area_sources(conn)
         conn.close()
 
-        # A1 and A2 kept, N1 skipped
-        labels = sorted(r["label"] for r in rows)
-        assert labels == ["A1", "A2"], f"expected A1, A2; got {labels}"
+        # All 3 rows emitted
+        assert len(rows) == 3
+        by_id = {r["label"]: r for r in rows}
 
-        # Diagnostic printed with correct count
-        out = buf.getvalue()
-        assert "1 engine-test site(s) skipped" in out, f"log missing: {out!r}"
+        # A1, A2 → source_type 'area', source_id 'area:...'
+        assert by_id["A1"]["source_type"] == "area"
+        assert by_id["A1"]["source_id"] == "area:A1"
+        assert by_id["A2"]["source_type"] == "area"
+        assert by_id["A2"]["source_id"] == "area:A2"
+
+        # N1 → source_type 'engine_test', source_id 'engine_test:...'
+        assert by_id["N1"]["source_type"] == "engine_test"
+        assert by_id["N1"]["source_id"] == "engine_test:N1"
+        # is_test_site flag also in extra_json for downstream consumers
+        import json as _json
+
+        extra = _json.loads(by_id["N1"]["extra_json"])
+        assert extra["is_test_site"] == "1"
     finally:
         os.unlink(path)
 
 
-def test_extract_multiple_test_sites_counted():
-    """Two test-site rows yields a count of 2 in the log line."""
+def test_extract_multiple_test_sites_all_emitted_as_engine_test():
+    """Two test-site rows both emitted with engine_test source_type."""
     path, conn = _make_scratch_db_with_column(
         [
             {"source_id": "N1", "is_test_site": "1", "geometry": None},
@@ -138,19 +148,21 @@ def test_extract_multiple_test_sites_counted():
         ]
     )
     try:
-        buf = io.StringIO()
-        with redirect_stdout(buf):
-            rows = _extract_area_sources(conn)
+        rows = _extract_area_sources(conn)
         conn.close()
-        assert len(rows) == 1
-        assert rows[0]["label"] == "A1"
-        assert "2 engine-test site(s) skipped" in buf.getvalue()
+        assert len(rows) == 3
+        engine_test_rows = [r for r in rows if r["source_type"] == "engine_test"]
+        area_rows = [r for r in rows if r["source_type"] == "area"]
+        assert len(engine_test_rows) == 2
+        assert len(area_rows) == 1
+        assert sorted(r["label"] for r in engine_test_rows) == ["COMP", "N1"]
     finally:
         os.unlink(path)
 
 
-def test_extract_no_test_sites_silent():
-    """When no rows are flagged, no diagnostic is emitted."""
+def test_extract_no_test_sites_all_area():
+    """When no rows are flagged, all come through as source_type
+    'area'. No engine_test rows produced."""
     path, conn = _make_scratch_db_with_column(
         [
             {"source_id": "A1", "is_test_site": "0", "geometry": None},
@@ -158,13 +170,10 @@ def test_extract_no_test_sites_silent():
         ]
     )
     try:
-        buf = io.StringIO()
-        with redirect_stdout(buf):
-            rows = _extract_area_sources(conn)
+        rows = _extract_area_sources(conn)
         conn.close()
         assert len(rows) == 2
-        # No skip-log line at all
-        assert "engine-test site(s) skipped" not in buf.getvalue()
+        assert all(r["source_type"] == "area" for r in rows)
     finally:
         os.unlink(path)
 

--- a/tests/test_austal_engine_test_label.py
+++ b/tests/test_austal_engine_test_label.py
@@ -1,0 +1,101 @@
+"""Unit tests for AUSTALDispersionModule._ti_type_label_for.
+
+Verifies that the AUSTAL by-type aggregation gives engine-test sites
+their own "engine_test" label even though they share the AreaSources
+Python class with regular area sources. Without this, sparse
+per-event engine-test emissions would be merged with (much larger,
+constant) area-source emissions and both dispersion signatures
+would be lost.
+
+Requires the real QGIS environment (imports AUSTALOutputModule which
+pulls in qgis.gui, qgis.PyQt.QtCore, etc.). Skipped on developer
+sandboxes without QGIS, same as tests/test_austal_slot_compaction.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("qgis")
+
+from open_alaqs.core.modules.AUSTALOutputModule import (  # noqa: E402
+    AUSTALDispersionModule,
+)
+
+
+class _FakeAreaSources:
+    """Duck-types AreaSources for the type-label check. Only the
+    class name and isTestSite() accessor matter."""
+
+    def __init__(self, is_test: bool):
+        self._is_test = is_test
+
+    def isTestSite(self) -> bool:
+        return self._is_test
+
+
+_FakeAreaSources.__name__ = "AreaSources"
+
+
+class _FakeRoadwaySources:
+    def isTestSite(self):  # pragma: no cover - defined only to prove
+        # the class-name gate short-circuits before isTestSite is ever
+        # consulted for non-Area sources.
+        raise AssertionError("isTestSite() must not be consulted for RoadwaySources")
+
+
+_FakeRoadwaySources.__name__ = "RoadwaySources"
+
+
+def test_regular_area_source_labelled_area():
+    src = _FakeAreaSources(is_test=False)
+    assert AUSTALDispersionModule._ti_type_label_for(src) == "area"
+
+
+def test_engine_test_area_source_labelled_engine_test():
+    src = _FakeAreaSources(is_test=True)
+    assert AUSTALDispersionModule._ti_type_label_for(src) == "engine_test"
+
+
+def test_roadway_source_labelled_road_without_touching_istestsite():
+    """Non-Area sources must not have isTestSite() invoked on them,
+    even if they happen to expose it (guard against future subclasses
+    that inherit the accessor)."""
+    src = _FakeRoadwaySources()
+    assert AUSTALDispersionModule._ti_type_label_for(src) == "road"
+
+
+def test_area_source_without_istestsite_method_falls_back_to_area():
+    """Very old AreaSources subclasses that predate the is_test_site
+    schema won't have the accessor. Those must not raise; they fall
+    back to 'area' unchanged."""
+
+    class OldAreaSources:
+        pass
+
+    OldAreaSources.__name__ = "AreaSources"
+    src = OldAreaSources()
+    assert AUSTALDispersionModule._ti_type_label_for(src) == "area"
+
+
+def test_istestsite_raising_is_swallowed():
+    """A bad accessor implementation must not propagate through the
+    aggregation. Fall through to 'area'."""
+
+    class BrokenAreaSources:
+        def isTestSite(self):
+            raise RuntimeError("db down")
+
+    BrokenAreaSources.__name__ = "AreaSources"
+    src = BrokenAreaSources()
+    assert AUSTALDispersionModule._ti_type_label_for(src) == "area"
+
+
+def test_unknown_class_returns_empty_string():
+    """Unknown source classes get "" (own bucket at aggregation time)."""
+
+    class WeirdSource:
+        pass
+
+    src = WeirdSource()
+    assert AUSTALDispersionModule._ti_type_label_for(src) == ""


### PR DESCRIPTION
Closes the two-part gap that meant engine test sites reached the QGIS compute path (fixed in PR #349) but never showed up in either the standalone parquet outputs or the plugin's AUSTAL export.

Standalone (openalaqs_standalone)
----------------------------------

extract_sources.py: emit test sites as source_type='engine_test' with source_id 'engine_test:<oid>' instead of skipping them. Regular area sources still come through as source_type='area', source_id 'area:<oid>'. is_test_site is passed through in extra_json for downstream consumers. Docstring updated to list all 6 source types.

compute_area.py: filter out test sites in the WHERE clause so their emissions don't get double-counted between the area path (0 anyway, since test sites have no *_kg_unit rates) and the new engine-test path. PRAGMA table_info probe guards against pre-v1b DBs that lack the is_test_site column entirely.

compute_engine_test.py: new compute_engine_test_emissions() wrapper matching the standard (alaqs_path, year, pollutants, time_window) signature. Iterates only hours where events actually overlap the window (cheaper than looping 8760 empty hours), calls the existing compute_engine_test_for_period per hour, emits long-form (timestamp, source_id, pollutant, kg_in_hour) rows in kg. Internal pollutant 'p2' is mapped to standard 'pm25' on output. New helpers _load_ei_lookup and _load_aircraft_lookup read the SQL tables the per-period compute needs.

orchestrate.py: append (compute_engine_test_emissions, 'engine_test') to stationary_computes so studies with test sites transparently produce engine_test rows in emissions.parquet. Always-on (no flag needed): a study with zero events contributes zero rows.

Plugin AUSTAL (open_alaqs/core/modules/AUSTALOutputModule.py) ------------------------------------------------------------

_ti_type_label_for: distinguish engine-test AreaSources instances (isTestSite() == True) from regular area sources by returning 'engine_test' instead of 'area'. The two share the AreaSources Python class (test sites are rows in shapes_area_sources with is_test_site='1'), so class-name-only dispatch would merge their per-hour g/s rates with much larger, constant regular-area rates in the by-type aggregation. Merging would smear the sparse test-event spikes into the ambient area emission and both dispersion signatures would be lost. Bare AreaSources subclasses without isTestSite() fall back to 'area' unchanged; a broken accessor that raises is caught defensively.

The rest of the AUSTAL export flow needs no changes: emissions flow through the standard (source, [emission]) tuple path already, and downstream aggregation / grid file writing dispatches on group id strings (not hard-coded to any particular type name).

Tests
-----

* Rewrote 2 tests in test_phase1b_extract_sources_standalone.py that asserted the old skip-and-log behavior for test sites (now assert they're emitted as source_type='engine_test'). Simplified a third test.
* New test_austal_engine_test_label.py covers _ti_type_label_for for regular area, engine-test area, roadway, old AreaSources without isTestSite, broken isTestSite, and unknown classes. Requires real QGIS (uses pytest.importorskip); skips cleanly in developer sandboxes without QGIS, same pattern as test_austal_slot_compaction.py.
* Full standalone suite: 1,042 passed, 1 skipped (test_austal requires QGIS).