### PR TITLE
chore(release): bump to 5.3.0 + changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ ISO 8601.
 
 ## [Unreleased]
 
+## [5.3.0] - 2026-08-04
+
 Engine-test emissions add-on. Adds a new mechanism for representing
 aircraft engine test runs (run-ups) as stationary emission sources
 with per-event fuel and per-pollutant computation matching the
@@ -53,11 +55,16 @@ regular movement path.
   saved normally. Users need to run the migration to gain the
   column.
 - **Form UX for test sites.** When "Engine test site" is ticked,
-  the Units per Year, Emissions tab (`*_kg_unit`), and Profile
-  fields gray out; validation on those fields is skipped; missing
-  values auto-fill with `"0"` on save. Only Source Name and Height
-  are required. Toggling back to a regular area source re-enables
-  the fields.
+  the Units per Year field disables (Parameters tab) and the
+  Profiles and Emissions tabs are disabled entirely via
+  `QTabWidget.setTabEnabled(False)`. Per-widget `setEnabled` had
+  no visual effect on widgets nested inside tabs — QGIS' attribute
+  form appears to override enabled state there — so the tab-level
+  approach is the one that actually communicates the intent.
+  Validation on the ignored fields is skipped; missing values
+  auto-fill with `"0"` on save. Only Source Name and Height are
+  required. Toggling back to a regular area source re-enables the
+  tabs.
 - **Source-name dropdown filter in Results Analysis.** Test-site
   sources (`is_test_site='1'`) only appear under `EngineTestSource`;
   regular area sources only appear under `AreaSource`. Prevents
@@ -78,6 +85,24 @@ regular movement path.
   ships `extract_engine_test_events.py` for the SQL side. Accepts
   an optional `conn` kwarg for BFFM2 meteo lookups; snap-only
   callers work with no signature change.
+- **Standalone orchestrator integration.**
+  `openalaqs_standalone/orchestrate.py` now calls
+  `compute_engine_test_emissions` alongside road / parking /
+  point / area, so a Dataiku recipe run against a study with
+  engine test events produces `engine_test` rows in
+  `emissions.parquet` and an `engine_test:<oid>` source row in
+  `sources.parquet`, with no flag needed. Downstream `austal_prep`
+  dispatches on `geometry_kind` (polygon), so engine-test sources
+  are picked up as time-varying polygon emitters and appear as
+  their own AUSTAL slot with per-hour g/s columns in
+  `series.dmna`.
+- **Plugin AUSTAL export labels engine-test sites as their own
+  group.** `AUSTALDispersionModule._ti_type_label_for` returns
+  `engine_test` for AreaSources instances with
+  `isTestSite() == True` instead of the shared `area` label. In
+  the by-type aggregation this keeps the sparse per-event g/s
+  spikes distinct from constant regular-area rates instead of
+  smearing them together.
 - **Three thrust modes.** `snap` (raw ICAO EEDB), `meem` (nvPM
   correction; numerically identical to `snap` for engine-test
   events because mode = anchor thrust), and `bffm2` (gas-phase
@@ -89,6 +114,40 @@ regular movement path.
 New public API on `Engine`: `getEmissionIndexByModeWithBFFM2(mode,
 ambient_conditions, mach=0.0)`. New public API on
 `AmbientConditionStore`: `getNearestByTime(timestamp_s)`.
+
+### Fixed
+
+- **`_resolve_ei` called mode-lookup methods on the wrong object.**
+  The helper was calling `engine.getEmissionIndexByMode(mode)` and
+  the two thrust-corrected variants directly on the `Engine`
+  instance. `Engine` doesn't define those methods; they live on the
+  `EngineEmissionIndex` store returned by `engine.getEmissionIndex()`.
+  The `AttributeError` was silently swallowed by an `except
+  Exception:` catch-all, so every mode returned `None`, every event
+  contributed nothing, and every test-site emission came out zero
+  (with no warning). Fixed to extract `ei_store` once and call the
+  mode methods on that. Also rewrote the phase-3 fake-engine tests
+  which had reproduced the wrong API shape and so wouldn't have
+  caught this regression.
+- **Helicopter class missing `getEmissionDynamicsByMode`** (issue
+  #340). Movement compute raised `AttributeError` on any helicopter
+  because `Helicopter` didn't implement the accessor the
+  fixed-wing path uses. Added a no-op that returns `{}`; the
+  existing `KeyError` fallback then kicks in and zero-extension
+  defaults are applied, matching the behaviour of a fixed-wing
+  aircraft with no `default_emission_dynamics` entry.
+
+### Diagnostics
+
+- **SQLSerializable duplicate-key warning now names the offending
+  table.** The message previously read `Already found entry with
+  key 'X'. Replacing existing entry.` with no hint about which of
+  the ~20 SQLSerializable-derived tables was producing the
+  duplicates. Now it reads `Already found entry with key 'X' in
+  table 'default_aircraft_engine_ei'. Replacing existing entry.`
+  Same message shape, one more field. Useful for tracing NULL-PK
+  corruption in customised `.alaqs` files (typical after an EEDB
+  update that inserted rows without oid values).
 
 ## [5.2.4] - 2026-06-18
 

--- a/open_alaqs/metadata.txt
+++ b/open_alaqs/metadata.txt
@@ -9,7 +9,7 @@ qgisMaximumVersion=4.99
 supportsQt6=True
 description=An open-source local air quality model
 
-version=5.2.4
+version=5.3.0
 author=Eurocontrol
 email=open-alaqs@eurocontrol.int
 
@@ -23,12 +23,10 @@ repository=https://gitlab.aerlabs.nl/eurocontrol/open_alaqs
 
 hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
-changelog=5.0.0
-    First stable release after the rebuild.
-    Added: schema migration scripts (CLI + GUI), CAEP14 v14 EI database, AUSTAL operating guide.
-    Changed: emissions vector layer reprojected to EPSG:3857, movements CSV auto-strips legacy columns, default_aircraft_engine_ei dropped legacy pm10_prefoa3 (32 cols).
-    Removed: 18 legacy 4.x-era tables (drop with --drop-extra-tables on migration).
-    Fixed: legacy SpatiaLite metadata migration (geometry_columns triggers).
+changelog=5.3.0
+    Feature release: engine-test emissions add-on.
+    Added: new is_test_site flag on area sources, engine_test_events table, CSV importer (in-QGIS dialog + CLI), EngineTestSourceModule with three thrust modes (snap / meem / bffm2), openalaqs_standalone integration with per-source, per-hour emission output routed through the same austal_prep pipeline as other stationary sources, distinct engine_test group in the plugin's AUSTAL export.
+    Fixed: _resolve_ei called the mode-lookup methods on Engine instead of its EmissionIndex store, producing zero emissions for every event. SQLSerializable duplicate-key warning now names the offending table. Tab-level gray-out for Profiles / Emissions when a test-site checkbox is ticked. Helicopter class missing getEmissionDynamicsByMode (issue #340).
     See CHANGELOG.md for details.
 
 # Tags are comma separated with spaces allowed


### PR DESCRIPTION
Feature release. Engine-test emissions add-on: a new mechanism for representing aircraft engine test runs (run-ups) as stationary emission sources with per-event fuel and per-pollutant computation matching the regular movement path.

Highlights
----------

Added
  * is_test_site flag on shapes_area_sources + engine_test_events table, both migration-safe via scripts/migrate_alaqs.py.
  * Per-source dialog and CLI for CSV-loading events, sharing one core implementation with 8 error and 5 warning codes.
  * UI toggle on the area-source form that disables the Profiles and Emissions tabs via QTabWidget.setTabEnabled(False) (the per-widget approach turned out to have no visual effect in QGIS attribute forms).
  * EngineTestSourceModule in the plugin plus the QGIS-free twin at openalaqs_standalone.compute_engine_test, bit-for-bit identical numerically.
  * Three thrust modes: snap (raw EEDB), meem (nvPM correction, numerically identical to snap for engine-test events because mode = anchor thrust), and bffm2 (gas-phase NOx / CO / HC ambient correction with ISA fallback).
  * Standalone orchestrator wiring: compute_engine_test_emissions joins road / parking / point / area in the stationary_computes dispatch, so Dataiku recipes pick up engine test events with no flag needed.
  * Plugin AUSTAL export labels engine-test sites as their own 'engine_test' group in the by-type aggregation, keeping the sparse per-event g/s spikes distinct from constant regular- area rates.
  * New public APIs: Engine.getEmissionIndexByModeWithBFFM2(mode, ambient_conditions, mach=0.0) and AmbientConditionStore.getNearestByTime(timestamp_s).

Fixed
  * _resolve_ei called mode-lookup methods on Engine instead of on the EmissionIndex store it returns via .getEmissionIndex(). The AttributeError was silently swallowed by a broad except, so every event contributed zero. Real-QGIS reproduction and fix. Phase-3 tests rewritten to exercise the correct two-level API.
  * Helicopter class missing getEmissionDynamicsByMode (issue #340). The fixed-wing movement path AttributeError'd on any helicopter; new no-op accessor lets the existing KeyError fallback path apply zero-extension defaults.

Diagnostics
  * SQLSerializable duplicate-key warning now includes the offending table name. Undiagnosable before; now points directly at (e.g.) default_aircraft_engine_ei after an EEDB update that inserted rows without oid values.

See CHANGELOG.md for the full entry.